### PR TITLE
fix: harden preview route state

### DIFF
--- a/mms_config_web.py
+++ b/mms_config_web.py
@@ -163,6 +163,13 @@ def _redact_inline_secrets(value: Any) -> str:
     return text
 
 
+def _is_redacted_secret_token(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return text in {"<redacted>", "[redacted]", "***", "****"} or "***" in text or "****" in text
+
+
 def _is_secret_like_key(key_lower: str) -> bool:
     if key_lower in _SAFE_TOKEN_COUNT_KEYS or key_lower.endswith("_tokens"):
         return False
@@ -509,13 +516,22 @@ def _resolve_preview_provider_secret(
         return provider
     config_root = _config_root_for_snapshot(config_path)
     provider_id = _safe_text(provider.get("id") or provider.get("provider_id"))
+    secret_refs = _preview_secret_refs_by_provider(config_root)
+    secret_values = _preview_secret_values_by_ref(config_root)
     secret_ref = _safe_text(provider.get("secret_ref"))
-    if provider_id and not secret_ref:
-        secret_ref = _preview_secret_refs_by_provider(config_root).get(provider_id, "")
-        if secret_ref:
-            provider["secret_ref"] = secret_ref
+    replacement_ref = secret_refs.get(provider_id, "") if provider_id else ""
+    if provider_id and replacement_ref and (
+        not secret_ref or _is_redacted_secret_token(secret_ref) or not _safe_text(secret_values.get(secret_ref))
+    ):
+        secret_ref = replacement_ref
+    elif _is_redacted_secret_token(secret_ref):
+        secret_ref = ""
+    if secret_ref:
+        provider["secret_ref"] = secret_ref
+    else:
+        provider.pop("secret_ref", None)
     if secret_ref and not _safe_text(provider.get("api_key") or provider.get("openai_api_key") or provider.get("anthropic_api_key")):
-        value = _preview_secret_values_by_ref(config_root).get(secret_ref, "")
+        value = secret_values.get(secret_ref, "")
         if value:
             provider["api_key"] = value
     return provider
@@ -533,6 +549,7 @@ def _attach_preview_secret_refs(
     refs = _preview_secret_refs_by_provider(_config_root_for_snapshot(config_path))
     if not refs:
         return cfg
+    values = _preview_secret_values_by_ref(_config_root_for_snapshot(config_path))
     providers = cfg.get("providers") if isinstance(cfg.get("providers"), list) else []
     changed = False
     next_providers = []
@@ -542,8 +559,15 @@ def _attach_preview_secret_refs(
             continue
         row = dict(provider)
         provider_id = _safe_text(row.get("id") or row.get("provider_id"))
-        if provider_id and not _safe_text(row.get("secret_ref")) and refs.get(provider_id):
-            row["secret_ref"] = refs[provider_id]
+        secret_ref = _safe_text(row.get("secret_ref"))
+        replacement_ref = refs.get(provider_id, "") if provider_id else ""
+        if provider_id and replacement_ref and (
+            not secret_ref or _is_redacted_secret_token(secret_ref) or not _safe_text(values.get(secret_ref))
+        ):
+            row["secret_ref"] = replacement_ref
+            changed = True
+        elif _is_redacted_secret_token(secret_ref):
+            row.pop("secret_ref", None)
             changed = True
         next_providers.append(row)
     if changed:
@@ -593,7 +617,15 @@ def _preview_bundle_config_from_verified_files(verified_files: dict[str, Any], *
         cached_url = _preview_cached_provider_url(provider_id)
         openai_base_url = _safe_text(route_info.get("openai_base_url"))
         anthropic_base_url = _safe_text(route_info.get("anthropic_base_url"))
-        secret_ref = _safe_text(route_info.get("secret_ref") or secret_refs.get(provider_id))
+        route_secret_ref = _safe_text(route_info.get("secret_ref"))
+        backend_secret_ref = _safe_text(secret_refs.get(provider_id))
+        secret_ref = route_secret_ref or backend_secret_ref
+        if backend_secret_ref and (
+            not secret_ref or _is_redacted_secret_token(secret_ref) or not _safe_text(secret_values.get(secret_ref))
+        ):
+            secret_ref = backend_secret_ref
+        elif _is_redacted_secret_token(secret_ref):
+            secret_ref = ""
         protocols = _normalize_model_list(profile.get("protocols"))
         if cached_url:
             if not openai_base_url and "openai_chat_completions" in protocols:

--- a/mms_registry_cli.py
+++ b/mms_registry_cli.py
@@ -526,14 +526,23 @@ def _model_source_readiness(
         status = "needs_init"
         headline = "Preview root needs registry DB initialization."
         next_action = {"label": "Initialize preview root", "command": "./mmf preview init --json"}
-    elif route_count <= 0:
-        status = "needs_import"
-        headline = "Preview DB has no route candidates yet."
-        next_action = {"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"}
+    elif bundle.get("verified") and bundle.get("runtime_ready") is True:
+        status = "ready"
+        watchdog_root = shlex.quote(str(root))
+        headline = "Preview root is ready: DB candidates, latest-approved bundle, and runtime routes verify."
+        next_action = {
+            "label": "Optional: run read-only watchdog check",
+            "command": f"scripts/mms_health_watchdog.py --config-dir {watchdog_root} --require-bundle --dry-run --print-json",
+        }
     elif not bundle.get("verified"):
-        status = "needs_publish"
-        headline = "Latest-approved bundle is missing or failed manifest verification."
-        next_action = {"label": "Publish and verify preview bundle", "command": "./mmf preview publish --json && ./mmf preview verify --json"}
+        if route_count <= 0:
+            status = "needs_import"
+            headline = "Preview DB has no route candidates yet."
+            next_action = {"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"}
+        else:
+            status = "needs_publish"
+            headline = "Latest-approved bundle is missing or failed manifest verification."
+            next_action = {"label": "Publish and verify preview bundle", "command": "./mmf preview publish --json && ./mmf preview verify --json"}
     elif bundle.get("runtime_ready") is not True:
         status = "verified_not_runtime_ready"
         if missing_urls > 0:
@@ -834,6 +843,8 @@ def preview_doctor(
     candidates = legacy.get("candidates") if isinstance(legacy.get("candidates"), dict) else {}
     bundle = source.get("generated_bundle") if isinstance(source.get("generated_bundle"), dict) else {}
     secrets = _preview_secret_backend_summary(root)
+    legacy_candidate_count = int(candidates.get("provider_route_count") or 0)
+    bundle_runtime_ready = bundle.get("verified") and bundle.get("runtime_ready") is True
 
     checks = [
         {
@@ -848,8 +859,8 @@ def preview_doctor(
         },
         {
             "id": "legacy_candidates",
-            "ok": int(candidates.get("provider_route_count") or 0) > 0,
-            "detail": f"provider_routes={int(candidates.get('provider_route_count') or 0)}",
+            "ok": legacy_candidate_count > 0 or bundle_runtime_ready,
+            "detail": f"provider_routes={legacy_candidate_count}",
         },
         {
             "id": "latest_bundle",
@@ -870,12 +881,20 @@ def preview_doctor(
     elif registry_db.get("status") != "ok":
         overall = "needs_init"
         next_actions.append({"label": "Initialize preview root", "command": "./mmf preview init --json"})
-    elif int(candidates.get("provider_route_count") or 0) <= 0:
-        overall = "needs_import"
-        next_actions.append({"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"})
+    elif bundle.get("verified") and bundle.get("runtime_ready") is True:
+        overall = "ready"
+        watchdog_root = shlex.quote(str(root))
+        next_actions.append({
+            "label": "Optional: run read-only watchdog check",
+            "command": f"scripts/mms_health_watchdog.py --config-dir {watchdog_root} --require-bundle --dry-run --print-json",
+        })
     elif not bundle.get("verified"):
-        overall = "needs_publish"
-        next_actions.append({"label": "Publish and verify preview bundle", "command": "./mmf preview publish --json && ./mmf preview verify --json"})
+        if int(candidates.get("provider_route_count") or 0) <= 0:
+            overall = "needs_import"
+            next_actions.append({"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"})
+        else:
+            overall = "needs_publish"
+            next_actions.append({"label": "Publish and verify preview bundle", "command": "./mmf preview publish --json && ./mmf preview verify --json"})
     elif bundle.get("runtime_ready") is not True:
         overall = "verified_not_runtime_ready"
         if int(bundle.get("router_missing_base_url_count") or 0) > 0:
@@ -1769,16 +1788,23 @@ def _provider_route_models(provider: Mapping[str, Any], *, ignore_fallback_model
     return result
 
 
+def _is_redacted_secret_token(value: Any) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    return text in {"<redacted>", "[redacted]", "***", "****"} or "***" in text or "****" in text
+
+
 def _provider_route_secret_ref(provider: Mapping[str, Any], credential_provider_ids: set[str]) -> tuple[str, str]:
     provider_id = str(provider.get("id") or provider.get("provider_id") or "default").strip() or "default"
-    explicit_ref = str(provider.get("secret_ref") or "").strip()
-    if explicit_ref:
-        return explicit_ref, "provider.secret_ref"
     if provider_id in credential_provider_ids:
         return f"pending-webui:{_secret_ref_part(provider_id)}:api_key", "credential_update"
+    explicit_ref = str(provider.get("secret_ref") or "").strip()
+    if explicit_ref and not _is_redacted_secret_token(explicit_ref):
+        return explicit_ref, "provider.secret_ref"
     for field in ("api_key", "openai_api_key", "anthropic_api_key"):
         value = str(provider.get(field) or "").strip()
-        if value:
+        if value and not _is_redacted_secret_token(value):
             return f"legacy-config:{_secret_ref_part(provider_id)}:{field}", f"config.{field}"
     return "", ""
 
@@ -2088,6 +2114,11 @@ def _route_scoped_candidate_payload(
     root = root.expanduser()
     profiles_payload = candidate_payload.get("profile") if isinstance(candidate_payload.get("profile"), Mapping) else {}
     profiles = profiles_payload.get("profiles") if isinstance(profiles_payload.get("profiles"), Mapping) else {}
+    candidate_provider_ids = {
+        str(provider_id or "").strip()
+        for provider_id in profiles.keys()
+        if str(provider_id or "").strip()
+    }
     scoped_hidden: dict[str, set[str]] = {}
     scoped_enabled: dict[str, bool] = {}
     for provider_id in scope:
@@ -2104,8 +2135,12 @@ def _route_scoped_candidate_payload(
         if route_id
     }
     preserved_entries: list[dict[str, Any]] = []
+    removed_provider_ids: set[str] = set()
     for entry in _latest_approved_route_entries(root):
         provider_id = str(entry.get("provider_id") or "").strip()
+        if provider_id and provider_id not in candidate_provider_ids:
+            removed_provider_ids.add(provider_id)
+            continue
         if provider_id in scope:
             model = str(entry.get("model") or "").strip()
             route_id = _provider_route_identity(model, provider_id)
@@ -2133,6 +2168,7 @@ def _route_scoped_candidate_payload(
             "refreshed_provider_ids": sorted(refresh_scope),
             "scoped_route_count": len(scoped_entries),
             "preserved_route_count": len(preserved_entries),
+            "removed_provider_ids": sorted(removed_provider_ids),
         }
     )
     payload["skipped"] = skipped

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -956,6 +956,146 @@ def test_config_web_secret_ref_without_value_is_not_key_set():
     assert summary["has_api_key"] is False
 
 
+def test_config_web_attach_preview_secret_refs_replaces_redacted_ref(tmp_path):
+    config_root = tmp_path / "mms-next"
+    secrets_dir = config_root / "secrets"
+    secrets_dir.mkdir(parents=True)
+    (secrets_dir / "webui-secrets.json").write_text(
+        json.dumps(
+            {
+                "secrets": [
+                    {
+                        "provider_id": "demo",
+                        "field": "api_key",
+                        "secret_ref": "pending-webui:demo:api_key",
+                        "value": "sk-demo-secret",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    result = mms_config_web._attach_preview_secret_refs(
+        {"providers": [{"id": "demo", "secret_ref": "pen***key"}]},
+        config_path=str(config_root / "config.toml"),
+        command_name="mmf",
+    )
+
+    assert result["providers"][0]["secret_ref"] == "pending-webui:demo:api_key"
+
+
+def test_config_web_resolve_preview_provider_secret_replaces_redacted_ref(tmp_path):
+    config_root = tmp_path / "mms-next"
+    secrets_dir = config_root / "secrets"
+    secrets_dir.mkdir(parents=True)
+    (secrets_dir / "webui-secrets.json").write_text(
+        json.dumps(
+            {
+                "secrets": [
+                    {
+                        "provider_id": "demo",
+                        "field": "api_key",
+                        "secret_ref": "pending-webui:demo:api_key",
+                        "value": "sk-demo-secret",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    result = mms_config_web._resolve_preview_provider_secret(
+        {"id": "demo", "secret_ref": "pen***key"},
+        config_path=str(config_root / "config.toml"),
+        command_name="mmf",
+    )
+
+    assert result["secret_ref"] == "pending-webui:demo:api_key"
+    assert result["api_key"] == "sk-demo-secret"
+
+
+def test_config_web_preview_bundle_config_from_verified_files_replaces_redacted_ref(tmp_path):
+    config_root = tmp_path / "mms-next"
+    generated_dir = config_root / "generated"
+    secrets_dir = config_root / "secrets"
+    generated_dir.mkdir(parents=True)
+    secrets_dir.mkdir(parents=True)
+    (secrets_dir / "webui-secrets.json").write_text(
+        json.dumps(
+            {
+                "secrets": [
+                    {
+                        "provider_id": "demo",
+                        "field": "api_key",
+                        "secret_ref": "pending-webui:demo:api_key",
+                        "value": "sk-demo-secret",
+                    }
+                ]
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    profile_path = generated_dir / "provider-profiles.generated.json"
+    router_path = generated_dir / "model-routes.json"
+    profile_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "demo": {
+                        "name": "Demo",
+                        "protocols": ["openai_chat_completions"],
+                        "supported_clis": ["codex"],
+                    }
+                },
+                "provider": {"default": "demo"},
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    router_path.write_text(
+        json.dumps(
+            {
+                "routes": {
+                    "gpt-5.5": {
+                        "primary": {
+                            "provider_id": "demo",
+                            "model": "gpt-5.5",
+                            "openai_base_url": "https://demo.example/v1",
+                            "api_key": "",
+                            "secret_ref": "pen***key",
+                        },
+                        "fallbacks": [],
+                    }
+                }
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    result = mms_config_web._preview_bundle_config_from_verified_files(
+        {
+            "profile": {"path": str(profile_path)},
+            "router": {"path": str(router_path)},
+        },
+        config_root=str(config_root),
+    )
+
+    provider = result["providers"][0]
+    assert provider["secret_ref"] == "pending-webui:demo:api_key"
+    assert provider["has_api_key"] is True
+
+
 def test_config_web_snapshot_includes_read_only_model_source_status(tmp_path):
     config_root = tmp_path / "mms-next"
     snapshot = mms_config_web.build_config_snapshot(
@@ -3537,6 +3677,76 @@ def test_config_web_registry_v2_apply_refreshed_provider_preserves_stale_routes_
     assert "claude-opus-4.7" not in router["routes"]
     assert cleanup["candidate"]["route_candidates"]["provider_route_count"] == 1
     assert cleanup["route_publish_guard"]["diff"]["removed_models_sample"] == ["claude-opus-4.7"]
+
+
+def test_config_web_registry_v2_apply_deleted_provider_does_not_resurrect(tmp_path):
+    config_root = tmp_path / "mms-next"
+    config_path = config_root / "config.toml"
+
+    def provider(provider_id, priority):
+        return {
+            "original_id": provider_id,
+            "id": provider_id,
+            "name": provider_id,
+            "enabled": True,
+            "role": "primary" if provider_id == "tokyo" else "fallback",
+            "priority": priority,
+            "protocols": ["anthropic_messages", "openai_chat_completions"],
+            "supported_clis": ["claude", "codex", "opencode"],
+            "models_endpoint": "manual",
+            "openai_base_url": f"https://{provider_id}.example/v1",
+            "anthropic_base_url": f"https://{provider_id}.example/v1",
+            "api_key": f"sk-{provider_id}-secret",
+            "update_credentials": True,
+            "fallback_models": ["mimo-v2.5"],
+            "extra_models": [],
+            "hidden_models": [],
+            "models": [{"id": "mimo-v2.5", "visible": True}],
+        }
+
+    first_payload = {
+        "draft": {
+            "provider_default": "tokyo",
+            "providers": [provider("tokyo", 200), provider("tencent", 100)],
+            "rescue": {},
+            "vision_sidecar": {},
+            "runtime": {"preferred_cli": "opencode", "coding_preset_model": "mimo-v2.5"},
+            "opencode": {"default_profile": "lite_pro_orchestrated", "agent_models": {}},
+        },
+        "confirm_v2_preview": True,
+        "confirm_phrase": "写入预览DB",
+    }
+    first = mms_config_web.apply_registry_v2_preview_plan(
+        {"providers": [{"id": "tokyo", "name": "Old"}], "provider": {"default": "tokyo"}},
+        first_payload,
+        config_path=str(config_path),
+    )
+
+    second_payload = json.loads(json.dumps(first_payload))
+    second_payload["draft"]["providers"] = [provider("tokyo", 200)]
+    second_payload["draft"]["route_scope_provider_ids"] = ["tencent"]
+    second = mms_config_web.apply_registry_v2_preview_plan(
+        {"providers": [{"id": "tokyo", "name": "Old"}], "provider": {"default": "tokyo"}},
+        second_payload,
+        config_path=str(config_path),
+    )
+    router = json.loads((config_root / "generated" / "model-routes.json").read_text(encoding="utf-8"))
+    snapshot = mms_config_web.build_config_snapshot(
+        {"providers": [{"id": "tokyo", "name": "Old"}], "provider": {"default": "tokyo"}},
+        config_path=str(config_path),
+        command_name="mmf",
+    )
+
+    provider_ids = {
+        leaf["provider_id"]
+        for route in router["routes"].values()
+        for leaf in [route["primary"], *(route.get("fallbacks") or [])]
+    }
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert provider_ids == {"tokyo"}
+    assert [item["id"] for item in snapshot["providers"]] == ["tokyo"]
 
 
 def test_config_web_registry_v2_apply_blocks_route_shrink_from_stale_small_draft(tmp_path):

--- a/tests/test_registry_cli.py
+++ b/tests/test_registry_cli.py
@@ -989,6 +989,46 @@ def test_registry_v2_save_candidate_writes_preview_db_without_secrets(tmp_path: 
         db.close()
 
 
+def test_provider_route_secret_ref_prefers_credential_update_over_redacted_ref() -> None:
+    secret_ref, source = mms_registry_cli._provider_route_secret_ref(
+        {"id": "primary-local", "secret_ref": "pen***key"},
+        {"primary-local"},
+    )
+
+    assert secret_ref == "pending-webui:primary_local:api_key"
+    assert source == "credential_update"
+
+
+def test_provider_route_secret_ref_ignores_redacted_api_key_fallback() -> None:
+    secret_ref, source = mms_registry_cli._provider_route_secret_ref(
+        {"id": "primary-local", "api_key": "pen***key"},
+        set(),
+    )
+
+    assert secret_ref == ""
+    assert source == ""
+
+
+def test_provider_route_secret_ref_prefers_credential_update_over_stale_ref() -> None:
+    secret_ref, source = mms_registry_cli._provider_route_secret_ref(
+        {"id": "primary-local", "secret_ref": "legacy-config:old:api_key"},
+        {"primary-local"},
+    )
+
+    assert secret_ref == "pending-webui:primary_local:api_key"
+    assert source == "credential_update"
+
+
+def test_provider_route_secret_ref_ignores_named_redacted_tokens() -> None:
+    secret_ref, source = mms_registry_cli._provider_route_secret_ref(
+        {"id": "primary-local", "secret_ref": "<redacted>", "api_key": "[redacted]"},
+        set(),
+    )
+
+    assert secret_ref == ""
+    assert source == ""
+
+
 def test_registry_v2_save_candidate_refuses_stable_root_without_allow_stable(tmp_path: Path) -> None:
     stable_root = tmp_path / "mms"
 
@@ -1374,6 +1414,93 @@ def test_publish_preview_bundle_prefers_latest_registry_v2_save_candidate(tmp_pa
     assert profile_payload["source"] == "registry-preview-v2-save-candidate"
     assert profile_payload["profiles"]["primary-local"]["models_endpoint"] == "/models"
     assert "sk-primary-local-secret" not in generated_text
+
+
+def test_route_scoped_candidate_payload_drops_deleted_provider_not_in_scope(tmp_path: Path) -> None:
+    config_dir = tmp_path / "mms-next"
+    policy = {"version": 1, "models": {"shared-model": {"visible": True}}}
+    first_cfg = {
+        "provider": {"default": "tokyo"},
+        "providers": [
+            {
+                "id": "tokyo",
+                "name": "Tokyo",
+                "enabled": True,
+                "role": "primary",
+                "priority": 200,
+                "default_openai_base_url": "https://tokyo.example/v1",
+                "api_key": "sk-tokyo-secret",
+                "models_endpoint": "/models",
+                "protocols": ["openai_chat_completions"],
+                "supported_clis": ["codex"],
+                "fallback_models": ["shared-model"],
+            },
+            {
+                "id": "tencent",
+                "name": "Tencent",
+                "enabled": True,
+                "role": "fallback",
+                "priority": 100,
+                "default_openai_base_url": "https://tencent.example/v1",
+                "api_key": "sk-tencent-secret",
+                "models_endpoint": "/models",
+                "protocols": ["openai_chat_completions"],
+                "supported_clis": ["codex"],
+                "fallback_models": ["shared-model"],
+            },
+        ],
+    }
+    mms_registry_cli.apply_registry_v2_save_candidate(
+        config_dir=config_dir,
+        config_payload=first_cfg,
+        policy_payload=policy,
+        credential_updates=[
+            {"provider_id": "tokyo", "api_key": "sk-tokyo-secret"},
+            {"provider_id": "tencent", "api_key": "sk-tencent-secret"},
+        ],
+        apply=True,
+        command_name="mmf registry",
+    )
+    mms_registry_cli.write_registry_v2_webui_secret_backend(
+        config_dir=config_dir,
+        credential_updates=[
+            {"provider_id": "tokyo", "api_key": "sk-tokyo-secret"},
+            {"provider_id": "tencent", "api_key": "sk-tencent-secret"},
+        ],
+        command_name="mmf registry",
+    )
+    mms_registry_cli.publish_preview_bundle(config_dir=config_dir)
+
+    second_cfg = {
+        "provider": {"default": "tokyo"},
+        "providers": [
+            {
+                "id": "tokyo",
+                "name": "Tokyo",
+                "enabled": True,
+                "role": "primary",
+                "priority": 200,
+                "default_openai_base_url": "https://tokyo.example/v1",
+                "api_key": "sk-tokyo-secret",
+                "models_endpoint": "/models",
+                "protocols": ["openai_chat_completions"],
+                "supported_clis": ["codex"],
+                "fallback_models": ["shared-model"],
+            }
+        ],
+    }
+    candidate_payload = mms_registry_cli._registry_v2_candidate_payload(second_cfg, policy_payload=policy)
+
+    scoped = mms_registry_cli._route_scoped_candidate_payload(
+        config_dir=config_dir,
+        candidate_payload=candidate_payload,
+        route_scope_provider_ids=["tokyo"],
+    )
+
+    provider_ids = {str(entry.get("provider_id") or "") for entry in scoped["route_entries"]}
+
+    assert provider_ids == {"tokyo"}
+    assert scoped["skipped"][-1]["removed_provider_ids"] == ["tencent"]
 
 
 def test_publish_preview_bundle_does_not_mix_foreign_registry_v2_policy_revision(tmp_path: Path) -> None:
@@ -2126,6 +2253,176 @@ def test_model_source_status_downgrades_stale_runtime_ready_when_route_url_missi
     assert status["generated_bundle"]["runtime_ready"] is False
     assert status["generated_bundle"]["runtime_ready_status"] == "not_ready"
     assert status["generated_bundle"]["router_missing_base_url_count"] == 1
+
+
+def test_model_source_status_ready_with_verified_runtime_ready_bundle_without_legacy_candidates(tmp_path: Path) -> None:
+    config_dir = tmp_path / "mms-next"
+    mms_registry_cli.init_config_root(config_dir=config_dir, command_name="mmf preview")
+    generated = config_dir / "generated"
+    generated.mkdir(parents=True, exist_ok=True)
+    router = generated / "model-routes.json"
+    lineup = generated / "model-routes.lineup.json"
+    profile = generated / "provider-profiles.generated.json"
+    policy = generated / "model-policy.effective.json"
+    capabilities = generated / "model-capabilities.approved.json"
+    mms_registry.write_json_atomic(
+        router,
+        {
+            "version": 1,
+            "runtime_ready": True,
+            "routes": {
+                "ready-model": {
+                    "primary": {
+                        "provider_id": "ready-provider",
+                        "model_id": "ready-model",
+                        "openai_base_url": "https://ready.example/v1",
+                        "api_key": "sk-ready-secret",
+                    },
+                    "fallbacks": [],
+                }
+            },
+        },
+    )
+    mms_registry.write_json_atomic(
+        lineup,
+        {
+            "version": 1,
+            "routes": {
+                "ready-model": {
+                    "primary": {"provider_id": "ready-provider", "model_id": "ready-model"},
+                    "fallbacks": [],
+                }
+            },
+        },
+    )
+    mms_registry.write_json_atomic(
+        profile,
+        {
+            "schema_version": 1,
+            "profiles": {
+                "ready-provider": {
+                    "name": "Ready Provider",
+                    "enabled": True,
+                    "protocols": ["openai_chat_completions"],
+                    "supported_clis": ["codex"],
+                }
+            },
+            "provider": {"default": "ready-provider"},
+        },
+    )
+    mms_registry.write_json_atomic(policy, {"version": 1, "models": {"ready-model": {"visible": True}}})
+    mms_registry.write_json_atomic(capabilities, {"schema": "mms.model_capabilities.approved.v1", "models": []})
+    mms_registry.export_latest_approved_bundle_manifest(
+        generated / "model-registry.latest-approved.json",
+        bundle_revision="bundle_ready_without_candidates",
+        capability_revision="cap_ready_without_candidates",
+        route_revision="route_ready_without_candidates",
+        policy_revision="policy_ready_without_candidates",
+        profile_revision="profile_ready_without_candidates",
+        files={
+            "router": {"path": router, "canonical_path": "generated/model-routes.json", "sensitivity": "secret"},
+            "lineup": {"path": lineup, "canonical_path": "generated/model-routes.lineup.json", "sensitivity": "non-secret"},
+            "profile": {"path": profile, "canonical_path": "generated/provider-profiles.generated.json", "sensitivity": "non-secret"},
+            "policy": {"path": policy, "canonical_path": "generated/model-policy.effective.json", "sensitivity": "non-secret"},
+            "capabilities": {"path": capabilities, "canonical_path": "generated/model-capabilities.approved.json", "sensitivity": "non-secret"},
+        },
+    )
+
+    status = mms_registry_cli.model_source_status(config_dir=config_dir, command_name="mmf config source")
+
+    assert status["registry_db"]["status"] == "ok"
+    assert status["legacy_import"]["candidates"]["provider_route_count"] == 0
+    assert status["generated_bundle"]["verified"] is True
+    assert status["generated_bundle"]["runtime_ready"] is True
+    assert status["status"] == "ready"
+    assert status["result"] == "READY"
+    assert status["ready"] is True
+
+
+def test_preview_doctor_ready_with_verified_runtime_ready_bundle_without_legacy_candidates(tmp_path: Path) -> None:
+    config_dir = tmp_path / "mms-next"
+    mms_registry_cli.init_config_root(config_dir=config_dir, command_name="mmf preview")
+    generated = config_dir / "generated"
+    generated.mkdir(parents=True, exist_ok=True)
+    router = generated / "model-routes.json"
+    lineup = generated / "model-routes.lineup.json"
+    profile = generated / "provider-profiles.generated.json"
+    policy = generated / "model-policy.effective.json"
+    capabilities = generated / "model-capabilities.approved.json"
+    mms_registry.write_json_atomic(
+        router,
+        {
+            "version": 1,
+            "runtime_ready": True,
+            "routes": {
+                "ready-model": {
+                    "primary": {
+                        "provider_id": "ready-provider",
+                        "model_id": "ready-model",
+                        "openai_base_url": "https://ready.example/v1",
+                        "api_key": "sk-ready-secret",
+                    },
+                    "fallbacks": [],
+                }
+            },
+        },
+    )
+    mms_registry.write_json_atomic(
+        lineup,
+        {
+            "version": 1,
+            "routes": {
+                "ready-model": {
+                    "primary": {"provider_id": "ready-provider", "model_id": "ready-model"},
+                    "fallbacks": [],
+                }
+            },
+        },
+    )
+    mms_registry.write_json_atomic(
+        profile,
+        {
+            "schema_version": 1,
+            "profiles": {
+                "ready-provider": {
+                    "name": "Ready Provider",
+                    "enabled": True,
+                    "protocols": ["openai_chat_completions"],
+                    "supported_clis": ["codex"],
+                }
+            },
+            "provider": {"default": "ready-provider"},
+        },
+    )
+    mms_registry.write_json_atomic(policy, {"version": 1, "models": {"ready-model": {"visible": True}}})
+    mms_registry.write_json_atomic(capabilities, {"schema": "mms.model_capabilities.approved.v1", "models": []})
+    mms_registry.export_latest_approved_bundle_manifest(
+        generated / "model-registry.latest-approved.json",
+        bundle_revision="bundle_ready_without_candidates_doctor",
+        capability_revision="cap_ready_without_candidates_doctor",
+        route_revision="route_ready_without_candidates_doctor",
+        policy_revision="policy_ready_without_candidates_doctor",
+        profile_revision="profile_ready_without_candidates_doctor",
+        files={
+            "router": {"path": router, "canonical_path": "generated/model-routes.json", "sensitivity": "secret"},
+            "lineup": {"path": lineup, "canonical_path": "generated/model-routes.lineup.json", "sensitivity": "non-secret"},
+            "profile": {"path": profile, "canonical_path": "generated/provider-profiles.generated.json", "sensitivity": "non-secret"},
+            "policy": {"path": policy, "canonical_path": "generated/model-policy.effective.json", "sensitivity": "non-secret"},
+            "capabilities": {"path": capabilities, "canonical_path": "generated/model-capabilities.approved.json", "sensitivity": "non-secret"},
+        },
+    )
+
+    summary = mms_registry_cli.preview_doctor(config_dir=config_dir, command_name="mmf config doctor")
+
+    assert summary["counts"]["candidate_provider_routes"] == 0
+    assert summary["bundle"]["verified"] is True
+    assert summary["bundle"]["runtime_ready"] is True
+    assert summary["status"] == "ready"
+    assert summary["result"] == "READY"
+    assert summary["ready"] is True
+    checks = {item["id"]: item for item in summary["checks"]}
+    assert checks["legacy_candidates"]["ok"] is True
+    assert summary["next_actions"][0]["command"].startswith("scripts/mms_health_watchdog.py")
 
 
 def test_mmf_preview_publish_wrapper_fails_closed_without_candidates(tmp_path: Path) -> None:


### PR DESCRIPTION
## What
- reject redacted or stale preview secret refs when building route candidates or hydrating WebUI state
- stop deleted providers from being resurrected by latest-approved route preservation
- prefer a verified runtime-ready bundle over legacy candidate counters in readiness and preview doctor
- add regression coverage for secret-ref replacement, provider deletion, and ready-without-legacy-candidates flows

## Validation
- `PYTHONPATH=. pytest tests/test_registry_cli.py::test_provider_route_secret_ref_prefers_credential_update_over_redacted_ref tests/test_registry_cli.py::test_provider_route_secret_ref_ignores_redacted_api_key_fallback tests/test_registry_cli.py::test_provider_route_secret_ref_prefers_credential_update_over_stale_ref tests/test_registry_cli.py::test_provider_route_secret_ref_ignores_named_redacted_tokens tests/test_registry_cli.py::test_registry_v2_save_candidate_writes_preview_db_without_secrets`
- `PYTHONPATH=. pytest tests/test_config_web.py -k "secret_ref_without_value or attach_preview_secret_refs_replaces_redacted_ref or resolve_preview_provider_secret_replaces_redacted_ref or preview_bundle_config_from_verified_files_replaces_redacted_ref or registry_v2_republish_reuses_preview_secret_refs or provider_model_fetch_resolves_preview_secret_ref"`
- `PYTHONPATH=. pytest tests/test_registry_cli.py::test_route_scoped_candidate_payload_drops_deleted_provider_not_in_scope tests/test_config_web.py::test_config_web_registry_v2_apply_deleted_provider_does_not_resurrect tests/test_config_web.py::test_config_web_registry_v2_apply_scoped_provider_manual_add_preserves_provider_routes tests/test_config_web.py::test_config_web_registry_v2_apply_refreshed_provider_preserves_stale_routes_until_explicit_cleanup tests/test_registry_cli.py::test_model_source_status_ready_with_verified_runtime_ready_bundle_without_legacy_candidates tests/test_registry_cli.py::test_preview_doctor_ready_with_verified_runtime_ready_bundle_without_legacy_candidates tests/test_registry_cli.py::test_preview_doctor_reports_needs_import_after_init tests/test_registry_cli.py::test_preview_doctor_reports_needs_publish_after_import tests/test_registry_cli.py::test_preview_doctor_reports_verified_not_runtime_ready_without_secret_backend tests/test_registry_cli.py::test_mmf_preview_doctor_wrapper_reports_ready_with_secret_backend tests/test_registry_cli.py::test_preview_include_secrets_enables_runtime_ready_publish_without_db_plaintext tests/test_registry_cli.py::test_preview_include_secrets_without_route_url_is_not_runtime_ready`

## Notes
- full `tests/test_registry_cli.py` and `tests/test_config_web.py` suites still contain pre-existing baseline failures unrelated to this PR; I re-ran the same failing cases on a clean baseline worktree and observed the same failures there
