### PR TITLE
feat: fallback deepseek hardening — incident log + rescue summary + pause hot fallback

### DIFF
--- a/docs/RESCUE_FALLBACK.md
+++ b/docs/RESCUE_FALLBACK.md
@@ -1,15 +1,16 @@
 # MMS Rescue Fallback
 
-Status: L3 file-first rescue with thin bridge hook, TUI rescue viewer, safe fallback handover generation, and optional current-session hot fallback for Codex Responses bridge failures.
+Status: L3 file-first rescue with thin bridge hook, TUI rescue viewer, safe fallback handover generation, incident logging, and paused current-session hot fallback for Codex Responses bridge failures.
 
 ## Current Scope
 
 - Writes deterministic rescue artifacts before any continuation model call.
 - Hooks terminal bridge failures for blocking classes: 429/quota, 403/401 permission/auth, context overflow, model not found, timeout, 5xx, and unsupported capability/parameter.
-- Global fallback defaults to file-first behavior: bridge failures write the rescue packet and `fallback-handover.md/json`, but do not call the fallback model automatically.
-- Codex Responses bridge can hot-fallback inside the current request only when `[rescue].hot_fallback_enabled = true` or `MMS_RESCUE_HOT_FALLBACK=1` is explicitly set.
-- Hot fallback resolves the selected model through `generated/model-routes.json` / `model-routes.json`; it does not hardcode a vendor/model route.
-- `MMS_RESCUE_HOT_FALLBACK=0` disables the automatic model call while keeping file-only rescue artifacts and fallback handoff generation.
+- Global fallback is file-first behavior: bridge failures write the rescue packet and `fallback-handover.md/json`, but do not switch the active request to the fallback model automatically.
+- Current-session hot fallback is paused pending redesign. `[rescue].hot_fallback_enabled = true` and `MMS_RESCUE_HOT_FALLBACK=1` are still parsed for compatibility, but the bridge keeps handoff-only behavior.
+- Fallback route resolution still reads `generated/model-routes.json` / `model-routes.json` so tests can verify cache-sensitive routes select Anthropic `/v1/messages` instead of `/v1/chat/completions`.
+- Blocking failures and cache-sensitive channel switches append redacted JSONL entries to `<resolved-mms-config>/logs/incidents.jsonl`.
+- When a fallback model is configured, the bridge may generate `summary.md` asynchronously in the rescue artifact directory; this is a recovery summary only, not a same-request hot fallback.
 - Keeps global OAuth fallback disabled.
 - Keeps private/public boundary crossing disabled.
 - Exposes recent rescue packets through `MMS -> Settings -> Interrupted / Rescue`.
@@ -31,15 +32,17 @@ Repo-local:
 <repo>/.mms/rescue/<timestamp>/fallback-handover.md
 <repo>/.mms/rescue/latest-fallback-handover.json
 <repo>/.mms/rescue/latest-fallback-handover.md
+<repo>/.mms/rescue/<timestamp>/summary.md
 ```
 
 Global metadata index:
 
 ```text
 <real-home>/.config/mms/rescue/index.jsonl
+<resolved-mms-config>/logs/incidents.jsonl
 ```
 
-The global index stores metadata and pointers only. Raw upstream bodies are redacted before write, and auth-bearing raw paths such as `.codex/auth.json`, `.claude.json`, `.gemini`, `config.toml`, credentials files, key files, and account folders are skipped.
+The global index and incident log store metadata and pointers only. Raw upstream bodies are redacted before write, auth-bearing raw paths such as `.codex/auth.json`, `.claude.json`, `.gemini`, `config.toml`, credentials files, key files, and account folders are skipped, and incident URLs/details are redacted before append.
 
 ## Real Home Resolution
 
@@ -53,7 +56,7 @@ It must not write rescue metadata under an isolated session HOME such as `.confi
 
 ## Current Limits
 
-- Hot fallback is currently scoped to the Codex Responses proxy path.
+- Hot fallback execution is currently paused; only route resolution, rescue artifacts, incident logs, fallback handovers, and async summaries remain active.
 - Context-heavy failures still rely on the rescue packet/context policy; MMS does not auto-compact before choosing a smaller fallback model.
 - No automatic session resume; the TUI viewer is read-only recovery metadata + packet display.
 - No registry DB persistence beyond the file-only metadata/index shape.

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -1155,6 +1155,14 @@ def _record_bridge_blocking_failure(
                     handover.get("source_event_id"),
                     fallback_model,
                 )
