### PR TITLE
ci: add Redline advisory PR gate

### DIFF
--- a/.github/workflows/digger.yml
+++ b/.github/workflows/digger.yml
@@ -1,8 +1,11 @@
-name: Digger
+name: Digger + Redline
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
 
 jobs:
   digger:
@@ -35,6 +38,12 @@ jobs:
 
       - name: Install Python test tools
         run: python3 -m pip install pytest httpx rich
+
+      - name: Prepare trusted Digger run directory
+        run: |
+          rm -rf .digger "$RUNNER_TEMP/digger-runs"
+          mkdir -p "$RUNNER_TEMP/digger-runs" .digger
+          ln -s "$RUNNER_TEMP/digger-runs" .digger/runs
 
       - name: Install digger
         env:
@@ -80,9 +89,212 @@ jobs:
               --fail-on-validation
           fi
 
+      - name: Verify trusted Digger run directory
+        if: always()
+        run: |
+          if [ ! -L .digger/runs ]; then
+            echo "::warning::.digger/runs is not the trusted symlink; ignoring checkout-local runs"
+            rm -rf "$RUNNER_TEMP/digger-runs"
+            mkdir -p "$RUNNER_TEMP/digger-runs"
+          fi
+
       - name: Upload review packet
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: digger
-          path: .digger/runs
+          path: ${{ runner.temp }}/digger-runs
+          retention-days: 30
+
+  redline:
+    needs: digger
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      REDLINE_GUARD_REF: 661dfbf52912534054a2340bf9dd5bca16a2c41f
+      REDLINE_GUARD_ENABLED: ${{ vars.REDLINE_GUARD_ENABLED || 'true' }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable package managers
+        run: corepack enable
+
+      - name: Prepare trusted Digger artifact directory
+        run: |
+          rm -rf .trusted-digger-artifact
+          mkdir -p .trusted-digger-artifact
+
+      - name: Download Digger artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: digger
+          path: .trusted-digger-artifact
+
+      - name: Locate Digger run
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import json
+          from pathlib import Path
+
+          candidates = {}
+          markers = ["manifest.json", "findings.json", "REVIEW.md", "baseline-summary.json"]
+          search_roots = [Path(".trusted-digger-artifact")]
+          for root in search_roots:
+              if not root.exists():
+                  continue
+              for marker in markers:
+                  for path in root.rglob(marker):
+                      parent = path.parent
+                      if parent.name == "checks":
+                          parent = parent.parent
+                      candidates[str(parent)] = parent
+
+          def sort_key(path: Path):
+              manifest = path / "manifest.json"
+              if manifest.exists():
+                  try:
+                      data = json.loads(manifest.read_text(encoding="utf-8"))
+                      return data.get("createdAt") or data.get("created_at") or ""
+                  except Exception:
+                      pass
+              return str(path.stat().st_mtime)
+
+          if candidates:
+              selected = sorted(candidates.values(), key=sort_key)[-1]
+              print(f"DIGGER_RUN_ROOT={selected}")
+          else:
+              print("DIGGER_RUN_ROOT=")
+          PY
+
+      - name: Install redline-guard
+        env:
+          REDLINE_GUARD_DEPLOY_KEY: ${{ secrets.REDLINE_GUARD_DEPLOY_KEY }}
+        run: |
+          mkdir -p .redline-guard/report
+          if [ "$REDLINE_GUARD_ENABLED" = "false" ]; then
+            echo "REDLINE_SKIP_REASON=REDLINE_GUARD_ENABLED=false" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          if [ -z "$REDLINE_GUARD_DEPLOY_KEY" ]; then
+            echo "REDLINE_SKIP_REASON=missing REDLINE_GUARD_DEPLOY_KEY secret" >> "$GITHUB_ENV"
+            exit 0
+          fi
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "$REDLINE_GUARD_DEPLOY_KEY"
+
+          npm install --global "git+ssh://git@github.com/CtriXin/redline-guard.git#${REDLINE_GUARD_REF}"
+
+      - name: Run redline-guard advisory audit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p .redline-guard/report
+
+          write_unknown_report() {
+            local reason="$1"
+            python3 - "$reason" <<'PY'
+          import json
+          import os
+          import sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          reason = sys.argv[1]
+          out = Path(".redline-guard/report")
+          out.mkdir(parents=True, exist_ok=True)
+          result = {
+              "version": "ci-advisory-fallback",
+              "createdAt": datetime.now(timezone.utc).isoformat(),
+              "decision": "unknown",
+              "color": "yellow",
+              "provider": "github",
+              "repo": "${{ github.repository }}",
+              "url": "${{ github.event.pull_request.html_url }}",
+              "sourceBranch": "${{ github.event.pull_request.head.ref }}",
+              "targetBranch": "${{ github.event.pull_request.base.ref }}",
+              "blockers": [],
+              "warnings": [reason],
+              "checks": [],
+              "diggerRunRoot": os.environ.get("DIGGER_RUN_ROOT", ""),
+          }
+          (out / "audit-result.json").write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+          (out / "audit-result.md").write_text(f"# redline-guard audit\n\nDecision: `unknown`\n\nReason: {reason}\n", encoding="utf-8")
+          PY
+          }
+
+          if [ -n "${REDLINE_SKIP_REASON:-}" ]; then
+            write_unknown_report "$REDLINE_SKIP_REASON"
+          elif [ -z "${DIGGER_RUN_ROOT:-}" ]; then
+            write_unknown_report "Digger artifact did not contain a run root"
+          else
+            set +e
+            redline-guard audit \
+              --provider github \
+              --pr "$PR_NUMBER" \
+              --repo "$GITHUB_WORKSPACE" \
+              --digger-run "$DIGGER_RUN_ROOT" \
+              --out .redline-guard/report
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ]; then
+              write_unknown_report "redline-guard exited with status $status"
+            fi
+          fi
+
+          find .redline-guard/report -type f ! -name '*.sha256' -print0 | while IFS= read -r -d '' file; do
+            sha256sum "$file" > "$file.sha256"
+          done
+
+      - name: Summarize Redline decision
+        if: always()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          path = Path(".redline-guard/report/audit-result.json")
+          if path.exists():
+              data = json.loads(path.read_text(encoding="utf-8"))
+              decision = data.get("decision", "unknown")
+              warnings = data.get("warnings") or []
+              blockers = data.get("blockers") or []
+          else:
+              decision = "unknown"
+              warnings = ["audit-result.json missing"]
+              blockers = []
+
+          print("## redline-guard advisory result")
+          print(f"- decision: `{decision}`")
+          print("- artifact: `redline-report`")
+          if blockers:
+              print(f"- blockers: {len(blockers)}")
+          if warnings:
+              print(f"- warnings: {len(warnings)}")
+          print("- mode: advisory-only; committee/human review remains the merge gate")
+          PY
+
+      - name: Upload Redline report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: redline-report
+          path: .redline-guard/report
+          retention-days: 30

