### PR TITLE
[codex] preserve stable WebUI model routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ immediately while refreshing `/models` in the background; if a family is still
 missing on the same key, compare provider config/credentials and run
 `mms models` or `mms doctor full`.
 
+Stable legacy route export is conservative: a refreshed provider `/models`
+response may add routes, but it does not drop previously approved local routes
+for the same enabled provider unless the provider is disabled/removed, the
+model is hidden, or WebUI sends an explicit stale-route cleanup scope.
+
 ## Quick Start
 
 Interactive launch:

--- a/docs/MODEL_CONFIG_CONTRACT.md
+++ b/docs/MODEL_CONFIG_CONTRACT.md
@@ -103,6 +103,10 @@ Bundle rules:
   first; explicit `force=True` still regenerates legacy root aliases from
   current config. Provider/account priority and bridge routing stay on the
   existing path.
+- In stable legacy roots, `force=True` preserves previously approved provider
+  routes when a refreshed `/models` response temporarily omits a model. Routes
+  are dropped only when the provider is removed/disabled, the model is hidden,
+  or an explicit stale-route cleanup scope is passed by WebUI/CLI tooling.
 
 See `docs/REGISTRY_ARCHITECTURE.md` for the full source/candidate/approved/
 runtime/health layer contract, `privacy_boundary` gates, deletion/tombstone

--- a/docs/SERVER_CLAUDE_CACHE_RUNBOOK.md
+++ b/docs/SERVER_CLAUDE_CACHE_RUNBOOK.md
@@ -149,6 +149,13 @@
 3. `anthropic-beta` 是否从客户端透传到了上游
 4. `cache_control` 是否在服务端中间转换时被吃掉或改坏
 
+### Watchdog / `/models` 注意事项
+
+Claude-compatible relay 的 `/models` 结果不再作为 Claude route 是否可用
+的硬性 presence check。健康检查应优先验证 `/v1/messages` smoke 与 cache
+evidence；`/models` 可以作为 endpoint liveness 参考，但不能因为上游未列出
+某个 Claude-family route 就自动判定 route 缺失或触发 route 删除。
+
 如果 1 成立、2 不成立，基本就是服务端兼容链问题。
 
 ---

--- a/mms_config_web.py
+++ b/mms_config_web.py
@@ -158,6 +158,18 @@ def _policy_path_for_config(config_path: str = "") -> str:
         return ""
 
 
+def _routes_path_for_config(config_path: str = "") -> str:
+    config_path = os.path.abspath(os.path.expanduser(str(config_path or ""))) if config_path else ""
+    if config_path:
+        return os.path.join(os.path.dirname(config_path), "model-routes.json")
+    try:
+        import mms_router
+
+        return str(getattr(mms_router, "MODEL_ROUTES_PATH", ""))
+    except Exception:
+        return ""
+
+
 def _load_json_file(path: str) -> dict[str, Any]:
     if not path or not os.path.exists(path):
         return {}
