### PR TITLE
feat: load optional agent rules directory

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -10204,6 +10204,19 @@ def _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir
         return []
 
     dst = os.path.join(session_claude_dir, "rules")
+    if os.path.isdir(dst) and not os.path.islink(dst):
+        loaded = []
+        for name, src in rule_files:
+            link = os.path.join(dst, name)
+            if os.path.exists(link) or os.path.islink(link):
+                continue
+            try:
+                os.symlink(src, link)
+            except OSError:
+                continue
+            loaded.append(name)
+        return loaded
+
     overlay_root = os.path.join(os.path.dirname(session_claude_dir), ".mms-agent-rules-overlay")
     merged_dir = os.path.join(overlay_root, "rules")
     if os.path.isdir(merged_dir) and not os.path.islink(merged_dir):
@@ -10260,7 +10273,7 @@ def _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir
     return loaded
 
 
-def _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_entry_set):
+def _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_entry_set, *, allow_agent_rules=False):
     """Merge entries from ~/.agents/{skills,commands,rules} into the session .claude tree.
 
     When ``~/.claude/skills/`` is a real directory (not a symlink), the existing
@@ -10293,7 +10306,8 @@ def _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_entr
                 os.symlink(src, dst)
             except OSError:
                 pass
-    _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir)
+    if allow_agent_rules:
+        _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir)
 
 
 def _prepare_claude_session_tree(
@@ -10308,11 +10322,13 @@ def _prepare_claude_session_tree(
     source_claude_dir=None,
     allowed_source_entries=None,
     disabled_session_surfaces=None,
+    allow_agent_rules=None,
 ):
     current_cwd = os.path.realpath(_safe_getcwd())
     normalized_account_id = str(account_id or "").strip()
     store = ensure_claude_project_store(current_cwd, account_id=normalized_account_id)
     skip_real_entries = set(skip_real_entries or ())
+    using_default_source_entries = allowed_source_entries is None
     allowed_source_entries = [
         str(entry).strip()
         for entry in (
@@ -10323,6 +10339,8 @@ def _prepare_claude_session_tree(
         if str(entry or "").strip()
     ]
     allowed_source_entry_set = set(allowed_source_entries)
+    if allow_agent_rules is None:
+        allow_agent_rules = using_default_source_entries
     scoped_claude_dir = source_claude_dir or _real_user_path(".claude")
     agents_dir = _real_user_path(".agents")
     if os.path.islink(session_claude_dir):
@@ -10359,7 +10377,12 @@ def _prepare_claude_session_tree(
             if os.path.exists(dst) or os.path.islink(dst):
                 continue
             os.symlink(src, dst)
-    _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_source_entry_set)
+    _merge_agents_into_session_tree(
+        session_claude_dir,
+        agents_dir,
+        allowed_source_entry_set,
+        allow_agent_rules=bool(allow_agent_rules),
+    )
     for entry in CLAUDE_PERSISTENT_ENTRIES:
         dst = os.path.join(session_claude_dir, entry)
         target = str(

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -10174,15 +10174,103 @@ def _link_claude_persistent_entry(session_claude_dir, entry, target):
     os.symlink(target, dst)
 
 
+_AGENT_RULE_FILE_SUFFIXES = (".md", ".markdown")
+
+
+def _optional_agent_rule_files(rules_dir):
+    """Return supported local agent rule files in deterministic load order."""
+    rules_dir = str(rules_dir or "").strip()
+    if not rules_dir or not os.path.isdir(rules_dir):
+        return []
+    try:
+        names = sorted(os.listdir(rules_dir), key=lambda item: (item.casefold(), item))
+    except OSError:
+        return []
+    rules = []
+    for name in names:
+        suffix = os.path.splitext(name)[1].lower()
+        if suffix not in _AGENT_RULE_FILE_SUFFIXES:
+            continue
+        path = os.path.join(rules_dir, name)
+        if os.path.isfile(path):
+            rules.append((name, path))
+    return rules
+
+
+def _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir):
+    """Load optional ~/.agents/rules/*.md into the isolated Claude rules dir."""
+    rule_files = _optional_agent_rule_files(os.path.join(str(agents_dir or ""), "rules"))
+    if not rule_files:
+        return []
+
+    dst = os.path.join(session_claude_dir, "rules")
+    overlay_root = os.path.join(os.path.dirname(session_claude_dir), ".mms-agent-rules-overlay")
+    merged_dir = os.path.join(overlay_root, "rules")
+    if os.path.isdir(merged_dir) and not os.path.islink(merged_dir):
+        shutil.rmtree(merged_dir)
+    elif os.path.exists(merged_dir) or os.path.islink(merged_dir):
+        os.unlink(merged_dir)
+    os.makedirs(merged_dir, exist_ok=True)
+
+    def _merge_existing(src_dir):
+        src_dir = str(src_dir or "").strip()
+        if not src_dir or not os.path.isdir(src_dir):
+            return
+        try:
+            if os.path.samefile(src_dir, merged_dir):
+                return
+        except Exception:
+            pass
+        try:
+            names = sorted(os.listdir(src_dir), key=lambda item: (item.casefold(), item))
+        except OSError:
+            return
+        for name in names:
+            src = os.path.join(src_dir, name)
+            link = os.path.join(merged_dir, name)
+            if os.path.exists(link) or os.path.islink(link):
+                continue
+            try:
+                os.symlink(src, link)
+            except OSError:
+                pass
+
+    if os.path.exists(dst) or os.path.islink(dst):
+        _merge_existing(os.path.realpath(dst))
+
+    loaded = []
+    for name, src in rule_files:
+        link = os.path.join(merged_dir, name)
+        if not os.path.exists(link) and not os.path.islink(link):
+            try:
+                os.symlink(src, link)
+            except OSError:
+                continue
+        loaded.append(name)
+
+    if not os.listdir(merged_dir):
+        return []
+    if os.path.islink(dst):
+        os.unlink(dst)
+    elif os.path.isdir(dst):
+        shutil.rmtree(dst)
+    elif os.path.exists(dst):
+        os.unlink(dst)
+    os.symlink(merged_dir, dst)
+    return loaded
+
+
 def _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_entry_set):
-    """Merge entries from ~/.agents/{skills,commands} into the session .claude tree.
+    """Merge entries from ~/.agents/{skills,commands,rules} into the session .claude tree.
 
     When ``~/.claude/skills/`` is a real directory (not a symlink), the existing
     symlink-creation logic in ``_prepare_claude_session_tree`` skips it.  Skills
     installed via ``install_global_commands.py`` live under ``~/.agents/skills/``
     and would therefore never reach the overlay chain.  This helper symlinks
     individual entries from ``~/.agents/{skills,commands}`` into the session
-    ``.claude/{skills,commands}`` directories so that they are picked up.
+    ``.claude/{skills,commands}`` directories so that they are picked up.  It
+    also opportunistically exposes Markdown files from ``~/.agents/rules/`` as
+    a local-only rule overlay; a missing or empty rules directory is a no-op.
     """
     if not os.path.isdir(agents_dir):
         return
@@ -10205,6 +10293,7 @@ def _merge_agents_into_session_tree(session_claude_dir, agents_dir, allowed_entr
                 os.symlink(src, dst)
             except OSError:
                 pass
+    _merge_optional_agent_rules_into_session_tree(session_claude_dir, agents_dir)
 
 
 def _prepare_claude_session_tree(

--- a/tests/test_claude_hardening_regressions.py
+++ b/tests/test_claude_hardening_regressions.py
@@ -2812,6 +2812,76 @@ def test_overlay_ecc_session_entries_merges_session_and_ecc_assets(monkeypatch, 
     assert os.path.islink(parent_dir / "rules" / "everything-claude-code-guardrails.md")
 
 
+def test_optional_agent_rules_loader_noops_when_missing_or_empty(tmp_path):
+    import mms_launchers
+
+    parent_dir = tmp_path / "session" / ".claude"
+    parent_dir.mkdir(parents=True)
+    agents_dir = tmp_path / ".agents"
+
+    assert mms_launchers._merge_optional_agent_rules_into_session_tree(str(parent_dir), str(agents_dir)) == []
+    assert not (parent_dir / "rules").exists()
+
+    (agents_dir / "rules").mkdir(parents=True)
+    assert mms_launchers._merge_optional_agent_rules_into_session_tree(str(parent_dir), str(agents_dir)) == []
+    assert not (parent_dir / "rules").exists()
+
+
+def test_optional_agent_rules_loader_filters_markdown_and_sorts(tmp_path):
+    import mms_launchers
+
+    rules_dir = tmp_path / ".agents" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "20-second.md").write_text("# second\n", encoding="utf-8")
+    (rules_dir / "10-first.MD").write_text("# first\n", encoding="utf-8")
+    (rules_dir / "30-third.markdown").write_text("# third\n", encoding="utf-8")
+    (rules_dir / "notes.txt").write_text("skip\n", encoding="utf-8")
+    (rules_dir / "40-dir.md").mkdir()
+
+    files = mms_launchers._optional_agent_rule_files(str(rules_dir))
+
+    assert [name for name, _path in files] == [
+        "10-first.MD",
+        "20-second.md",
+        "30-third.markdown",
+    ]
+
+
+def test_merge_agents_into_session_tree_loads_optional_agent_rules(tmp_path):
+    import mms_launchers
+
+    parent_dir = tmp_path / "session" / ".claude"
+    parent_dir.mkdir(parents=True)
+    existing_rules = tmp_path / "existing-rules"
+    existing_rules.mkdir()
+    (existing_rules / "00-existing.md").write_text("# existing\n", encoding="utf-8")
+    os.symlink(existing_rules, parent_dir / "rules")
+
+    agents_dir = tmp_path / ".agents"
+    (agents_dir / "rules").mkdir(parents=True)
+    (agents_dir / "rules" / "20-second.md").write_text("# second\n", encoding="utf-8")
+    (agents_dir / "rules" / "10-first.md").write_text("# first\n", encoding="utf-8")
+    (agents_dir / "rules" / "notes.txt").write_text("skip\n", encoding="utf-8")
+    (agents_dir / "rules" / "nested.md").mkdir()
+
+    mms_launchers._merge_agents_into_session_tree(
+        str(parent_dir),
+        str(agents_dir),
+        {"skills", "commands"},
+    )
+
+    assert os.path.islink(parent_dir / "rules")
+    assert sorted(os.listdir(parent_dir / "rules")) == [
+        "00-existing.md",
+        "10-first.md",
+        "20-second.md",
+    ]
+    assert os.path.islink(parent_dir / "rules" / "10-first.md")
+    assert os.path.islink(parent_dir / "rules" / "20-second.md")
+    assert not (parent_dir / "rules" / "notes.txt").exists()
+    assert not (parent_dir / "rules" / "nested.md").exists()
+
+
 def test_claude_gateway_env_materializes_session_ecc_assets_and_env(monkeypatch, tmp_path):
     import mms_launchers
 

--- a/tests/test_claude_hardening_regressions.py
+++ b/tests/test_claude_hardening_regressions.py
@@ -2847,6 +2847,29 @@ def test_optional_agent_rules_loader_filters_markdown_and_sorts(tmp_path):
     ]
 
 
+def test_optional_agent_rules_loader_preserves_existing_real_rules_dir(tmp_path):
+    import mms_launchers
+
+    parent_dir = tmp_path / "session" / ".claude"
+    existing_rules = parent_dir / "rules"
+    existing_rules.mkdir(parents=True)
+    existing_file = existing_rules / "00-existing.md"
+    existing_file.write_text("# existing\n", encoding="utf-8")
+
+    agents_dir = tmp_path / ".agents"
+    (agents_dir / "rules").mkdir(parents=True)
+    (agents_dir / "rules" / "10-local.md").write_text("# local\n", encoding="utf-8")
+
+    loaded = mms_launchers._merge_optional_agent_rules_into_session_tree(str(parent_dir), str(agents_dir))
+
+    assert loaded == ["10-local.md"]
+    assert existing_rules.is_dir()
+    assert not existing_rules.is_symlink()
+    assert existing_file.read_text(encoding="utf-8") == "# existing\n"
+    assert os.path.islink(existing_rules / "10-local.md")
+    assert (existing_rules / "10-local.md").read_text(encoding="utf-8") == "# local\n"
+
+
 def test_merge_agents_into_session_tree_loads_optional_agent_rules(tmp_path):
     import mms_launchers
 
@@ -2868,6 +2891,7 @@ def test_merge_agents_into_session_tree_loads_optional_agent_rules(tmp_path):
         str(parent_dir),
         str(agents_dir),
         {"skills", "commands"},
+        allow_agent_rules=True,
     )
 
     assert os.path.islink(parent_dir / "rules")
@@ -2880,6 +2904,48 @@ def test_merge_agents_into_session_tree_loads_optional_agent_rules(tmp_path):
     assert os.path.islink(parent_dir / "rules" / "20-second.md")
     assert not (parent_dir / "rules" / "notes.txt").exists()
     assert not (parent_dir / "rules" / "nested.md").exists()
+
+
+def test_prepare_claude_session_tree_skips_agent_rules_for_restricted_allowlist(monkeypatch, tmp_path):
+    import mms_launchers
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    monkeypatch.chdir(repo_dir)
+
+    raw_root = tmp_path / "project-store"
+    real_home = tmp_path / "real-home"
+    agents_rules = real_home / ".agents" / "rules"
+    agents_rules.mkdir(parents=True)
+    (agents_rules / "10-local.md").write_text("# local\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        mms_launchers,
+        "ensure_claude_project_store",
+        lambda cwd, account_id="": {"project_key": "project-key"},
+    )
+    monkeypatch.setattr(
+        mms_launchers,
+        "claude_raw_entry_path",
+        lambda entry, cwd, account_id="": raw_root / entry,
+    )
+    monkeypatch.setattr(mms_launchers, "_real_user_path", lambda *parts: str(real_home.joinpath(*parts)))
+    monkeypatch.setattr(mms_launchers, "record_claude_session_start", lambda **kwargs: None)
+    monkeypatch.setattr(mms_launchers, "write_slot_marker", lambda *args, **kwargs: None)
+
+    session_home = tmp_path / "session"
+    session_claude_dir = session_home / ".claude"
+    session_claude_dir.mkdir(parents=True)
+
+    mms_launchers._prepare_claude_session_tree(
+        str(session_home),
+        str(session_claude_dir),
+        account_id="oauth-a",
+        runtime_kind="oauth",
+        allowed_source_entries=mms_launchers._CLAUDE_OAUTH_SESSION_SOURCE_ENTRY_ALLOWLIST,
+    )
+
+    assert not (session_claude_dir / "rules").exists()
 
 
 def test_claude_gateway_env_materializes_session_ecc_assets_and_env(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- add optional `~/.agents/rules` Markdown discovery for isolated Claude session rules
- no-op when the local rules directory is missing, empty, or has no supported files
- load supported Markdown files deterministically while skipping unrelated files/directories

## Safety

- does not vendor private rule text into the repo
- does not write real `~/.config/mms/**`, credentials, accounts, or auth state
- does not change provider/account/routing/bridge/default model behavior

## Validation

- `python3 -m py_compile mms_launchers.py`
- `python3 -m pytest -q tests/test_claude_hardening_regressions.py -k 'optional_agent_rules or overlay_ecc_session_entries'` → `4 passed`
- `python3 scripts/regression_fresh_user_gate.py --quick` → `61 passed`, `fresh-user regression: PASS`
- `git diff --check`

Closes #26
