### PR TITLE
ci: add Digger PR validation

### DIFF
--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   digger:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    env:
+      DIGGER_REF: 9c22178c961ebe25914b6580b9e7a1000af046f9
     permissions:
       contents: read
       pull-requests: write
@@ -49,7 +52,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "$DIGGER_DEPLOY_KEY"
 
-          npm install --global "git+ssh://git@github.com/CtriXin/digger.git#codex/baseline-aware-validation"
+          npm install --global "git+ssh://git@github.com/CtriXin/digger.git#${DIGGER_REF}"
 
       - name: Run digger
         env:

--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +63,7 @@ jobs:
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
               --baseline-aware \
+              --post-comment \
               --fail-on-validation \
               --llm mms \
               --mms-reviewer "$DIGGER_MMS_REVIEWER"
@@ -70,6 +72,7 @@ jobs:
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
               --baseline-aware \
+              --post-comment \
               --fail-on-validation
           fi
 

--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -57,6 +57,7 @@ jobs:
           DIGGER_HEAD: ${{ github.event.pull_request.head.sha }}
           DIGGER_MMS_COMMAND: ${{ secrets.DIGGER_MMS_COMMAND }}
           DIGGER_MMS_REVIEWER: minimax-m2.7
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           if [ -n "$DIGGER_MMS_COMMAND" ]; then
             digger ci github \

--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -1,11 +1,11 @@
-name: Review Pilot
+name: Digger
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
-  review-pilot:
+  digger:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,12 +32,12 @@ jobs:
       - name: Install Python test tools
         run: python3 -m pip install pytest httpx rich
 
-      - name: Install review-pilot
+      - name: Install digger
         env:
-          REVIEW_PILOT_DEPLOY_KEY: ${{ secrets.REVIEW_PILOT_DEPLOY_KEY }}
+          DIGGER_DEPLOY_KEY: ${{ secrets.DIGGER_DEPLOY_KEY }}
         run: |
-          if [ -z "$REVIEW_PILOT_DEPLOY_KEY" ]; then
-            echo "Missing REVIEW_PILOT_DEPLOY_KEY secret."
+          if [ -z "$DIGGER_DEPLOY_KEY" ]; then
+            echo "Missing DIGGER_DEPLOY_KEY secret."
             exit 1
           fi
 
@@ -46,27 +46,27 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
           eval "$(ssh-agent -s)"
-          ssh-add - <<< "$REVIEW_PILOT_DEPLOY_KEY"
+          ssh-add - <<< "$DIGGER_DEPLOY_KEY"
 
-          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#codex/baseline-aware-validation"
+          npm install --global "git+ssh://git@github.com/CtriXin/digger.git#codex/baseline-aware-validation"
 
-      - name: Run review-pilot
+      - name: Run digger
         env:
-          REVIEW_PILOT_BASE: ${{ github.event.pull_request.base.sha }}
-          REVIEW_PILOT_HEAD: ${{ github.event.pull_request.head.sha }}
-          REVIEW_PILOT_MMS_COMMAND: ${{ secrets.REVIEW_PILOT_MMS_COMMAND }}
-          REVIEW_PILOT_MMS_REVIEWER: minimax-m2.7
+          DIGGER_BASE: ${{ github.event.pull_request.base.sha }}
+          DIGGER_HEAD: ${{ github.event.pull_request.head.sha }}
+          DIGGER_MMS_COMMAND: ${{ secrets.DIGGER_MMS_COMMAND }}
+          DIGGER_MMS_REVIEWER: minimax-m2.7
         run: |
-          if [ -n "$REVIEW_PILOT_MMS_COMMAND" ]; then
-            review-pilot ci github \
+          if [ -n "$DIGGER_MMS_COMMAND" ]; then
+            digger ci github \
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
               --baseline-aware \
               --fail-on-validation \
               --llm mms \
-              --mms-reviewer "$REVIEW_PILOT_MMS_REVIEWER"
+              --mms-reviewer "$DIGGER_MMS_REVIEWER"
           else