@@ -236,7 +248,11 @@ def _model_capability_defaults(model_id: str, policy_entry: dict[str, Any] | Non
     return caps
 
 
-def _provider_effective_model_rows(provider: dict[str, Any], policy_payload: dict[str, Any]) -> list[dict[str, Any]]:
+def _provider_effective_model_rows(
+    provider: dict[str, Any],
+    policy_payload: dict[str, Any],
+    approved_route_models: list[str] | None = None,
+) -> list[dict[str, Any]]:
     model_sources: dict[str, str] = {}
     provider_id = _safe_text(provider.get("id"))
     cached_raw: list[str] = []
@@ -249,8 +265,21 @@ def _provider_effective_model_rows(provider: dict[str, Any], policy_payload: dic
             cached_source = _safe_text(cached.get("base_source") or "remote") or "remote"
     except Exception:
         cached_raw = []
-    for model in cached_raw or _normalize_model_list(provider.get("fallback_models")):
-        model_sources.setdefault(model, cached_source if cached_raw else "fallback")
+    row_models: list[str] = []
+    row_sources: dict[str, str] = {}
+    for item in (provider.get("models") if isinstance(provider.get("models"), list) else []):
+        model_id = _safe_text(item.get("id") or item.get("model")) if isinstance(item, dict) else _safe_text(item)
+        if not model_id:
+            continue
+        row_models.append(model_id)
+        if isinstance(item, dict):
+            row_sources.setdefault(model_id, _safe_text(item.get("source") or "manual") or "manual")
+    fallback_models = _normalize_model_list(provider.get("fallback_models"))
+    approved_models = _normalize_model_list(approved_route_models)
+    base_models = cached_raw or fallback_models or approved_models or row_models
+    for model in base_models:
+        source = cached_source if cached_raw else ("fallback" if fallback_models else ("approved_route" if approved_models else row_sources.get(model, "manual")))
+        model_sources.setdefault(model, source)
     for model in _normalize_model_list(provider.get("extra_models")):
         model_sources.setdefault(model, "extra")
     policy_models = policy_payload.get("models") if isinstance(policy_payload.get("models"), dict) else {}
@@ -279,7 +308,38 @@ def _provider_stale_hidden_models(provider: dict[str, Any], model_rows: list[dic
     return [model for model in _normalize_model_list(provider.get("hidden_models")) if model not in current_ids]
 
 
-def _provider_summary(provider: dict[str, Any], *, policy_payload: dict[str, Any] | None = None) -> dict[str, Any]:
+def _approved_route_models_by_provider(config_path: str = "") -> dict[str, list[str]]:
+    routes_payload = _load_json_file(_routes_path_for_config(config_path))
+    routes = routes_payload.get("routes") if isinstance(routes_payload.get("routes"), dict) else {}
+    by_provider: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    for route_model, route_info in routes.items():
+        model_id = _safe_text(route_model)
+        if not model_id or not isinstance(route_info, dict):
+            continue
+        leaves = []
+        primary = route_info.get("primary")
+        if isinstance(primary, dict):
+            leaves.append(primary)
+        leaves.extend(item for item in (route_info.get("fallbacks") or []) if isinstance(item, dict))
+        for leaf in leaves:
+            provider_id = _safe_text(leaf.get("provider_id"))
+            if not provider_id:
+                continue
+            provider_seen = seen.setdefault(provider_id, set())
+            if model_id in provider_seen:
+                continue
+            provider_seen.add(model_id)
+            by_provider.setdefault(provider_id, []).append(model_id)
+    return {provider_id: sorted(models, key=lambda item: item.lower()) for provider_id, models in by_provider.items()}
+
+
+def _provider_summary(
+    provider: dict[str, Any],
+    *,
+    policy_payload: dict[str, Any] | None = None,
+    approved_route_models: list[str] | None = None,
+) -> dict[str, Any]:
     provider = provider if isinstance(provider, dict) else {}
     provider_id = _safe_text(provider.get("id"))
     protocols = provider.get("protocols") if isinstance(provider.get("protocols"), list) else []
@@ -300,7 +360,9 @@ def _provider_summary(provider: dict[str, Any], *, policy_payload: dict[str, Any
     anthropic_base = config_anthropic_base or credential_anthropic_base
     api_key = _safe_text(provider.get("api_key") or provider.get("openai_api_key"))
     policy_payload = policy_payload if isinstance(policy_payload, dict) else {}
-    model_rows = _provider_effective_model_rows(provider, policy_payload)
+    approved_route_models = _normalize_model_list(approved_route_models)
+    model_rows = _provider_effective_model_rows(provider, policy_payload, approved_route_models)
+    approved_route_set = set(approved_route_models)
     return {
         "id": provider_id,
         "original_id": provider_id,
@@ -322,11 +384,12 @@ def _provider_summary(provider: dict[str, Any], *, policy_payload: dict[str, Any
         "api_key": "",
         "has_api_key": bool(api_key or creds.get("has_api_key")),
         "update_credentials": False,
+        "approved_route_models": approved_route_models,
         "fallback_models": _normalize_model_list(provider.get("fallback_models")),
         "extra_models": _normalize_model_list(provider.get("extra_models")),
         "hidden_models": _normalize_model_list(provider.get("hidden_models")),
         "stale_hidden_models": _provider_stale_hidden_models(provider, model_rows),
-        "model_count": len(dict.fromkeys(models or [row["id"] for row in model_rows])),
+        "model_count": len(dict.fromkeys(models + list(approved_route_set) or [row["id"] for row in model_rows])),
         "models": model_rows,
     }
 
@@ -523,7 +586,16 @@ def build_config_snapshot(
     providers = cfg.get("providers") if isinstance(cfg.get("providers"), list) else []
     policy_path = _policy_path_for_config(config_path)
     policy_payload = _load_json_file(policy_path)
-    provider_rows = [_provider_summary(item, policy_payload=policy_payload) for item in providers if isinstance(item, dict)]
+    approved_routes = _approved_route_models_by_provider(config_path)
+    provider_rows = [
+        _provider_summary(
+            item,
+            policy_payload=policy_payload,
+            approved_route_models=approved_routes.get(_safe_text(item.get("id")), []),
+        )
+        for item in providers
+        if isinstance(item, dict)
+    ]
     vision_sidecar = cfg.get("vision_sidecar") if isinstance(cfg.get("vision_sidecar"), dict) else {}
     rescue = cfg.get("rescue") if isinstance(cfg.get("rescue"), dict) else {}
     provider_default = _safe_text((cfg.get("provider") if isinstance(cfg.get("provider"), dict) else {}).get("default"))
@@ -838,6 +910,25 @@ def _extract_draft(payload: dict[str, Any]) -> dict[str, Any]:
     payload = payload if isinstance(payload, dict) else {}
     draft = payload.get("draft") if isinstance(payload.get("draft"), dict) else payload
     return draft if isinstance(draft, dict) else {}
+
+
+def _route_refresh_provider_ids_from_payload(payload: dict[str, Any] | None) -> list[str]:
+    payload = payload if isinstance(payload, dict) else {}
+    draft = _extract_draft(payload)
+    for source in (payload, draft):
+        values = source.get("route_refresh_provider_ids") or source.get("stale_route_cleanup_provider_ids")
+        if not isinstance(values, list):
+            continue
+        result = []
+        seen = set()
+        for item in values:
+            provider_id = _safe_text(item)
+            if provider_id and provider_id not in seen:
+                seen.add(provider_id)
+                result.append(provider_id)
+        if result:
+            return result
+    return []
 
 
 def _copy_existing_provider(existing: dict[str, Any] | None, provider_payload: dict[str, Any]) -> dict[str, Any]:
@@ -1566,7 +1657,15 @@ def apply_config_plan(
         save_report["model_policy"] = _write_model_policy_audited(policy_path, plan["model_policy"], config_path=target_config_path, reason=f"{reason}:model-policy")
 
     try:
-        save_report["routes_export"] = bool(mms_core._refresh_routes_export_for_hive(plan["config"], force=True, quiet=True, startup_safe=True))  # noqa: SLF001
+        save_report["routes_export"] = bool(  # noqa: SLF001
+            mms_core._refresh_routes_export_for_hive(
+                plan["config"],
+                force=True,
+                quiet=True,
+                startup_safe=True,
+                route_refresh_provider_ids=_route_refresh_provider_ids_from_payload(payload),
+            )
+        )
     except Exception:
         save_report["routes_export"] = False
 
@@ -2556,22 +2655,23 @@ _HTML_PAGE = r"""<!doctype html>
           </div>
           <div class="tab-panel" data-tab-panel="models">
             <div class="model-section">
-              <p class="muted">拉取通道支持的模型列表，或手动添加模型。取消勾选「显示」可将模型隐藏。需要长期保留的模型请使用「手动补充」。</p>
+              <p class="muted">这是当前通道的模型清单，不是全局模型池。拉取缺失的旧 route 默认保留；手动补充会写入当前通道 extra_models，取消勾选「显示」会写入 hidden_models。</p>
               <div class="card">
                 <div class="btns">
                   <button id="fetchModels">拉取当前通道模型</button>
                   <button id="testList" class="secondary">测试 /models</button>
+                  <label class="check"><input id="autoStaleCleanupOnFetch" type="checkbox"><span>拉取后自动标记缺失旧 route 为待清理（本页临时）</span></label>
                   <input id="modelSearch" placeholder="搜索模型" style="max-width:260px">
                 </div>
-                <label style="margin-top:14px">手动补充模型（逗号或换行分隔）</label>
+                <label style="margin-top:14px">手动补充当前通道模型（extra_models，逗号或换行分隔）</label>
                 <textarea id="manualModels" placeholder="例如：gpt-5.5, qwen3.6-plus, K2.6"></textarea>
                 <div class="btns">
-                  <button id="addManualModels" class="secondary">添加到列表</button>
+                  <button id="addManualModels" class="secondary">添加到补充模型库</button>
                   <button id="clearHidden" class="ghost">取消当前通道全部隐藏</button>
-                  <button id="clearAllStaleHidden" class="ghost">一键清理全部通道过期隐藏项</button>
+                  <button id="clearAllStaleHidden" class="ghost">移除全部通道未匹配隐藏规则</button>
                 </div>
-                <div id="modelChips" class="chips" style="margin-top:10px"></div>
               </div>
+              <div id="modelChips" class="card"></div>
               <div class="card" id="staleHiddenBox"></div>
               <div class="table-wrap"><table id="modelTable"></table></div>
             </div>
@@ -2740,11 +2840,12 @@ const sections=[
   ['save','保存审计','diff / backup / audit'],
   ['refs','本地参考','配置契约 / docs']
 ];
-let state=null; let activeProvider=0; let activeProviderTab='config'; let lastPlan=null; let opencodeAgentFilter="all"; let opencodeOnlyOverridden=false;
+let state=null; let activeProvider=0; let activeProviderTab='config'; let lastPlan=null; let opencodeAgentFilter="all"; let opencodeOnlyOverridden=false; let editingExtraModels=false; let touchedProviders=new Set(); let staleCleanupProviders=new Set();
 const $=id=>document.getElementById(id);
 function toast(msg){const el=$('toast');el.textContent=msg;el.classList.add('show');setTimeout(()=>el.classList.remove('show'),3600)}
 async function api(path,body){const res=await fetch(path,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body||{})});const data=await res.json();if(!res.ok){data.ok=false;data.http_status=res.status;data.error=data.error||res.statusText}return data}
 function current(){return state.providers[activeProvider]}
+function touchProvider(id){if(id)touchedProviders.add(id)}
 function setSection(id){document.querySelectorAll('[data-section]').forEach(el=>el.classList.toggle('hide',el.dataset.section!==id));document.querySelectorAll('.navbtn').forEach(el=>el.classList.toggle('active',el.dataset.id===id))}
 function switchProviderTab(tab){activeProviderTab=tab;document.querySelectorAll('.provider-tabs .tab-btn').forEach(b=>b.classList.toggle('active',b.dataset.tab===tab));document.querySelectorAll('.tab-panel').forEach(p=>p.classList.toggle('active',p.dataset.tabPanel===tab))}
 function renderNav(){ $('nav').innerHTML=sections.map(([id,title,sub])=>`<button class="navbtn" data-id="${id}">${title}<small>${sub}</small></button>`).join(''); document.querySelectorAll('.navbtn').forEach(b=>b.onclick=()=>setSection(b.dataset.id)); setSection('channel') }
@@ -2757,20 +2858,22 @@ function checks(name,values,allowed){values=values||[];return `<div class="check
 function checkedValues(name){return [...document.querySelectorAll(`input[name="${name}"]:checked`)].map(x=>x.value)}
 function renderProviderForm(){const p=current(); if(!p){$('providerForm').innerHTML='<p>暂无通道</p>';return} $('providerForm').innerHTML=`<div class="grid"><div class="span6"><label>内部 ID</label><input id="pId" value="${escapeHtml(p.id)}"></div><div class="span6"><label>显示名</label><input id="pName" value="${escapeHtml(p.name)}"></div><div class="span4"><label>状态</label><select id="pEnabled"><option value="true" ${p.enabled?'selected':''}>启用</option><option value="false" ${!p.enabled?'selected':''}>禁用</option></select></div><div class="span4"><label>role</label><select id="pRole">${['primary','auto','fallback'].map(v=>`<option ${p.role===v?'selected':''}>${v}</option>`).join('')}</select></div><div class="span4"><label>priority</label><input id="pPriority" type="number" value="${escapeHtml(p.priority||100)}"></div><div class="span6"><label>OpenAI base URL</label><input id="pOpenAI" value="${escapeHtml(p.openai_base_url||'')}" placeholder="https://.../v1"></div><div class="span6"><label>Anthropic base URL</label><input id="pAnthropic" value="${escapeHtml(p.anthropic_base_url||'')}" placeholder="https://.../v1 或 /anthropic"></div><div class="span6"><label>API Key（留空不更新）</label><input id="pKey" type="password" placeholder="${p.has_api_key?'已保存；输入新 key 才会覆盖':'sk-...'}"></div><div class="span6"><label>models_endpoint</label><input id="pModelsEndpoint" value="${escapeHtml(p.models_endpoint||'/models')}" placeholder="/models 或 manual"></div><div class="span12"><label>protocols</label>${checks('pProtocols',p.protocols,['anthropic_messages','openai_chat_completions'])}</div><div class="span12"><label>supported CLIs</label>${checks('pClis',p.supported_clis,['claude','codex','opencode','agy'])}</div><div class="span12 check"><input id="pUpdateCreds" type="checkbox"><span>保存时更新 credentials.sh（需要填写 API Key；会 backup + audit）</span></div><div class="span12 check"><input id="pDefault" type="checkbox" ${state.provider_default===p.id?'checked':''}><span>设为默认 provider</span></div></div><div class="btns"><button id="saveProviderForm">保存通道修改</button></div>`;bindProviderForm()}
 function bindProviderForm(){['pId','pName','pEnabled','pRole','pPriority','pOpenAI','pAnthropic','pModelsEndpoint'].forEach(id=>$(id).oninput=syncProvider);$('pKey').oninput=syncProvider;$('pUpdateCreds').onchange=syncProvider;$('pDefault').onchange=()=>{syncProvider(); if($('pDefault').checked) state.provider_default=current().id; renderProviders();};document.querySelectorAll('input[name="pProtocols"],input[name="pClis"]').forEach(x=>x.onchange=syncProvider);const save=$('saveProviderForm');if(save)save.onclick=()=>{syncProvider();setSection('save');toast('通道修改已暂存，生成保存预览后再写入')}}
-function syncProvider(){const p=current(); if(!p)return; const old=p.id;p.id=$('pId').value.trim()||p.id;p.name=$('pName').value.trim()||p.id;p.enabled=$('pEnabled').value==='true';p.role=$('pRole').value;p.priority=Number($('pPriority').value||100);p.openai_base_url=$('pOpenAI').value.trim();p.anthropic_base_url=$('pAnthropic').value.trim();p.models_endpoint=$('pModelsEndpoint').value.trim()||'/models';p.protocols=checkedValues('pProtocols');p.supported_clis=checkedValues('pClis');p.api_key=$('pKey').value;p.update_credentials=$('pUpdateCreds').checked;if(state.provider_default===old)state.provider_default=p.id;renderProviderList();renderTestSelectors();}
+function syncProvider(){const p=current(); if(!p)return; const old=p.id;touchProvider(old);p.id=$('pId').value.trim()||p.id;if(p.id!==old){touchedProviders.delete(old);touchProvider(p.id)}p.name=$('pName').value.trim()||p.id;p.enabled=$('pEnabled').value==='true';p.role=$('pRole').value;p.priority=Number($('pPriority').value||100);p.openai_base_url=$('pOpenAI').value.trim();p.anthropic_base_url=$('pAnthropic').value.trim();p.models_endpoint=$('pModelsEndpoint').value.trim()||'/models';p.protocols=checkedValues('pProtocols');p.supported_clis=checkedValues('pClis');p.api_key=$('pKey').value;p.update_credentials=$('pUpdateCreds').checked;if(state.provider_default===old)state.provider_default=p.id;renderProviderList();renderTestSelectors();}
 function providerModels(p){p=p||{};const map=new Map();const baseRows=(p.models||[]).filter(r=>r&&r.id&&r.source!=='hidden');baseRows.forEach(r=>map.set(r.id,{...r,capabilities:{...(r.capabilities||{})}}));if(!baseRows.length){(p.fallback_models||[]).forEach(id=>{if(!map.has(id))map.set(id,{id,source:'fallback',visible:!(p.hidden_models||[]).includes(id),favorite:false,capabilities:defaultCaps(id)})})}(p.extra_models||[]).forEach(id=>{if(!map.has(id))map.set(id,{id,source:'extra',visible:!(p.hidden_models||[]).includes(id),favorite:false,capabilities:defaultCaps(id)})});(p.hidden_models||[]).forEach(id=>{if(map.has(id))map.get(id).visible=false});return [...map.values()].sort((a,b)=>a.id.localeCompare(b.id))}
 function defaultCaps(id){const l=String(id||'').toLowerCase();return {text:true,vision:['mimo-v2.5','mimo-v2-omni','k2.6','k2.6-code-preview','kimi-k2.5','qwen3.6-plus','qwen3.6-flash','qwen3.5-plus'].includes(l)||l.startsWith('claude-')||l.startsWith('gemini-'),tool_use:/^(claude|gpt|o|qwen|kimi|glm|minimax|gemini)/.test(l),reasoning:/gpt-5|qwen3|kimi-k2|glm-5|deepseek|claude/.test(l),long_context:/1m|long|qwen3|kimi-k2|gpt-5|claude/.test(l),cache_sensitive:/^(qwen|kimi|k2\.|glm|deepseek|minimax|mimo)/.test(l)}}
 function providerCurrentIds(p){return new Set(providerModels(p).map(r=>r.id))}
 function staleHiddenModels(p){const ids=providerCurrentIds(p);return [...new Set([...(p.stale_hidden_models||[]),...(p.hidden_models||[]).filter(id=>!ids.has(id))])]}
 function cleanupStaleHidden(p){const stale=staleHiddenModels(p);const doomed=new Set(stale);p.hidden_models=(p.hidden_models||[]).filter(x=>!doomed.has(x));p.stale_hidden_models=[];return stale.length}
-function cleanupAllStaleHidden(){let total=0;(state.providers||[]).forEach(p=>{total+=cleanupStaleHidden(p)});renderProviders();toast(total?`已清理 ${total} 个过期 hidden_models`:'没有需要清理的过期隐藏项')}
+function cleanupAllStaleHidden(){let total=0;(state.providers||[]).forEach(p=>{total+=cleanupStaleHidden(p)});renderProviders();toast(total?`已移除 ${total} 条未匹配隐藏规则`:'没有需要移除的未匹配隐藏规则')}
 function visibleModelsForProvider(providerId,{visionFirst=false,includeHidden=false,enabledOnly=false}={}){let rows=[];(state.providers||[]).forEach(p=>{if(providerId&&p.id!==providerId)return;if(enabledOnly&&p.enabled===false)return;providerModels(p).forEach(r=>{if(!includeHidden&&r.visible===false)return;rows.push({...r,provider_id:p.id,provider_name:p.name||p.id,capabilities:{...(r.capabilities||defaultCaps(r.id))}})})});const seen=new Set();rows=rows.filter(r=>{const key=(providerId?'':r.provider_id+'::')+r.id;if(seen.has(key))return false;seen.add(key);return true});rows.sort((a,b)=>{const av=!!(a.capabilities||{}).vision,bv=!!(b.capabilities||{}).vision;if(visionFirst&&av!==bv)return av?-1:1;return (a.provider_id+' '+a.id).localeCompare(b.provider_id+' '+b.id)});return rows}
 function providerOptions(selected,{blankLabel='请选择通道',auto=false,enabledOnly=false}={}){const opts=[];const providers=providerEntries().filter(({p})=>!enabledOnly||p.enabled||p.id===selected);if(auto)opts.push(`<option value="" ${!selected?'selected':''}>自动选择 provider</option>`);else opts.push(`<option value="" ${!selected?'selected':''}>${escapeHtml(blankLabel)}</option>`);opts.push(...providers.map(({p})=>{const disabled=p.enabled?'':' [disabled 当前配置值]';return `<option value="${escapeHtml(p.id)}" ${p.id===selected?'selected':''}>${escapeHtml(p.name||p.id)} / ${escapeHtml(p.id)}${disabled}</option>`}));if(selected&&!state.providers.some(p=>p.id===selected))opts.push(`<option value="${escapeHtml(selected)}" selected>当前配置值：${escapeHtml(selected)}</option>`);return opts.join('')}
 function modelOptionValue(providerId,row){return providerId?row.id:`${row.provider_id}::${row.id}`}
 function decodeModelSelection(value,currentProvider){const text=String(value||'');if(!text)return{provider_id:currentProvider||'',model:''};const marker='::';if(text.includes(marker)){const [provider_id,...rest]=text.split(marker);return{provider_id,model:rest.join(marker)}}return{provider_id:currentProvider||'',model:text}}
 function modelOptions(providerId,selected,{visionFirst=false,auto=false,defaultModels=[],enabledOnly=false,selectedProvider=''}={}){const rows=visibleModelsForProvider(providerId,{visionFirst,enabledOnly});let opts=[];if(auto)opts.push(`<option value="" ${!selected?'selected':''}>自动路线${defaultModels.length?'：'+escapeHtml(defaultModels.join(' / ')):''}</option>`);else opts.push(`<option value="" ${!selected?'selected':''}>请选择模型</option>`);let matched=false;opts.push(...rows.map(r=>{const value=modelOptionValue(providerId,r);const label=providerId?r.id:`${r.provider_id} / ${r.id}`;const tag=(r.capabilities||{}).vision?' [vision]':'';const isSelected=providerId?r.id===selected:((selectedProvider&&r.provider_id===selectedProvider&&r.id===selected)||(!selectedProvider&&r.id===selected));if(isSelected)matched=true;return `<option value="${escapeHtml(value)}" ${isSelected?'selected':''}>${escapeHtml(label)}${tag}</option>`}));if(selected&&!matched)opts.push(`<option value="${escapeHtml(selected)}" selected>当前配置值：${escapeHtml(selected)}</option>`);return opts.join('')}
-function renderStaleHiddenBox(p){const stale=staleHiddenModels(p);const box=$('staleHiddenBox');if(!box)return;if(!stale.length){box.innerHTML='<strong>过期隐藏项</strong><p class="muted">当前没有“已不在通道模型列表里”的 hidden_models。</p>';return}box.innerHTML=`<strong>过期隐藏项（不在当前通道模型列表）</strong><p class="muted">这些多半是之前手动隐藏过、后来通道不再返回的模型。默认保留配置但不放进主表；确认无用后可清理。</p><div class="chips">${stale.map(m=>`<span class="chip">${escapeHtml(m)} <button data-stale-rm="${escapeHtml(m)}">清理</button></span>`).join('')}</div><div class="btns"><button id="clearStaleHidden" class="ghost">清理当前通道过期隐藏项</button></div>`;document.querySelectorAll('[data-stale-rm]').forEach(b=>b.onclick=()=>{p.hidden_models=(p.hidden_models||[]).filter(x=>x!==b.dataset.staleRm);p.stale_hidden_models=(p.stale_hidden_models||[]).filter(x=>x!==b.dataset.staleRm);renderModelTable()});$('clearStaleHidden').onclick=()=>{const count=cleanupStaleHidden(p);renderModelTable();toast(count?`已清理 ${count} 个当前通道过期 hidden_models`:'没有需要清理的过期隐藏项')}}
-function renderModelTable(){const p=current(); if(!p)return;const q=($('modelSearch')?.value||'').toLowerCase();const rows=providerModels(p).filter(r=>r.id.toLowerCase().includes(q));$('modelChips').innerHTML=(p.extra_models||[]).map(m=>`<span class="chip">${escapeHtml(m)} <button data-rm="${escapeHtml(m)}">×</button></span>`).join('');document.querySelectorAll('[data-rm]').forEach(b=>b.onclick=()=>{p.extra_models=(p.extra_models||[]).filter(x=>x!==b.dataset.rm);renderModelTable()});renderStaleHiddenBox(p);$('modelTable').innerHTML=`<thead><tr><th>显示</th><th>模型</th><th>来源</th><th>收藏</th><th>text</th><th>vision</th><th>tool</th><th>reason</th><th>long</th><th>cache</th></tr></thead><tbody>${rows.map(r=>{const c=r.capabilities||{};return `<tr><td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-field="visible" ${r.visible?'checked':''}></td><td class="mono">${escapeHtml(r.id)}</td><td><span class="tag ${r.visible?'':'off'}">${escapeHtml(r.source||'manual')}</span></td><td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-field="favorite" ${r.favorite?'checked':''}></td>${['text','vision','tool_use','reasoning','long_context','cache_sensitive'].map(k=>`<td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-cap="${k}" ${c[k]?'checked':''}></td>`).join('')}</tr>`}).join('')}</tbody>`;document.querySelectorAll('#modelTable input').forEach(x=>x.onchange=onModelToggle);renderTestSelectors();renderFallback();renderRuntime()}
+function staleRouteModels(p){const approved=(p.approved_route_models&&p.approved_route_models.length?p.approved_route_models:(p.fallback_models||[]));const remote=new Set((p.models||[]).filter(r=>r&&r.id).map(r=>String(r.id)));const extras=new Set((p.extra_models||[]).map(x=>String(x)));return [...new Set(approved.filter(id=>id&&!remote.has(String(id))&&!extras.has(String(id))))]}
+function renderStaleRouteBox(p){const box=$('staleRouteBox');if(!box)return;const stale=staleRouteModels(p);if(!stale.length){box.innerHTML='<strong>缺失旧 route</strong><p class="muted">当前没有“本地已批准但本次拉取未返回”的旧 route。</p>';return}const armed=staleCleanupProviders.has(p.id);box.innerHTML=`<strong>缺失旧 route（默认保留）</strong><p class="muted">这些模型在本地已批准 routes 里，但不在当前拉取到的模型列表里。默认不会删除；如果勾选“拉取后自动标记”，本页后续拉取会自动标记清理。避免上游 /models 抖动或 New API 临时关闭导致下游模型被清空。</p><div class="chips">${stale.slice(0,24).map(m=>`<span class="chip">${escapeHtml(m)}</span>`).join('')}${stale.length>24?`<span class="chip">+${stale.length-24}</span>`:''}</div><div class="btns"><button id="armStaleRouteCleanup" class="ghost">${armed?'已标记：保存时清理这些旧 route':'显式标记保存时清理这些旧 route'}</button></div>`;$('armStaleRouteCleanup').onclick=()=>{staleCleanupProviders.add(p.id);touchProvider(p.id);renderStaleRouteBox(p);toast(`已标记 ${p.id}：下次保存会清理 ${stale.length} 条缺失旧 route`)}}
+function renderStaleHiddenBox(p){const stale=staleHiddenModels(p);const box=$('staleHiddenBox');if(!box)return;if(!stale.length){box.innerHTML='<strong>未匹配隐藏规则（hidden_models）</strong><p class="muted">当前没有“暂时匹配不到模型行”的隐藏规则。</p>';return}box.innerHTML=`<strong>未匹配隐藏规则（hidden_models）</strong><p class="muted">这些只是当前通道 hidden_models 里的隐藏规则，暂时没有匹配到当前模型行；不等于远端不存在，也不等于 route 待删除。移除后如果模型仍在远端或 approved routes 里，会重新显示出来。</p><div class="chips">${stale.map(m=>`<span class="chip">${escapeHtml(m)} <button data-stale-rm="${escapeHtml(m)}">移除记录</button></span>`).join('')}</div><div class="btns"><button id="clearStaleHidden" class="ghost">移除当前通道未匹配隐藏规则</button></div>`;document.querySelectorAll('[data-stale-rm]').forEach(b=>b.onclick=()=>{p.hidden_models=(p.hidden_models||[]).filter(x=>x!==b.dataset.staleRm);p.stale_hidden_models=(p.stale_hidden_models||[]).filter(x=>x!==b.dataset.staleRm);renderModelTable()});$('clearStaleHidden').onclick=()=>{const count=cleanupStaleHidden(p);renderModelTable();toast(count?`已移除 ${count} 条当前通道未匹配隐藏规则`:'没有需要移除的未匹配隐藏规则')}}
+function renderModelTable(){const p=current(); if(!p)return;const q=($('modelSearch')?.value||'').toLowerCase();const rows=providerModels(p).filter(r=>r.id.toLowerCase().includes(q));const extras=p.extra_models||[];$('modelChips').innerHTML=`<strong>当前通道补充模型库（extra_models）</strong><p class="muted">这些模型是手动补充到当前 provider 的可用模型，会参与当前通道路由；不是待删除列表，也不是全局模型池。</p><div class="chips">${extras.length?extras.map(m=>`<span class="chip">${escapeHtml(m)}${editingExtraModels?` <button data-rm-extra="${escapeHtml(m)}">从补充库移除</button>`:''}</span>`).join(''):'<span class="muted">当前通道暂无手动补充模型。</span>'}</div><div class="btns"><button id="toggleExtraEdit" class="ghost">${editingExtraModels?'完成编辑':'编辑补充模型库'}</button></div><div id="staleRouteBox"></div>`;$('toggleExtraEdit').onclick=()=>{editingExtraModels=!editingExtraModels;renderModelTable()};document.querySelectorAll('[data-rm-extra]').forEach(b=>b.onclick=()=>{p.extra_models=extras.filter(x=>x!==b.dataset.rmExtra);toast(`已从当前通道补充模型库移除 ${b.dataset.rmExtra}`);renderModelTable()});renderStaleRouteBox(p);renderStaleHiddenBox(p);$('modelTable').innerHTML=`<thead><tr><th>显示</th><th>模型</th><th>来源</th><th>收藏</th><th>text</th><th>vision</th><th>tool</th><th>reason</th><th>long</th><th>cache</th></tr></thead><tbody>${rows.map(r=>{const c=r.capabilities||{};return `<tr><td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-field="visible" ${r.visible?'checked':''}></td><td class="mono">${escapeHtml(r.id)}</td><td><span class="tag ${r.visible?'':'off'}">${escapeHtml(r.source||'manual')}</span></td><td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-field="favorite" ${r.favorite?'checked':''}></td>${['text','vision','tool_use','reasoning','long_context','cache_sensitive'].map(k=>`<td><input type="checkbox" data-model="${escapeHtml(r.id)}" data-cap="${k}" ${c[k]?'checked':''}></td>`).join('')}</tr>`}).join('')}</tbody>`;document.querySelectorAll('#modelTable input').forEach(x=>x.onchange=onModelToggle);renderTestSelectors();renderFallback();renderRuntime()}
 function onModelToggle(e){const p=current();const model=e.target.dataset.model;let row=providerModels(p).find(r=>r.id===model)||{id:model,source:'hidden',visible:!(p.hidden_models||[]).includes(model),favorite:false,capabilities:defaultCaps(model)};row.policy_touched=true;if(e.target.dataset.field==='visible'){row.visible=e.target.checked;p.hidden_models=e.target.checked?(p.hidden_models||[]).filter(x=>x!==model):[...(p.hidden_models||[]).filter(x=>x!==model),model]}else if(e.target.dataset.field==='favorite'){row.favorite=e.target.checked}else if(e.target.dataset.cap){row.capabilities=row.capabilities||{};row.capabilities[e.target.dataset.cap]=e.target.checked}p.model_capabilities=p.model_capabilities||{};p.model_capabilities[model]=row.capabilities;p.models=(p.models||[]).filter(r=>r.id!==model).concat(row);renderTestSelectors();renderFallback();renderRuntime()}
 function renderTestSelectors(){const tp=$('testProvider');if(!tp)return;tp.innerHTML=providerEntries().map(({p,i})=>`<option value="${i}">${escapeHtml(p.name||p.id)}${p.enabled?'':' [disabled]'}</option>`).join('');tp.value=String(activeProvider);tp.onchange=()=>{activeProvider=Number(tp.value);renderAll()};const models=providerModels(current()||{});$('testModel').innerHTML=models.map(r=>`<option>${escapeHtml(r.id)}</option>`).join('')}
 function syncFallback(){state.rescue=state.rescue||{};state.rescue.fallback_model=$('rescueModel').value.trim();state.rescue.fallback_cli=$('rescueCli').value;state.rescue.hot_fallback_enabled=$('rescueHot').checked;state.vision_sidecar=state.vision_sidecar||{};state.vision_sidecar.enabled=$('visionEnabled').checked;state.vision_sidecar.provider_id=$('visionProvider').value.trim();state.vision_sidecar.model=$('visionModel').value.trim();state.vision_sidecar.candidates=[...document.querySelectorAll('[data-vision-candidate]')].map(row=>({provider_id:row.querySelector('[data-vc-provider]').value.trim(),model:row.querySelector('[data-vc-model]').value.trim()})).filter(x=>x.provider_id&&x.model)}
@@ -2799,13 +2902,13 @@ function renderRuntime(){state.runtime=state.runtime||{};state.opencode=state.op
 function renderRefs(){ $('refsGrid').innerHTML=(state.references||[]).map(r=>`<div class="card span6"><h3>${escapeHtml(r.title)}</h3><p>${escapeHtml(r.summary)}</p><p class="mono">${escapeHtml(r.path)}</p></div>`).join('') }
 function levelLabel(level){return level==='danger'?'高风险':(level==='warn'?'注意':'信息')}
 function renderReviewSummary(plan){const review=plan?.review_summary||{};const counts=review.counts||{};const risks=review.risks||[];const items=review.items||[];const riskHtml=risks.length?`<h4>风险提示</h4><div>${risks.map(r=>`<p><span class="tag ${r.level==='danger'?'off':''}">${escapeHtml(levelLabel(r.level))}</span> <strong>${escapeHtml(r.title)}</strong> ${escapeHtml(r.detail)}</p>`).join('')}</div>`:'<p><span class="tag">无高风险提示</span></p>';const itemHtml=items.length?items.map(item=>`<p><span class="tag ${item.level==='danger'?'off':''}">${escapeHtml(levelLabel(item.level))}</span> <strong>${escapeHtml(item.title)}</strong> ${escapeHtml(item.detail)}</p>`).join(''):'<p class="muted">没有检测到配置变化。</p>';$('reviewSummary').innerHTML=`<div class="chips"><span class="chip">变化 ${counts.items||0}</span><span class="chip">风险 ${counts.risks||0}</span><span class="chip">清理 hidden ${counts.hidden_removed||0}</span><span class="chip">凭据更新 ${counts.credential_updates||0}</span></div>${riskHtml}<h4>将要写入的变化</h4>${itemHtml}`}
-function draft(){syncProvider();syncFallback();syncRuntime();return JSON.parse(JSON.stringify({providers:state.providers,provider_default:state.provider_default,rescue:state.rescue,vision_sidecar:state.vision_sidecar,runtime:state.runtime,opencode:state.opencode}))}
+function draft(){syncProvider();syncFallback();syncRuntime();return JSON.parse(JSON.stringify({providers:state.providers,provider_default:state.provider_default,rescue:state.rescue,vision_sidecar:state.vision_sidecar,runtime:state.runtime,opencode:state.opencode,route_refresh_provider_ids:[...staleCleanupProviders]}))}
 function renderAll(){renderStatus();renderProviders();renderFallback();renderRuntime();renderRefs()}
 async function load(){const res=await fetch('/api/state');state=await res.json();state.providers=state.providers||[];renderNav();renderAll();}
 $('addProvider').onclick=()=>{state.providers.push({id:`provider-${state.providers.length+1}`,original_id:'',name:'新通道',enabled:true,role:'auto',priority:100,models_endpoint:'/models',protocols:['anthropic_messages','openai_chat_completions'],supported_clis:['claude','codex','opencode'],openai_base_url:'',anthropic_base_url:'',api_key:'',update_credentials:false,fallback_models:[],extra_models:[],hidden_models:[],models:[]});activeProvider=state.providers.length-1;renderAll()}
 $('duplicateProvider').onclick=()=>{const p=JSON.parse(JSON.stringify(current()));p.id=p.id+'-copy';p.original_id='';p.name=p.name+' Copy';p.api_key='';p.has_api_key=false;state.providers.push(p);activeProvider=state.providers.length-1;renderAll()}
 $('modelSearch').oninput=renderModelTable;$('addManualModels').onclick=()=>{const p=current();const vals=$('manualModels').value.split(/[\n,]/).map(x=>x.trim()).filter(Boolean);p.extra_models=[...new Set([...(p.extra_models||[]),...vals])];p.hidden_models=(p.hidden_models||[]).filter(x=>!vals.includes(x));$('manualModels').value='';renderModelTable();toast(`已添加 ${vals.length} 个模型`)};$('clearHidden').onclick=()=>{current().hidden_models=[];renderModelTable()};$('clearAllStaleHidden').onclick=cleanupAllStaleHidden
-$('fetchModels').onclick=async()=>{syncProvider();const data=await api('/api/provider/models',{provider:current(),force_refresh:true});if(data.models){const p=current();p.models=data.models.map(id=>({id,source:data.base_source||'remote',visible:!(p.hidden_models||[]).includes(id),favorite:false,capabilities:defaultCaps(id)}));renderModelTable();$('testResult').textContent=JSON.stringify(data,null,2);toast(`拉取到 ${data.models.length} 个模型；不会自动写入 fallback_models`)}else{$('testResult').textContent=JSON.stringify(data,null,2)}};
+$('fetchModels').onclick=async()=>{syncProvider();const data=await api('/api/provider/models',{provider:current(),force_refresh:true});if(data.ok&&Array.isArray(data.models)){const p=current();if(!p.approved_route_models||!p.approved_route_models.length){p.approved_route_models=(p.models||[]).filter(r=>r&&r.id&&r.source!=='derived_alias').map(r=>r.id)}p.models=data.models.map(id=>({id,source:data.base_source||'remote',visible:!(p.hidden_models||[]).includes(id),favorite:false,capabilities:defaultCaps(id)}));touchProvider(p.id);if($('autoStaleCleanupOnFetch')?.checked&&staleRouteModels(p).length){staleCleanupProviders.add(p.id)}renderModelTable();$('testResult').textContent=JSON.stringify(data,null,2);toast(staleCleanupProviders.has(p.id)?`拉取到 ${data.models.length} 个模型；已自动标记缺失旧 route 清理`:`拉取到 ${data.models.length} 个模型；不会自动写入 fallback_models；缺失旧 route 默认保留`)}else{$('testResult').textContent=JSON.stringify(data,null,2);toast(data.error||'模型拉取失败，请看测试结果')}};
 $('testList').onclick=async()=>{$('testResult').textContent=JSON.stringify(await api('/api/provider/test',{provider:current(),force_refresh:true}),null,2);setSection('test')}
 $('testModelBtn').onclick=async()=>{$('testResult').textContent='测试中...';const data=await api('/api/model/test',{provider:state.providers[Number($('testProvider').value)],model:$('testModel').value,protocol:$('testProtocol').value,prompt:$('testPrompt').value});$('testResult').textContent=JSON.stringify(data,null,2)}
 $('chatTestBtn').onclick=async()=>{$('testResult').textContent='测试中...';const data=await api('/api/chat/test',{provider:state.providers[Number($('testProvider').value)],model:$('testModel').value,protocol:$('testProtocol').value,prompt:$('testPrompt').value});$('testResult').textContent=JSON.stringify(data,null,2)}

--- a/mms_core.py
+++ b/mms_core.py
@@ -3505,7 +3505,7 @@ def _trigger_routes_export_after_usage_write():
     ).start()
 
 
-def _refresh_routes_export_for_hive(cfg=None, *, force=True, quiet=False, startup_safe=False):
+def _refresh_routes_export_for_hive(cfg=None, *, force=True, quiet=False, startup_safe=False, route_refresh_provider_ids=None):
     """Synchronously refresh the Hive-facing routes export from current config."""
     try:
         from mms_router import export_model_routes
@@ -3516,7 +3516,10 @@ def _refresh_routes_export_for_hive(cfg=None, *, force=True, quiet=False, startu
             if current_cfg is None:
                 return False
             current_cfg = apply_local_overrides(current_cfg)
-        export_model_routes(current_cfg, force=force, startup_safe=startup_safe)
+        kwargs = {"force": force, "startup_safe": startup_safe}
+        if route_refresh_provider_ids:
+            kwargs["route_refresh_provider_ids"] = route_refresh_provider_ids
+        export_model_routes(current_cfg, **kwargs)
         return True
     except Exception as exc:
         if not quiet:

--- a/mms_router.py
+++ b/mms_router.py
@@ -804,6 +804,98 @@ def _read_existing_lineup_routes():
     return routes if isinstance(routes, dict) else {}
 
 
+def _route_leaf_provider_id(route_leaf):
+    if not isinstance(route_leaf, dict):
+        return ""
+    return _clean_str(route_leaf.get("provider_id"))
+
+
+def _route_has_provider(route_info, provider_id):
+    if not isinstance(route_info, dict) or not provider_id:
+        return False
+    leaves = []
+    primary = route_info.get("primary")
+    if isinstance(primary, dict):
+        leaves.append(primary)
+    leaves.extend(item for item in (route_info.get("fallbacks") or []) if isinstance(item, dict))
+    return any(_route_leaf_provider_id(item) == provider_id for item in leaves)
+
+
+def _provider_preserved_route_leaf(provider_info):
+    return {
+        "provider_id": _clean_str(provider_info.get("provider_id")),
+        "anthropic_base_url": _clean_str(provider_info.get("anthropic_base_url")),
+        "openai_base_url": _clean_str(provider_info.get("openai_base_url")),
+        "api_key": str(provider_info.get("api_key") or ""),
+    }
+
+
+def _preserve_existing_provider_routes(routes, providers_info, *, route_refresh_provider_ids=None):
+    """Keep approved local routes when a provider /models response temporarily shrinks."""
+    try:
+        existing_payload = _read_json_file(MODEL_ROUTES_PATH)
+    except (OSError, json.JSONDecodeError):
+        return routes
+    existing_routes = existing_payload.get("routes") if isinstance(existing_payload.get("routes"), dict) else {}
+    if not existing_routes:
+        return routes
+
+    refresh_scope = {
+        _clean_str(item)
+        for item in (route_refresh_provider_ids or [])
+        if _clean_str(item)
+    }
+    provider_by_id = {
+        _clean_str(info.get("provider_id")): info
+        for info in providers_info
+        if _clean_str(info.get("provider_id"))
+    }
+    hidden_by_provider = {
+        provider_id: {
+            _clean_str(model)
+            for model in (info.get("hidden_models") or [])
+            if _clean_str(model)
+        }
+        for provider_id, info in provider_by_id.items()
+    }
+
+    merged = {
+        model: {
+            "primary": dict(info.get("primary") or {}),
+            "fallbacks": [dict(item) for item in (info.get("fallbacks") or []) if isinstance(item, dict)],
+        }
+        for model, info in routes.items()
+        if isinstance(info, dict)
+    }
+    for model_name, route_info in existing_routes.items():
+        model = _clean_str(model_name)
+        if not model or not isinstance(route_info, dict):
+            continue
+        leaves = []
+        primary = route_info.get("primary")
+        if isinstance(primary, dict):
+            leaves.append(primary)
+        leaves.extend(item for item in (route_info.get("fallbacks") or []) if isinstance(item, dict))
+        for leaf in leaves:
+            provider_id = _route_leaf_provider_id(leaf)
+            provider_info = provider_by_id.get(provider_id)
+            if not provider_info:
+                continue
+            if provider_id in refresh_scope:
+                continue
+            if model in hidden_by_provider.get(provider_id, set()):
+                continue
+            current = merged.setdefault(model, {"primary": {}, "fallbacks": []})
+            if _route_has_provider(current, provider_id):
+                continue
+            preserved_leaf = _provider_preserved_route_leaf(provider_info)
+            if not current.get("primary"):
+                current["primary"] = preserved_leaf
+            elif len(current.setdefault("fallbacks", [])) < 3:
+                current["fallbacks"].append(preserved_leaf)
+    return {model: info for model, info in merged.items() if info.get("primary")}
+
+
 def _canonical_lineup_payload(routes, *, generated_at, source_routes_hash):
     existing_routes = _read_existing_lineup_routes()
     ordered_routes = {}
@@ -1128,7 +1220,7 @@ def _persist_routes_export(routes):
     return _read_json_file(MODEL_ROUTES_PATH)
 
 
-def export_model_routes(cfg=None, force=False, startup_safe=False):
+def export_model_routes(cfg=None, force=False, startup_safe=False, route_refresh_provider_ids=None):
     """导出 Hive 可直接消费的最小路由契约，并做 snapshot 去重。"""
     from mms_core import (
         load_config, apply_local_overrides, resolve_provider_context,
@@ -1223,6 +1315,7 @@ def export_model_routes(cfg=None, force=False, startup_safe=False):
             "models": models,
             "supported_clis": supported_clis,
             "is_default": is_default,
+            "hidden_models": provider_def.get("hidden_models") or [],
         })
         seen_ids.add(pid)
 
@@ -1306,6 +1399,11 @@ def export_model_routes(cfg=None, force=False, startup_safe=False):
             "fallbacks": fallbacks,
         }
 
+    routes = _preserve_existing_provider_routes(
+        routes,
+        providers_info,
+        route_refresh_provider_ids=route_refresh_provider_ids,
+    )
     persisted = _persist_routes_export(routes)
     return persisted.get("routes", {})
 

--- a/mms_tui.py
+++ b/mms_tui.py
@@ -1390,7 +1390,8 @@ def select_submodel_tui(
                         if focus == "model":
                             _safe_addstr(stdscr, y, ll + 1, " " * max(1, left_w - 4), name_attr)
                         _safe_addstr(stdscr, y, ll - 1, "|", marker_attr)
-                        _safe_addstr(stdscr, y, ll + 1, model_name, name_attr, max_w=left_w - 4)
+                        visible_model = _marquee_text(model_name, left_w - 4, marquee_tick)
+                        _safe_addstr(stdscr, y, ll + 1, visible_model, name_attr, max_w=left_w - 4)
                     else:
                         _safe_addstr(stdscr, y, ll + 1, model_name, curses.color_pair(2), max_w=left_w - 4)
 

--- a/scripts/mms_health_watchdog.py
+++ b/scripts/mms_health_watchdog.py
@@ -337,6 +337,14 @@ def model_presence_alias_candidates(model_id: str) -> set[str]:
     return candidates
 
 
+def is_claude_model_presence_exempt(model_id: str) -> bool:
+    normalized = str(model_id or "").strip().lower()
+    if not normalized:
+        return False
+    tail = normalized.rsplit("/", 1)[-1]
+    return tail.startswith(("claude-", "anthropic.claude-", "anthropic-claude-"))
+
+
 def route_source_checks(config_dir: Path, routes_payload: dict[str, Any], policy_payload: dict[str, Any]) -> list[CheckResult]:
     results: list[CheckResult] = []
     routes_text = json.dumps(routes_payload, ensure_ascii=False)
@@ -395,6 +403,7 @@ def model_presence_checks(
     allowed = model_policy_allowed(policy_payload)
     missing: list[str] = []
     checked = 0
+    skipped_claude = 0
     for model, role, route in route_entries(routes_payload):
         if allowed and model not in allowed:
             continue
@@ -410,13 +419,19 @@ def model_presence_checks(
         # primary availability check plus endpoint liveness check.
         if role != "primary":
             continue
-        checked += 1
         wire_model = str(route.get("model_id") or model).strip()
+        if is_claude_model_presence_exempt(model) or is_claude_model_presence_exempt(wire_model):
+            skipped_claude += 1
+            continue
+        checked += 1
         if not (model_presence_alias_candidates(wire_model) & models):
             missing.append(f"{model}@{provider_id}/{role} as {wire_model}")
     if missing:
         return [CheckResult("model_presence", "policy_models", "warning", "fail", "missing: " + ", ".join(missing[:12]))]
-    return [CheckResult("model_presence", "policy_models", "info", "ok", f"checked {checked} route entries with model lists")]
+    detail = f"checked {checked} route entries with model lists"
+    if skipped_claude:
+        detail += f"; skipped {skipped_claude} Claude route entries"
+    return [CheckResult("model_presence", "policy_models", "info", "ok", detail)]
 
 
 def build_report(config_dir: Path, timeout: int) -> dict[str, Any]:

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -79,6 +79,42 @@ def test_config_web_snapshot_separates_stale_hidden_models():
     assert current["visible"] is False
 
 
+def test_config_web_snapshot_exposes_approved_route_models(tmp_path):
+    routes_path = tmp_path / "model-routes.json"
+    routes_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "routes": {
+                    "retired-route-model": {
+                        "primary": {"provider_id": "demo-provider"},
+                        "fallbacks": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = {
+        "providers": [
+            {
+                "id": "demo-provider",
+                "name": "Demo",
+                "models_endpoint": "/models",
+                "fallback_models": [],
+                "extra_models": [],
+            }
+        ]
+    }
+
+    snapshot = mms_config_web.build_config_snapshot(cfg, config_path=str(tmp_path / "config.toml"))
+    provider = snapshot["providers"][0]
+
+    assert provider["approved_route_models"] == ["retired-route-model"]
+    assert provider["models"][0]["id"] == "retired-route-model"
+    assert provider["models"][0]["source"] == "approved_route"
+
+
 def test_config_web_print_summary_exits_without_server(capsys):
     rc = mms_config_web.run_config_web(
         {"providers": []},
@@ -131,6 +167,8 @@ def test_config_web_fetch_models_does_not_persist_to_fallback_models():
     html = mms_config_web._HTML_PAGE
 
     assert "不会自动写入 fallback_models" in html
+    assert "缺失旧 route（默认保留）" in html
+    assert "移除全部通道未匹配隐藏规则" in html
     assert "p.fallback_models=[...new Set(data.models)]" not in html
 
 
@@ -599,6 +637,40 @@ def test_config_web_save_uses_audited_writers(monkeypatch, tmp_path):
     assert any(path.name == "credentials.sh.bak" for path in bak_paths)
     assert any(path.name == "model-policy.json.bak" for path in bak_paths)
     assert "sk-super-secret-value" not in encoded
+
+
+def test_config_web_save_passes_explicit_route_cleanup_scope(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    credentials_path = tmp_path / "credentials.sh"
+    policy_path = tmp_path / "model-policy.json"
+    config_path.write_text('[[providers]]\nid = "demo"\nname = "Old"\n', encoding="utf-8")
+    credentials_path.write_text("", encoding="utf-8")
+    policy_path.write_text('{"version":1,"models":{},"projects":{}}\n', encoding="utf-8")
+
+    calls = []
+    monkeypatch.setattr(mms_core, "_config_write_target_path", lambda: str(config_path))
+    monkeypatch.setattr(mms_core, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(mms_core, "CREDENTIALS_PATH", str(credentials_path))
+    monkeypatch.setattr(mms_core, "_trigger_routes_export_after_credentials_write", lambda: None)
+    monkeypatch.setattr(
+        mms_core,
+        "_refresh_routes_export_for_hive",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+    )
+
+    payload = _draft_payload()
+    payload["confirm_save"] = True
+    payload["confirm_phrase"] = "保存配置"
+    payload["route_refresh_provider_ids"] = ["demo"]
+
+    result = mms_config_web.apply_config_plan(
+        {"providers": [{"id": "demo", "name": "Old"}], "provider": {"default": "demo"}},
+        payload,
+        config_path=str(config_path),
+    )
+
+    assert result["ok"] is True
+    assert calls[-1][1]["route_refresh_provider_ids"] == ["demo"]
 
 
 def test_config_web_provider_model_fetch_can_be_stubbed(monkeypatch):

--- a/tests/test_health_watchdog.py
+++ b/tests/test_health_watchdog.py
@@ -1,0 +1,45 @@
+from scripts import mms_health_watchdog as watchdog
+
+
+def test_model_presence_skips_claude_routes_from_models_endpoint_check():
+    routes_payload = {
+        "routes": {
+            "claude-opus-4-6": {
+                "primary": {
+                    "provider_id": "tokyo",
+                    "anthropic_base_url": "https://tokyo.example/v1",
+                    "model_id": "claude-opus-4-6",
+                },
+                "fallbacks": [],
+            }
+        }
+    }
+    providers = {"tokyo": {"models_endpoint": "/models"}}
+    model_sets = {("tokyo", "https://tokyo.example/v1/models"): {"not-returned-by-claude-relay"}}
+
+    results = watchdog.model_presence_checks(routes_payload, providers, model_sets, {})
+
+    assert results[0].status == "ok"
+    assert "skipped 1 Claude route entries" in results[0].detail
+
+
+def test_model_presence_still_warns_for_non_claude_missing_models():
+    routes_payload = {
+        "routes": {
+            "qwen3.6-plus": {
+                "primary": {
+                    "provider_id": "qwen",
+                    "openai_base_url": "https://qwen.example/v1",
+                    "model_id": "qwen3.6-plus",
+                },
+                "fallbacks": [],
+            }
+        }
+    }
+    providers = {"qwen": {"models_endpoint": "/models"}}
+    model_sets = {("qwen", "https://qwen.example/v1/models"): {"qwen3.5-plus"}}
+
+    results = watchdog.model_presence_checks(routes_payload, providers, model_sets, {})
+
+    assert results[0].status == "fail"
+    assert "qwen3.6-plus@qwen/primary" in results[0].detail

--- a/tests/test_model_routes_export.py
+++ b/tests/test_model_routes_export.py
@@ -184,6 +184,120 @@ def test_export_model_routes_writes_minimal_hive_contract_and_snapshot(monkeypat
     assert stat.S_IMODE(latest_path.stat().st_mode) == 0o600
 
 
+def test_export_model_routes_preserves_existing_provider_routes_on_probe_shrink(monkeypatch, tmp_path):
+    import mms_router
+
+    _patch_export_dependencies(
+        monkeypatch,
+        contexts={
+            "demo-provider": {
+                "id": "demo-provider",
+                "provider_name": "Demo Provider",
+                "anthropic_base_url": "",
+                "openai_base_url": "https://demo.example.com/v1",
+                "api_key": "sk-demo-new",
+                "models": ["new-remote-model"],
+            }
+        },
+    )
+    _patch_export_paths(monkeypatch, tmp_path)
+    (tmp_path / "model-routes.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "routes": {
+                    "old-approved-model": {
+                        "primary": {
+                            "provider_id": "demo-provider",
+                            "openai_base_url": "https://old.example.com/v1",
+                            "anthropic_base_url": "",
+                            "api_key": "sk-old",
+                            "model_id": "old-approved-model",
+                        },
+                        "fallbacks": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = {
+        "provider": {"default": "demo-provider"},
+        "providers": [
+            {
+                "id": "demo-provider",
+                "role": "auto",
+                "priority": 75,
+                "enabled": True,
+                "protocols": ["openai_chat_completions"],
+                "supported_clis": ["codex"],
+                "hidden_models": [],
+            }
+        ],
+    }
+
+    routes = mms_router.export_model_routes(cfg, force=True)
+
+    assert routes["new-remote-model"]["primary"]["provider_id"] == "demo-provider"
+    assert routes["old-approved-model"]["primary"]["provider_id"] == "demo-provider"
+    assert routes["old-approved-model"]["primary"]["openai_base_url"] == "https://demo.example.com/v1"
+    assert routes["old-approved-model"]["primary"]["api_key"] == "sk-demo-new"
+
+
+def test_export_model_routes_can_explicitly_cleanup_preserved_provider_routes(monkeypatch, tmp_path):
+    import mms_router
+
+    _patch_export_dependencies(
+        monkeypatch,
+        contexts={
+            "demo-provider": {
+                "id": "demo-provider",
+                "provider_name": "Demo Provider",
+                "anthropic_base_url": "",
+                "openai_base_url": "https://demo.example.com/v1",
+                "api_key": "sk-demo",
+                "models": ["new-remote-model"],
+            }
+        },
+    )
+    _patch_export_paths(monkeypatch, tmp_path)
+    (tmp_path / "model-routes.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "routes": {
+                    "old-approved-model": {
+                        "primary": {"provider_id": "demo-provider", "openai_base_url": "https://demo.example.com/v1"},
+                        "fallbacks": [],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = {
+        "providers": [
+            {
+                "id": "demo-provider",
+                "role": "auto",
+                "priority": 75,
+                "enabled": True,
+                "protocols": ["openai_chat_completions"],
+                "supported_clis": ["codex"],
+            }
+        ],
+    }
+
+    routes = mms_router.export_model_routes(
+        cfg,
+        force=True,
+        route_refresh_provider_ids=["demo-provider"],
+    )
+
+    assert "new-remote-model" in routes
+    assert "old-approved-model" not in routes
+
+
 def test_export_model_routes_prefers_verified_latest_approved_bundle(monkeypatch, tmp_path):
     monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
     import mms_router

--- a/tests/test_tui_marquee.py
+++ b/tests/test_tui_marquee.py
@@ -1,0 +1,19 @@
+from mms_tui import _display_width, _marquee_text
+
+
+def test_marquee_text_scrolls_long_model_names():
+    text = "anthropic/claude-opus-4.6-thinking"
+    first = _marquee_text(text, 12, 0)
+    later = _marquee_text(text, 12, 8)
+
+    assert first == "anthropic/cl"
+    assert later != first
+    assert _display_width(first) <= 12
+    assert _display_width(later) <= 12
+
+
+def test_marquee_text_keeps_short_model_names_static():
+    text = "mimo-v2.5"
+
+    assert _marquee_text(text, 20, 0) == text
+    assert _marquee_text(text, 20, 99) == text


### PR DESCRIPTION
## What Changed

- Backports the MMF/WebUI route-stability fix to the no-DB stable branch without pulling registry-v2 code into `release/stable-v3.3-no-db`.
- Stable legacy `model-routes.json` export now preserves previously approved provider routes when a refreshed `/models` response temporarily omits a model.
- WebUI now distinguishes:
  - `extra_models` as current-provider manual additions
  - unmatched `hidden_models` rules
  - missing approved routes that are kept by default
- WebUI can send an explicit stale-route cleanup scope when the user marks missing routes for cleanup.
- Watchdog skips Claude-family model-presence failures from `/models` lists, while still checking endpoint liveness.
- TUI scrolls the selected long model name in the left model list.

## Why / Root Cause

Stable legacy export rebuilt routes from current probe output. If upstream `/models` stopped listing a model, or a New API channel temporarily hid it, saving from WebUI could shrink downstream `model-routes.json` even though the local route had previously been approved.

The main branch fix uses registry-v2 latest-approved guardrails; this stable branch is intentionally no-DB, so this PR adds a stable-compatible preservation layer in `mms_router` instead of cherry-picking registry-v2 internals.

## Impact

- Safer stable WebUI saves: provider refresh can add routes but does not silently delete old approved routes.
- Routes still disappear when explicitly intended: provider removed/disabled, model hidden, or WebUI stale cleanup scope is sent.
- No real config writes were performed by this backport.
- Compatibility docs and Claude cache/watchdog runbook notes are updated.

## Validation

- `PYTHONPATH=. rtk pytest tests/test_config_web.py tests/test_model_routes_export.py tests/test_health_watchdog.py tests/test_tui_marquee.py tests/test_tui_recency_sort.py -q` -> `62 passed`
- `rtk python -m py_compile mms_config_web.py mms_core.py mms_router.py mms_tui.py scripts/mms_health_watchdog.py` -> pass
- `rtk git diff --check` -> pass

## Notes

- Local regression report: `.ai/regression-reports/2026-05-29-stable-webui-route-preservation.md`
- Issue tracking note: `/Users/xin/issue-tracking/multi-model-switch/2026-05-29-stable-webui-route-preservation.md`