+        _append_incident_log(
+            model=model_name or getattr(server, "model_name", ""),
+            provider_id=provider_id or getattr(server, "provider_id", ""),
+            status_code=status_code,
+            bridge_surface=bridge_surface,
+            request_url=request_url,
+            event="blocking_failure",
+        )
         return payload
     except Exception as exc:
         _bridge_error_logger.warning("rescue file-only packet failed: %s", exc, exc_info=True)
@@ -1526,6 +1534,39 @@ def _chatcompletions_error_requests_messages(body_text):
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 GEMINI_BRIDGE_SCRIPT = os.path.join(ROOT_DIR, "scripts", "gemini_codeassist_bridge.mjs")
+
+_INCIDENT_LOG_PATH = os.path.join(
+    os.path.expanduser("~"), ".config", "mms", "logs", "incidents.jsonl"
+)
+
+
+def _append_incident_log(
+    *,
+    model="",
+    provider_id="",
+    status_code=None,
+    bridge_surface="",
+    request_url="",
+    event="blocking_failure",
+    detail="",
+):
+    """Append one JSONL line to ~/.config/mms/logs/incidents.jsonl. Best-effort, never raises."""
+    try:
+        os.makedirs(os.path.dirname(_INCIDENT_LOG_PATH), exist_ok=True)
+        entry = {
+            "ts": int(time.time()),
+            "model": str(model or ""),
+            "provider_id": str(provider_id or ""),
+            "status_code": status_code,
+            "bridge_surface": str(bridge_surface or ""),
+            "request_url": str(request_url or ""),
+            "event": str(event or ""),
+            "detail": str(detail or ""),
+        }
+        with open(_INCIDENT_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except Exception:
+        pass
 
 
 def _now_ms():
@@ -4760,6 +4801,15 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                     "chatcompletions fallback rejected for cache-sensitive transport; retrying messages: model=%s",
                     model_name,
                 )