--- a/docs/DIGGER_PR_VALIDATION.md
+++ b/docs/DIGGER_PR_VALIDATION.md
@@ -62,3 +62,23 @@ is not a merge bot and must not be treated as committee approval.
 - Fork PRs are out of scope for now and are skipped by the same-repository guard.
 - Digger results are advisory. A passing Digger run does not replace committee
   review, human merge approval, or the project-specific release checklist.
+
+## Redline Follow-up Gate
+
+A follow-up workflow job may run `redline-guard` after Digger. The first MMS
+integration keeps Redline advisory-only and artifact-only:
+
+- The Redline job depends on Digger with `needs: digger` and uses `if: always()`
+  so missing Digger evidence becomes an `unknown` report instead of a silent gap.
+- Redline consumes the Digger artifact named `digger` and writes
+  `.redline-guard/report` as artifact `redline-report`.
+- Redline does not receive `pull-requests: write` or `issues: write`, and the CI
+  command intentionally omits `--comment`, `--notify`, callback actions, merge,
+  approve, deploy, close, and force-push behavior.
+- `blocked`, `needs-review`, and `unknown` decisions are advisory in the first
+  integration. Committee/human review remains the merge gate.
+- Redline installation must be pinned by commit SHA through `REDLINE_GUARD_REF`
+  or another immutable coordinate.
+
+See [`docs/REDLINE_PR_GATE.md`](REDLINE_PR_GATE.md) for the Redline artifact,
+secret, permission, kill-switch, and local fallback contract.