-            review-pilot ci github \
+            digger ci github \
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
               --baseline-aware \
@@ -77,5 +77,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: review-pilot
-          path: .review-pilot/runs
+          name: digger
+          path: .digger/runs

--- a/.github/workflows/review-pilot.yml
+++ b/.github/workflows/review-pilot.yml
@@ -48,7 +48,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "$REVIEW_PILOT_DEPLOY_KEY"
 
-          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#cf5040fcd65e985b96b650aa2eb43028064f1639"
+          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#90d3c75c68ea9aef892114d379c4e6cf15ada1d6"
 
       - name: Run review-pilot
         env:
@@ -61,6 +61,7 @@ jobs:
             review-pilot ci github \
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
+              --baseline-aware \
               --fail-on-validation \
               --llm mms \
               --mms-reviewer "$REVIEW_PILOT_MMS_REVIEWER"
@@ -68,6 +69,7 @@ jobs:
             review-pilot ci github \
               --checkout "$GITHUB_WORKSPACE" \
               --dry-run \
+              --baseline-aware \
               --fail-on-validation
           fi
 

--- a/.github/workflows/review-pilot.yml
+++ b/.github/workflows/review-pilot.yml
@@ -1,0 +1,71 @@
+name: Review Pilot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review-pilot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable package managers
+        run: corepack enable
+
+      - name: Install review-pilot
+        env:
+          REVIEW_PILOT_DEPLOY_KEY: ${{ secrets.REVIEW_PILOT_DEPLOY_KEY }}
+        run: |
+          if [ -z "$REVIEW_PILOT_DEPLOY_KEY" ]; then
+            echo "Missing REVIEW_PILOT_DEPLOY_KEY secret."
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "$REVIEW_PILOT_DEPLOY_KEY"
+
+          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#cf5040fcd65e985b96b650aa2eb43028064f1639"
+
+      - name: Run review-pilot
+        env:
+          REVIEW_PILOT_BASE: ${{ github.event.pull_request.base.sha }}
+          REVIEW_PILOT_HEAD: ${{ github.event.pull_request.head.sha }}
+          REVIEW_PILOT_MMS_COMMAND: ${{ secrets.REVIEW_PILOT_MMS_COMMAND }}
+          REVIEW_PILOT_MMS_REVIEWER: minimax-m2.7
+        run: |
+          if [ -n "$REVIEW_PILOT_MMS_COMMAND" ]; then
+            review-pilot ci github \
+              --checkout "$GITHUB_WORKSPACE" \
+              --dry-run \
+              --fail-on-validation \
+              --llm mms \
+              --mms-reviewer "$REVIEW_PILOT_MMS_REVIEWER"
+          else
+            review-pilot ci github \
+              --checkout "$GITHUB_WORKSPACE" \
+              --dry-run \
+              --fail-on-validation
+          fi
+
+      - name: Upload review packet
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: review-pilot
+          path: .review-pilot/runs

--- a/.github/workflows/review-pilot.yml
+++ b/.github/workflows/review-pilot.yml
@@ -19,10 +19,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Enable package managers
         run: corepack enable
+
+      - name: Install Python test tools
+        run: python3 -m pip install pytest
 
       - name: Install review-pilot
         env:

--- a/.github/workflows/review-pilot.yml
+++ b/.github/workflows/review-pilot.yml
@@ -30,7 +30,7 @@ jobs:
         run: corepack enable
 
       - name: Install Python test tools
-        run: python3 -m pip install pytest
+        run: python3 -m pip install pytest httpx rich
 
       - name: Install review-pilot
         env:

--- a/.github/workflows/review-pilot.yml
+++ b/.github/workflows/review-pilot.yml
@@ -48,7 +48,7 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add - <<< "$REVIEW_PILOT_DEPLOY_KEY"
 
-          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#90d3c75c68ea9aef892114d379c4e6cf15ada1d6"
+          npm install --global "git+ssh://git@github.com/CtriXin/review-pilot.git#codex/baseline-aware-validation"
 
       - name: Run review-pilot
         env:

--- a/docs/DIGGER_PR_VALIDATION.md
+++ b/docs/DIGGER_PR_VALIDATION.md
@@ -1,0 +1,64 @@
+# Digger PR Validation
+
+Digger is an advisory CI gate for MMS pull requests. It builds a baseline-aware
+review packet and, when validation fails, posts a PR comment with the result. It
+is not a merge bot and must not be treated as committee approval.
+
+## Security Boundary
+
+- The workflow runs on `pull_request`, not `pull_request_target`, so it does not
+  execute with the target branch's elevated context while checking out untrusted
+  PR code.
+- The job is limited to same-repository PRs with
+  `github.event.pull_request.head.repo.full_name == github.repository`. Fork PRs
+  are intentionally skipped until Digger can run from a public, no-secret install
+  path.
+- The job requests only the permissions it currently needs:
+  - `contents: read` to checkout and inspect the repository.
+  - `pull-requests: write` and `issues: write` to post PR feedback. GitHub PR
+    conversation comments are issue comments, so `issues: write` is required for
+    that path.
+- The Digger deploy key is used only during the install step to fetch the private
+  `CtriXin/digger` package. It is not exported into the later `Run digger` step.
+- `GITHUB_TOKEN` is passed only to `digger ci github` so Digger can discover the
+  PR context and post the advisory comment.
+- `--dry-run` is required. The workflow must not merge, push, apply patches, or
+  mutate repository state beyond posting comments and uploading artifacts.
+- `DIGGER_MMS_COMMAND` is optional and secret-backed. When absent, Digger runs in
+  non-LLM validation mode. When present, it is treated as trusted maintainer CI
+  configuration and must not be sourced from PR content.
+
+## Pinning Policy
+
+- GitHub Actions are pinned to major versions for maintenance compatibility:
+  - `actions/checkout@v4`
+  - `actions/setup-node@v4`
+  - `actions/setup-python@v5`
+  - `actions/upload-artifact@v4`
+- Runtime versions are explicit:
+  - Node `24`
+  - Python `3.12`
+- The Digger package is pinned to a specific commit in the workflow with
+  `DIGGER_REF`. Do not switch this back to a floating branch or tag in CI.
+- Python test tools are currently installed by package name (`pytest`, `httpx`,
+  `rich`) without version pins because they are runner support dependencies, not
+  MMS runtime dependencies. If Digger starts depending on exact behavior from
+  those tools, pin them or move them into a checked-in constraints file.
+- `ssh-keyscan github.com` is used only to establish GitHub as a known SSH host
+  for the private install. If this workflow becomes release-blocking for outside
+  contributors, replace it with a maintained pinned host-key setup or a public
+  package install path.
+
+## Branch Coverage
+
+- The workflow is intentionally declared without `branches` filters. Any branch
+  that contains this workflow can run it for PRs targeting that branch.
+- Today this PR targets `main`, so the immediate coverage is `head -> main` PRs
+  after the workflow lands on `main`.
+- To cover `dev` PRs, the workflow must also exist on `dev` because GitHub uses
+  the base branch's workflow definition for `pull_request` runs.
+- To cover `release/*` PRs, cherry-pick or merge the workflow into the relevant
+  release branch first.
+- Fork PRs are out of scope for now and are skipped by the same-repository guard.
+- Digger results are advisory. A passing Digger run does not replace committee
+  review, human merge approval, or the project-specific release checklist.


### PR DESCRIPTION
Adds Digger GitHub Actions validation for pull requests.\n\n- Installs Digger from the private CtriXin/digger repo through a read-only deploy key.\n- Runs Digger in GitHub CI checkout mode with baseline-aware validation.\n- Fails only when head introduces new validation failures.\n- Uploads .digger/runs as an artifact for review packets.\n\nAgent-Model: gpt-5\nAgent-Family: openai\nAgent-Session: 019eb5d0-a335-7d61-b310-cc39ee5271c4\nAgent-Step: 0.8.1