+                _append_incident_log(
+                    model=model_name,
+                    provider_id=provider_id,
+                    status_code=last_status,
+                    bridge_surface="chatcompletions_to_messages_retry",
+                    request_url=target_url,
+                    event="cache_sensitive_channel_switch",
+                    detail="chatcompletions rejected; retrying via anthropic messages",
+                )
                 self._do_anthropic_messages_fallback(
                     payload,
                     model_name,
@@ -5083,6 +5133,15 @@ class _ResponsesToChatHandler(_ResponsesProxyHandler):
                         _bridge_error_logger.warning(
                             "primary chat bridge rejected for cache-sensitive transport; retrying messages: model=%s",
                             model_name,
+                        )
+                        _append_incident_log(
+                            model=model_name,
+                            provider_id=provider_id,
+                            status_code=response.status_code,
+                            bridge_surface="chat_to_messages_retry",
+                            request_url=target_url,
+                            event="cache_sensitive_channel_switch",
+                            detail="chatcompletions rejected; retrying via anthropic messages",
                         )
                         self._do_anthropic_messages_fallback(
                             payload,

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -1163,10 +1163,94 @@ def _record_bridge_blocking_failure(
             request_url=request_url,
             event="blocking_failure",
         )
+        if payload and fallback_model:
+            artifacts = payload.get("artifacts") if isinstance(payload.get("artifacts"), dict) else {}
+            rescue_dir = str(artifacts.get("dir") or "").strip()
+            _generate_rescue_summary(
+                server, payload,
+                fallback_model=fallback_model,
+                rescue_dir=rescue_dir,
+            )
         return payload
     except Exception as exc:
         _bridge_error_logger.warning("rescue file-only packet failed: %s", exc, exc_info=True)
         return None
+
+
+def _generate_rescue_summary(server, payload, *, fallback_model, rescue_dir):
+    """Call fallback model to generate a session summary; write to rescue_dir/summary.md.
+
+    Best-effort: never raises, never blocks the main response.
+    """
+    if not fallback_model or not rescue_dir:
+        return
+    try:
+        routes = _load_rescue_hot_fallback_routes(server, fallback_model)
+        if not routes:
+            return
+        route = routes[0]
+        gateway_url = str(route.get("gateway_url") or route.get("openai_base_url") or "").strip()
+        gateway_key = str(route.get("gateway_key") or route.get("api_key") or "").strip()
+        model_id = str(route.get("model") or fallback_model).strip()
+        if not gateway_url or not gateway_key:
+            return
+        failed = payload.get("failed") if isinstance(payload.get("failed"), dict) else {}
+        session_meta = payload.get("session_meta") if isinstance(payload.get("session_meta"), dict) else {}
+        task_goal = str(session_meta.get("task_goal") or "").strip()
+        failed_model = str(failed.get("model") or payload.get("model") or "").strip()
+        status_code = failed.get("status_code")
+        failure_kind = str(failed.get("failure_kind") or "").strip()
+        error_summary = str(failed.get("error_summary") or "")[:500]
+        prompt_parts = [
+            "A model API call failed during an MMS session. Generate a concise recovery summary.",
+            "",
+            f"Failed model: {failed_model}",
+            f"Status: {status_code}",
+            f"Failure type: {failure_kind}",
+        ]
+        if task_goal:
+            prompt_parts.append(f"Session goal: {task_goal}")
+        if error_summary:
+            prompt_parts.append(f"Error (truncated): {error_summary[:300]}")
+        prompt_parts.extend([
+            "",
+            "Write a recovery summary in markdown with these sections:",
+            "1. **What was being worked on** (from session goal if available)",
+            "2. **What failed** (model, status, error type)",
+            "3. **Suggested next steps** (how to resume or retry)",
+            "",
+            "Keep it under 300 words. Be concrete, not generic.",
+        ])
+        user_msg = "\n".join(prompt_parts)
+        body = json.dumps({
+            "model": model_id,
+            "messages": [{"role": "user", "content": user_msg}],
+            "max_tokens": 800,
+        }).encode("utf-8")
+        target_url = f"{gateway_url.rstrip('/')}/chat/completions"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {gateway_key}",
+        }
+        httpx = _ensure_httpx()
+        with httpx.stream("POST", target_url, headers=headers, content=body, timeout=30) as resp:
+            resp_body = resp.read().decode("utf-8", errors="replace")
+        if resp.status_code >= 200 and resp.status_code < 300:
+            data = json.loads(resp_body)
+            summary_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            if summary_text:
+                summary_path = os.path.join(str(rescue_dir), "summary.md")
+                with open(summary_path, "w", encoding="utf-8") as f:
+                    f.write(f"# Rescue Summary\n\n")
+                    f.write(f"- generated_at: {int(time.time())}\n")
+                    f.write(f"- fallback_model: {fallback_model}\n")
+                    f.write(f"- source_model: {failed_model}\n\n")
+                    f.write(summary_text)
+                _bridge_error_logger.warning(
+                    "rescue summary written: model=%s path=%s", fallback_model, summary_path
+                )
+    except Exception as exc:
+        _bridge_error_logger.warning("rescue summary generation failed: %s", exc, exc_info=True)
 
 
 def _truthy(value):
@@ -1178,6 +1262,9 @@ def _truthy(value):
 
 
 def _rescue_hot_fallback_enabled(server):
+    # PAUSED: same-session hot fallback is disabled pending redesign.
+    # See: https://github.com/anthropics/claude-code/issues (hot fallback continuity)
+    return False
     raw = str(os.environ.get("MMS_RESCUE_HOT_FALLBACK", "") or "").strip().lower()
     fallback = _current_rescue_fallback(server)
     if raw in {"1", "true", "yes", "on", "enable", "enabled"}:

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -1112,7 +1112,7 @@ def _record_bridge_blocking_failure(
     fallback_mode="auto_default_handover",
     automatic_model_call=False,
 ):
-    """Best-effort L3 rescue hook; never calls another model or OAuth flow."""
+    """Best-effort L3 rescue hook; never switches runtime or OAuth flow."""
     if not bool(getattr(server, "rescue_enabled", False)):
         return None
     try:
@@ -1156,6 +1156,7 @@ def _record_bridge_blocking_failure(
                     fallback_model,
                 )
         _append_incident_log(
+            server=server,
             model=model_name or getattr(server, "model_name", ""),
             provider_id=provider_id or getattr(server, "provider_id", ""),
             status_code=status_code,
@@ -1166,7 +1167,7 @@ def _record_bridge_blocking_failure(
         if payload and fallback_model:
             artifacts = payload.get("artifacts") if isinstance(payload.get("artifacts"), dict) else {}
             rescue_dir = str(artifacts.get("dir") or "").strip()
-            _generate_rescue_summary(
+            _schedule_rescue_summary(
                 server, payload,
                 fallback_model=fallback_model,
                 rescue_dir=rescue_dir,
@@ -1177,10 +1178,26 @@ def _record_bridge_blocking_failure(
         return None
 
 
+def _schedule_rescue_summary(server, payload, *, fallback_model, rescue_dir):
+    """Generate rescue summaries off the response path."""
+    try:
+        payload_copy = copy.deepcopy(payload)
+        worker = threading.Thread(
+            target=_generate_rescue_summary,
+            args=(server, payload_copy),
+            kwargs={"fallback_model": fallback_model, "rescue_dir": rescue_dir},
+            name="mms-rescue-summary",
+            daemon=True,
+        )
+        worker.start()
+    except Exception as exc:
+        _bridge_error_logger.warning("rescue summary scheduling failed: %s", exc, exc_info=True)
+
+
 def _generate_rescue_summary(server, payload, *, fallback_model, rescue_dir):
     """Call fallback model to generate a session summary; write to rescue_dir/summary.md.
 
-    Best-effort: never raises, never blocks the main response.
+    Best-effort: never raises. The bridge schedules this outside the main response path.
     """
     if not fallback_model or not rescue_dir:
         return
@@ -1189,6 +1206,7 @@ def _generate_rescue_summary(server, payload, *, fallback_model, rescue_dir):
         if not routes:
             return
         route = routes[0]
+        protocol = str(route.get("protocol") or "openai_chat_completions").strip()
         gateway_url = str(route.get("gateway_url") or route.get("openai_base_url") or "").strip()
         gateway_key = str(route.get("gateway_key") or route.get("api_key") or "").strip()
         model_id = str(route.get("model") or fallback_model).strip()
@@ -1222,24 +1240,56 @@ def _generate_rescue_summary(server, payload, *, fallback_model, rescue_dir):
             "Keep it under 300 words. Be concrete, not generic.",
         ])
         user_msg = "\n".join(prompt_parts)
-        body = json.dumps({
+        request_payload = {
             "model": model_id,
             "messages": [{"role": "user", "content": user_msg}],
             "max_tokens": 800,
-        }).encode("utf-8")
-        target_url = f"{gateway_url.rstrip('/')}/chat/completions"
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {gateway_key}",
         }
-        httpx = _ensure_httpx()
-        with httpx.stream("POST", target_url, headers=headers, content=body, timeout=30) as resp:
+        auth_protocol = "anthropic_messages" if protocol == "anthropic_messages" else "openai_chat"
+        target_url = _build_gateway_url(
+            gateway_url,
+            "/messages" if protocol == "anthropic_messages" else "/chat/completions",
+        )
+        headers = {"Content-Type": "application/json"}
+        if protocol == "anthropic_messages":
+            headers.update({"x-api-key": gateway_key, "anthropic-version": "2023-06-01"})
+        else:
+            headers["Authorization"] = f"Bearer {gateway_key}"
+        apply_profile_auth_headers(
+            headers,
+            protocol=auth_protocol,
+            api_key=gateway_key,
+            provider_id=str(route.get("provider_id") or ""),
+            profile_id=str(route.get("provider_profile") or route.get("profile") or ""),
+            base_url=gateway_url,
+            model_name=model_id,
+        )
+        httpx_mod = _ensure_httpx()
+        if httpx_mod is None:
+            return
+        with httpx_mod.stream(
+            "POST",
+            target_url,
+            headers=headers,
+            json=request_payload,
+            timeout=30,
+            **_route_httpx_kwargs(server, route, target_url),
+        ) as resp:
             resp_body = resp.read().decode("utf-8", errors="replace")
         if resp.status_code >= 200 and resp.status_code < 300:
             data = json.loads(resp_body)
-            summary_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            if protocol == "anthropic_messages":
+                content = data.get("content") if isinstance(data.get("content"), list) else []
+                summary_text = "\n".join(
+                    str(block.get("text") or "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ).strip()
+            else:
+                summary_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
             if summary_text:
                 summary_path = os.path.join(str(rescue_dir), "summary.md")
+                os.makedirs(os.path.dirname(summary_path), exist_ok=True)
                 with open(summary_path, "w", encoding="utf-8") as f:
                     f.write(f"# Rescue Summary\n\n")
                     f.write(f"- generated_at: {int(time.time())}\n")
@@ -1263,7 +1313,7 @@ def _truthy(value):
 
 def _rescue_hot_fallback_enabled(server):
     # PAUSED: same-session hot fallback is disabled pending redesign.
-    # See: https://github.com/anthropics/claude-code/issues (hot fallback continuity)
+    # Keep file-first rescue + fallback handover active without switching the live request.
     return False
     raw = str(os.environ.get("MMS_RESCUE_HOT_FALLBACK", "") or "").strip().lower()
     fallback = _current_rescue_fallback(server)
@@ -1622,13 +1672,41 @@ def _chatcompletions_error_requests_messages(body_text):
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 GEMINI_BRIDGE_SCRIPT = os.path.join(ROOT_DIR, "scripts", "gemini_codeassist_bridge.mjs")
 
-_INCIDENT_LOG_PATH = os.path.join(
-    os.path.expanduser("~"), ".config", "mms", "logs", "incidents.jsonl"
-)
+def _incident_log_path(server=None):
+    config_root = ""
+    if server is not None:
+        config_root = _rescue_config_root(server)
+    if not config_root:
+        try:
+            config_root = resolve_mms_config_dir()
+        except Exception:
+            config_root = os.path.join(os.path.expanduser("~"), ".config", "mms")
+    return os.path.join(str(config_root), "logs", "incidents.jsonl")
+
+
+def _redact_incident_value(value):
+    try:
+        from mms_rescue import assert_secret_safe, redact_text
+
+        text = redact_text(value)
+        assert_secret_safe(text)
+        return text
+    except Exception:
+        raw = str(value or "")
+        if not raw:
+            return ""
+        try:
+            parsed = urlsplit(raw)
+            if parsed.scheme and parsed.netloc:
+                return parsed.path or "/"
+        except Exception:
+            pass
+        return "<REDACTED>"
 
 
 def _append_incident_log(
     *,
+    server=None,
     model="",
     provider_id="",
     status_code=None,
@@ -1637,21 +1715,30 @@ def _append_incident_log(
     event="blocking_failure",
     detail="",
 ):
-    """Append one JSONL line to ~/.config/mms/logs/incidents.jsonl. Best-effort, never raises."""
+    """Append one JSONL line to the resolved MMS config logs dir. Best-effort, never raises."""
     try:
-        os.makedirs(os.path.dirname(_INCIDENT_LOG_PATH), exist_ok=True)
+        incident_path = _incident_log_path(server)
+        os.makedirs(os.path.dirname(incident_path), exist_ok=True)
         entry = {
             "ts": int(time.time()),
-            "model": str(model or ""),
-            "provider_id": str(provider_id or ""),
+            "model": _redact_incident_value(model),
+            "provider_id": _redact_incident_value(provider_id),
             "status_code": status_code,
-            "bridge_surface": str(bridge_surface or ""),
-            "request_url": str(request_url or ""),
-            "event": str(event or ""),
-            "detail": str(detail or ""),
+            "bridge_surface": _redact_incident_value(bridge_surface),
+            "request_url": _redact_incident_value(request_url),
+            "event": _redact_incident_value(event),
+            "detail": _redact_incident_value(detail),
         }
-        with open(_INCIDENT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        line = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+        try:
+            from mms_rescue import assert_secret_safe
+
+            assert_secret_safe(line)
+        except Exception:
+            return
+        with locked_state_file(incident_path):
+            with open(incident_path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
     except Exception:
         pass
 
@@ -4889,6 +4976,7 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                     model_name,
                 )
                 _append_incident_log(
+                    server=self.server,
                     model=model_name,
                     provider_id=provider_id,
                     status_code=last_status,
@@ -5222,6 +5310,7 @@ class _ResponsesToChatHandler(_ResponsesProxyHandler):
                             model_name,
                         )
                         _append_incident_log(
+                            server=self.server,
                             model=model_name,
                             provider_id=provider_id,
                             status_code=response.status_code,

--- a/tests/test_mms_rescue.py
+++ b/tests/test_mms_rescue.py
@@ -250,6 +250,48 @@ def test_record_blocking_failure_redacts_secret_upstream_body(tmp_path):
     assert payload["safety"]["automatic_model_call"] is False
 
 
+def test_bridge_blocking_failure_incident_log_uses_config_root_and_redacts(monkeypatch, tmp_path):
+    import mms_bridge
+
+    repo = tmp_path / "repo"
+    config_root = tmp_path / "mms-config"
+    home = tmp_path / "home"
+    repo.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    server = types.SimpleNamespace(
+        rescue_enabled=True,
+        rescue_repo_root=str(repo),
+        rescue_config_root=str(config_root),
+        model_name="gpt-5.5",
+        provider_id="private-relay",
+        rescue_fallback_model="",
+        rescue_fallback_cli="",
+        rescue_hot_fallback_enabled=False,
+    )
+
+    payload = mms_bridge._record_bridge_blocking_failure(
+        server,
+        model_name="gpt-5.5",
+        provider_id="private-relay",
+        status_code=429,
+        body_text='{"error":{"message":"quota","api_key":"sk-live-secret-1234567890"}}',
+        request_url="https://relay.example/v1/responses?api_key=sk-query-secret-1234567890",
+        bridge_surface="codex_responses_proxy",
+    )
+
+    assert payload is not None
+    incident_log = config_root / "logs" / "incidents.jsonl"
+    assert incident_log.exists()
+    text = incident_log.read_text(encoding="utf-8")
+    assert "sk-query-secret" not in text
+    assert "sk-live-secret" not in text
+    entry = json.loads(text.splitlines()[0])
+    assert entry["event"] == "blocking_failure"
+    assert entry["status_code"] == 429
+    assert "<REDACTED>" in entry["request_url"]
+    assert not (home / ".config" / "mms" / "logs" / "incidents.jsonl").exists()
+
+
 def test_bridge_mocked_429_writes_file_only_rescue_without_oauth(monkeypatch, tmp_path):
     import mms_bridge
 
@@ -335,7 +377,7 @@ def test_bridge_mocked_429_writes_file_only_rescue_without_oauth(monkeypatch, tm
     assert handover["fallback"]["automatic_model_call"] is False
 
 
-def test_responses_proxy_hot_fallback_uses_configured_rescue_model(monkeypatch, tmp_path):
+def test_responses_proxy_hot_fallback_pause_writes_handover_only(monkeypatch, tmp_path):
     import mms_bridge
 
     repo = tmp_path / "repo"
@@ -430,23 +472,19 @@ def test_responses_proxy_hot_fallback_uses_configured_rescue_model(monkeypatch, 
 
     handler.do_POST()
 
-    assert captured["model_name"] == "deepseek-v4-flash"
-    assert captured["gateway_url"] == "https://deepseek.example/v1"
-    assert captured["gateway_key"] == "sk-deepseek-test"
-    assert captured["route"]["provider_id"] == "newapi-deepseek"
+    assert captured["status"] == 503
+    assert "model_name" not in captured
     latest_json = repo / ".mms" / "rescue" / "latest.json"
     assert latest_json.exists()
     latest = json.loads(latest_json.read_text(encoding="utf-8"))
-    assert latest["safety"]["automatic_model_call"] is True
+    assert latest["safety"]["automatic_model_call"] is False
     assert latest["safety"]["global_oauth_fallback"] == "disabled"
     handover = json.loads((repo / ".mms" / "rescue" / "latest-fallback-handover.json").read_text(encoding="utf-8"))
     assert handover["fallback"]["model"] == "deepseek-v4-flash"
-    assert handover["fallback"]["mode"] == "hot_fallback_attempt"
-    assert handover["fallback"]["automatic_model_call"] is True
+    assert handover["fallback"]["mode"] == "auto_default_handover"
+    assert handover["fallback"]["automatic_model_call"] is False
     assert handover["safety"]["global_oauth_fallback"] == "disabled"
-    assert emitted_events
-    assert emitted_events[0][0] == ("fallback", "deepseek-v4-flash")
-    assert "rescue_hot_fallback" in emitted_events[0][1]["note"]
+    assert emitted_events == []
 
 
 def test_responses_proxy_hot_fallback_prefers_anthropic_messages_for_deepseek(monkeypatch, tmp_path):
@@ -544,12 +582,13 @@ def test_responses_proxy_hot_fallback_prefers_anthropic_messages_for_deepseek(mo
 
     handler.do_POST()
 
-    assert captured["model_name"] == "deepseek-v4-flash"
-    assert captured["gateway_url"] == "https://deepseek.example"
-    assert captured["gateway_key"] == "sk-deepseek-test"
-    assert captured["route"]["provider_id"] == "newapi-deepseek"
-    assert captured["route"]["protocol"] == "anthropic_messages"
+    assert captured["status"] == 524
+    assert "model_name" not in captured
     assert captured.get("chat_called") is None
+    routes = mms_bridge._load_rescue_hot_fallback_routes(handler.server, "deepseek-v4-flash")
+    assert routes[0]["provider_id"] == "newapi-deepseek"
+    assert routes[0]["gateway_url"] == "https://deepseek.example"
+    assert routes[0]["protocol"] == "anthropic_messages"
 
 
 def test_responses_proxy_hot_fallback_uses_messages_for_cache_sensitive_openai_only_route(monkeypatch, tmp_path):
@@ -648,15 +687,16 @@ def test_responses_proxy_hot_fallback_uses_messages_for_cache_sensitive_openai_o
 
     handler.do_POST()
 
-    assert captured["model_name"] == "deepseek-v4-flash"
-    assert captured["gateway_url"] == "https://deepseek.example/v1"
-    assert captured["gateway_key"] == "sk-deepseek-test"
-    assert captured["route"]["provider_id"] == "newapi-deepseek"
-    assert captured["route"]["protocol"] == "anthropic_messages"
+    assert captured["status"] == 524
+    assert "model_name" not in captured
     assert captured.get("chat_called") is None
+    routes = mms_bridge._load_rescue_hot_fallback_routes(handler.server, "deepseek-v4-flash")
+    assert routes[0]["provider_id"] == "newapi-deepseek"
+    assert routes[0]["gateway_url"] == "https://deepseek.example/v1"
+    assert routes[0]["protocol"] == "anthropic_messages"
 
 
-def test_chatcompletions_fallback_retries_messages_when_gateway_requests_messages(monkeypatch):
+def test_chatcompletions_fallback_retries_messages_when_gateway_requests_messages(monkeypatch, tmp_path):
     import mms_bridge
 
     class FakeResponse:
@@ -695,6 +735,7 @@ def test_chatcompletions_fallback_retries_messages_when_gateway_requests_message
         speed_scope=None,
         reasoning_enabled=True,
         reasoning_effort="high",
+        rescue_config_root=str(tmp_path / "mms-config"),
     )
     captured = {}
 
@@ -729,9 +770,10 @@ def test_chatcompletions_fallback_retries_messages_when_gateway_requests_message
     assert captured["route"]["protocol"] == "anthropic_messages"
     assert captured["route"]["fallback_reason"] == "cache_sensitive_messages_retry"
     assert "status" not in captured
+    assert (tmp_path / "mms-config" / "logs" / "incidents.jsonl").exists()
 
 
-def test_primary_codex_chat_bridge_retries_messages_when_gateway_requests_messages(monkeypatch):
+def test_primary_codex_chat_bridge_retries_messages_when_gateway_requests_messages(monkeypatch, tmp_path):
     import mms_bridge
 
     class FakeResponse:
@@ -792,6 +834,7 @@ def test_primary_codex_chat_bridge_retries_messages_when_gateway_requests_messag
         route_status_paths=[],
         reasoning_enabled=True,
         reasoning_effort="high",
+        rescue_config_root=str(tmp_path / "mms-config"),
     )
     captured = {}
 
@@ -821,6 +864,7 @@ def test_primary_codex_chat_bridge_retries_messages_when_gateway_requests_messag
     assert captured["route"]["fallback_reason"] == "cache_sensitive_messages_retry"
     assert not blocking
     assert "status" not in captured
+    assert (tmp_path / "mms-config" / "logs" / "incidents.jsonl").exists()
 
 
 def test_anthropic_messages_hot_fallback_posts_messages_endpoint(monkeypatch, tmp_path):
@@ -900,6 +944,83 @@ def test_anthropic_messages_hot_fallback_posts_messages_endpoint(monkeypatch, tm
     assert calls[0][2]["json"]["model"] == "deepseek-v4-flash"
     assert b"response.output_text.delta" in handler.wfile.getvalue()
     assert b"ok" in handler.wfile.getvalue()
+
+
+def test_generate_rescue_summary_uses_anthropic_messages_route(monkeypatch, tmp_path):
+    import mms_bridge
+
+    config_root = tmp_path / "mms-config"
+    rescue_dir = tmp_path / "repo" / ".mms" / "rescue" / "event"
+    (config_root / "generated").mkdir(parents=True)
+    (config_root / "generated" / "model-routes.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "routes": {
+                    "deepseek-v4-flash": {
+                        "primary": {
+                            "provider_id": "newapi-deepseek",
+                            "anthropic_base_url": "https://deepseek.example",
+                            "openai_base_url": "https://deepseek.example/v1",
+                            "api_key": "sk-deepseek-test",
+                            "model_id": "deepseek-v4-flash",
+                        },
+                        "fallbacks": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    class FakeResponse:
+        status_code = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        @staticmethod
+        def read():
+            return json.dumps({"content": [{"type": "text", "text": "Resume from the rescue packet."}]}).encode()
+
+    def fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr(mms_bridge, "httpx", types.SimpleNamespace(stream=fake_stream))
+    monkeypatch.setattr(mms_bridge, "_ensure_httpx", lambda: mms_bridge.httpx)
+    server = types.SimpleNamespace(
+        rescue_config_root=str(config_root),
+        proxy_url="",
+        no_proxy="",
+    )
+    payload = {
+        "failed": {
+            "model": "gpt-5.5",
+            "status_code": 429,
+            "failure_kind": "rate_limit_or_quota",
+            "error_summary": "quota",
+        },
+        "session_meta": {"task_goal": "fix PR #1"},
+    }
+
+    mms_bridge._generate_rescue_summary(
+        server,
+        payload,
+        fallback_model="deepseek-v4-flash",
+        rescue_dir=str(rescue_dir),
+    )
+
+    assert calls[0][0] == "POST"
+    assert calls[0][1] == "https://deepseek.example/v1/messages"
+    assert calls[0][2]["headers"]["x-api-key"] == "sk-deepseek-test"
+    assert calls[0][2]["json"]["model"] == "deepseek-v4-flash"
+    summary = (rescue_dir / "summary.md").read_text(encoding="utf-8")
+    assert "Resume from the rescue packet." in summary
 
 
 def test_responses_proxy_hot_fallback_reads_current_rescue_config(monkeypatch, tmp_path):
@@ -1006,13 +1127,13 @@ def test_responses_proxy_hot_fallback_reads_current_rescue_config(monkeypatch, t
 
     handler.do_POST()
 
-    assert captured["model_name"] == "deepseek-v4-flash"
-    assert captured["gateway_url"] == "https://deepseek.example/v1"
-    assert captured["route"]["provider_id"] == "newapi-deepseek"
-    assert handler.server.rescue_fallback_model == "deepseek-v4-flash"
-    assert handler.server.rescue_fallback_cli == "codex"
+    assert captured["status"] == 503
+    assert "model_name" not in captured
     handover = json.loads((repo / ".mms" / "rescue" / "latest-fallback-handover.json").read_text(encoding="utf-8"))
-    assert handover["fallback"]["automatic_model_call"] is True
+    assert handover["fallback"]["model"] == "deepseek-v4-flash"
+    assert handover["fallback"]["cli"] == "codex"
+    assert handover["fallback"]["mode"] == "auto_default_handover"
+    assert handover["fallback"]["automatic_model_call"] is False
     assert handover["safety"]["global_oauth_fallback"] == "disabled"
 
 


### PR DESCRIPTION
## Summary

- **Incident log**: append JSONL to `~/.config/mms/logs/incidents.jsonl` on every blocking failure and cache-sensitive channel switch
- **Rescue summary**: call fallback model (deepseek) to generate recovery summary at `rescue_dir/summary.md` on blocking failure
- **Pause hot fallback**: disable same-session hot fallback pending redesign
- **Cache-sensitive retry**: route cache-sensitive rescue fallback over anthropic messages; retry primary codex bridge over messages when chatcompletions is rejected

## Test plan

- [ ] Verify `~/.config/mms/logs/incidents.jsonl` is created on 429/524
- [ ] Verify `summary.md` is generated in rescue directory
- [ ] Verify hot fallback does not trigger (MMS_RESCUE_HOT_FALLBACK=0 or code pause)
- [ ] Run `python3 -m pytest tests/test_mms_rescue.py -x`