--- a/docs/REDLINE_PR_GATE.md
+++ b/docs/REDLINE_PR_GATE.md
@@ -1,0 +1,112 @@
+# Redline PR Gate
+
+Redline is the downstream advisory gate for MMS pull requests. It consumes the
+Digger artifact plus provider PR/check metadata and writes a durable
+`redline-report` artifact for committee review.
+
+This first integration is intentionally advisory-only. Redline does not approve,
+merge, deploy, close, force-push, post comments, or mutate repository state.
+Committee/human approval remains the final merge gate.
+
+## Workflow Shape
+
+The GitHub Actions flow is:
+
+1. `digger` runs first and uploads `.digger/runs` as artifact `digger`.
+   The workflow removes checkout-provided `.digger`, recreates `.digger/runs`
+   as a symlink to `$RUNNER_TEMP/digger-runs`, and uploads only that trusted
+   runner-temp directory. If a tool replaces the symlink, the workflow discards
+   checkout-local runs instead of uploading them.
+2. `redline` runs with `needs: digger` and `if: always()` for same-repository PRs.
+3. The job removes and recreates a trusted artifact directory, downloads artifact
+   `digger` into that directory, locates one Digger run root only from that
+   downloaded artifact root, installs pinned `redline-guard`, and runs:
+
+   ```bash
+   redline-guard audit \
+     --provider github \
+     --pr "$PR_NUMBER" \
+     --repo "$GITHUB_WORKSPACE" \
+     --digger-run "$DIGGER_RUN_ROOT" \
+     --out .redline-guard/report
+   ```
+
+4. The job uploads `.redline-guard/report` as artifact `redline-report` with
+   30-day retention.
+5. The job writes one Actions step-summary line with the decision and artifact
+   name so reviewers can see advisory status without opening the artifact first.
+
+If Digger produces no run root, Redline installation is disabled, or Redline
+exits non-zero, the workflow writes an `unknown` fallback report and exits `0`.
+That keeps tool/setup failures visible without deadlocking development.
+
+## Secrets And Permissions
+
+Required for private-tool install:
+
+- `DIGGER_DEPLOY_KEY`: read-only deploy key for `CtriXin/digger`.
+- `REDLINE_GUARD_DEPLOY_KEY`: read-only deploy key for `CtriXin/redline-guard`.
+
+Optional:
+
+- `DIGGER_MMS_COMMAND`: maintainer-controlled command for Digger semantic review.
+- Repository variable `REDLINE_GUARD_ENABLED=false`: advisory kill switch that
+  makes Redline write an `unknown` report instead of installing/running.
+
+Permissions:
+
+- Top-level default is `contents: read`.
+- Digger receives `pull-requests: write` and `issues: write` only because it
+  posts advisory PR comments.
+- Redline receives `contents: read` and `pull-requests: read` only. It does not
+  receive comment/write permissions in the first integration.
+
+## Pinning
+
+- Digger is pinned by `DIGGER_REF` in the workflow.
+- Redline is pinned by `REDLINE_GUARD_REF` in the workflow.
+- GitHub Actions are pinned by major versions for maintainability.
+- Node is pinned to `24`; Python is pinned to `3.12` for the Digger job.
+- `ssh-keyscan github.com` remains a documented TOFU tradeoff while the tools are
+  private. Future public packages, reusable workflows, Docker images, or pinned
+  host keys should remove that risk.
+
+## Artifact Contract
+
+Redline writes these files when available:
+
+- `audit-result.json`
+- `audit-result.md`
+- `comment.md`
+- `digger-evidence.json`
+- `*.sha256` sidecars for each uploaded report file
+
+The artifact name is `redline-report`. The first retention value is 30 days.
+Release workflows may raise retention later if committee wants longer audit
+history.
+
+## Branch And Fork Behavior
+
+The workflow uses `pull_request`, not `pull_request_target`, and is guarded to
+same-repository PRs while private install credentials are required. Fork PRs are
+skipped until Digger and Redline have a public/no-secret distribution path.
+
+A base branch receives this gate only after the workflow exists on that branch.
+To cover `dev`, merge or cherry-pick this workflow into `dev`; to cover
+`release/*`, land it on the relevant release branch first.
+
+## Local Fallback
+
+Maintainers can run Redline locally after downloading or generating a Digger run:
+
+```bash
+redline-guard audit \
+  --provider github \
+  --pr <number-or-url> \
+  --repo <repo-path> \
+  --digger-run <repo-path>/.digger/runs/<run-id> \
+  --out <repo-path>/.redline-guard/report
+```
+
+Do not pass `--comment`, `--notify`, or callback/action flags unless the human
+explicitly asks for those write/notification surfaces.


### PR DESCRIPTION
## Summary

- add a `redline` job downstream of the Digger PR validation workflow
- install `redline-guard` from pinned commit `661dfbf52912534054a2340bf9dd5bca16a2c41f`
- consume the Digger artifact, upload `redline-report`, write step summary, and keep the first integration advisory-only
- document secrets, permissions, kill switch, artifact contract, and local fallback in `docs/REDLINE_PR_GATE.md`

## Scope / Dependency

- Depends on #4 and is intentionally stacked on `codex/review-pilot-ci` so PR #4 remains Digger-only.
- After #4 lands, this can be retargeted/cherry-picked to the active base branch.
- Redline does not post comments, notify, approve, merge, deploy, close, or force-push.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/digger.yml')"`
- `git diff --check`
- local `redline-guard audit` smoke against PR #4 with temporary Digger evidence, verifying `audit-result.json`, `audit-result.md`, and `digger-evidence.json`

Refs #14

Agent-Model: gpt-5
Agent-Family: openai