### PR TITLE
fix: bound opencode health probes

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import copy
 import inspect
 import json
+import math
 import os
 import re
 import shlex
@@ -7019,7 +7020,7 @@ def _gateway_ping_timeout(runtime=None):
         value = float(raw)
     except (TypeError, ValueError):
         return 8
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         return 8
     return min(value, 8)
 

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -7010,6 +7010,20 @@ def _seed_oauth_claude_session_settings(account_claude_dir, session_claude_dir):
     return seeded_settings
 
 
+def _gateway_ping_timeout(runtime=None):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    raw = runtime.get("gateway_health_timeout_sec")
+    if raw in (None, ""):
+        raw = 8
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 8
+    if value <= 0:
+        return 8
+    return min(value, 8)
+
+
 def _gateway_ping(base_url, api_key, runtime=None):
     """Quick connectivity check; returns True/False/None (None = can't determine)."""
     _ensure_bridge_helpers()
@@ -7033,7 +7047,7 @@ def _gateway_ping(base_url, api_key, runtime=None):
             models_url,
             runtime=runtime,
             headers=headers,
-            timeout=8,
+            timeout=_gateway_ping_timeout(runtime),
         )
         return 200 <= int(getattr(r, "status_code", 0) or 0) < 300
     except Exception:

--- a/mms_opencode_launch.py
+++ b/mms_opencode_launch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 
 
@@ -40,7 +41,7 @@ def _opencode_float_setting(runtime, env_name, runtime_keys, default, *, environ
         value = float(raw)
     except (TypeError, ValueError):
         return float(default)
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         return float(default)
     return min(value, 8.0)
 
@@ -56,9 +57,12 @@ def _opencode_int_setting(runtime, env_name, runtime_keys, default, *, environ=N
     if not raw:
         return int(default)
     try:
-        return max(0, int(raw))
+        value = int(raw)
     except (TypeError, ValueError):
         return int(default)
+    if value <= 0:
+        return int(default)
+    return value
 
 
 def _opencode_health_check_timeout(runtime, *, environ=None):
@@ -129,8 +133,6 @@ def _opencode_health_check_routes(runtime, routes, *, environ=None):
         1,
         environ=environ,
     )
-    if max_routes <= 0:
-        return []
     return unique[:max_routes]
 
 

--- a/mms_opencode_launch.py
+++ b/mms_opencode_launch.py
@@ -2,6 +2,154 @@
 
 from __future__ import annotations
 
+import os
+
+
+_FALSE_VALUES = {"0", "false", "no", "off", "disable", "disabled", "skip"}
+_TRUE_VALUES = {"1", "true", "yes", "on", "enable", "enabled"}
+_DEFAULT_OPENCODE_HEALTH_TIMEOUT_SEC = 2.0
+
+
+def _env(environ=None):
+    return os.environ if environ is None else environ
+
+
+def _opencode_health_check_enabled(runtime, *, environ=None):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    if runtime.get("skip_gateway_health_check"):
+        return False
+    raw = str(_env(environ).get("MMS_OPENCODE_HEALTHCHECK") or "").strip().lower()
+    if raw in _FALSE_VALUES:
+        return False
+    if raw in _TRUE_VALUES:
+        return True
+    return True
+
+
+def _opencode_float_setting(runtime, env_name, runtime_keys, default, *, environ=None):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    raw = str(_env(environ).get(env_name) or "").strip()
+    if not raw:
+        for key in runtime_keys:
+            if key in runtime and runtime.get(key) not in (None, ""):
+                raw = str(runtime.get(key)).strip()
+                break
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return float(default)
+    if value <= 0:
+        return float(default)
+    return min(value, 8.0)
+
+
+def _opencode_int_setting(runtime, env_name, runtime_keys, default, *, environ=None):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    raw = str(_env(environ).get(env_name) or "").strip()
+    if not raw:
+        for key in runtime_keys:
+            if key in runtime and runtime.get(key) not in (None, ""):
+                raw = str(runtime.get(key)).strip()
+                break
+    if not raw:
+        return int(default)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _opencode_health_check_timeout(runtime, *, environ=None):
+    return _opencode_float_setting(
+        runtime,
+        "MMS_OPENCODE_HEALTHCHECK_TIMEOUT",
+        ("opencode_health_check_timeout_sec", "gateway_health_timeout_sec"),
+        _DEFAULT_OPENCODE_HEALTH_TIMEOUT_SEC,
+        environ=environ,
+    )
+
+
+def _opencode_route_health_key(route):
+    protocol = str(route.get("protocol") or "openai_chat_completions").strip()
+    route_base_url = route.get("anthropic_base_url") if protocol == "anthropic_messages" else route.get("openai_base_url")
+    return (route.get("provider_id"), protocol, route_base_url)
+
+
+def _opencode_ordered_unique_routes(runtime, routes):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    routes = [route for route in (routes or []) if isinstance(route, dict)]
+    if len(routes) <= 1:
+        return routes
+
+    by_id = {}
+    for route in routes:
+        route_id = str(route.get("id") or "").strip()
+        if route_id and route_id not in by_id:
+            by_id[route_id] = route
+
+    ordered = []
+    preferred_ids = []
+    default_route_key = str(runtime.get("opencode_default_route_key") or "").strip()
+    if default_route_key:
+        preferred_ids.append(default_route_key)
+    configured = runtime.get("opencode_launch_fallback_route_keys")
+    if isinstance(configured, str):
+        configured = [configured]
+    if isinstance(configured, (list, tuple)):
+        preferred_ids.extend(str(item or "").strip() for item in configured)
+    for route_id in preferred_ids:
+        route = by_id.get(route_id)
+        if route is not None and route not in ordered:
+            ordered.append(route)
+    for route in routes:
+        if route not in ordered:
+            ordered.append(route)
+
+    unique = []
+    seen = set()
+    for route in ordered:
+        key = _opencode_route_health_key(route)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(route)
+    return unique
+
+
+def _opencode_health_check_routes(runtime, routes, *, environ=None):
+    unique = _opencode_ordered_unique_routes(runtime, routes)
+    if len(unique) <= 1:
+        return unique
+    max_routes = _opencode_int_setting(
+        runtime,
+        "MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES",
+        ("opencode_health_check_max_routes",),
+        1,
+        environ=environ,
+    )
+    if max_routes <= 0:
+        return []
+    return unique[:max_routes]
+
+
+def _opencode_route_health_runtime(runtime, route, *, timeout_sec):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    health_runtime = dict(runtime)
+    protocol = str(route.get("protocol") or "openai_chat_completions").strip()
+    health_runtime["id"] = route.get("provider_id") or health_runtime.get("id")
+    if protocol == "anthropic_messages":
+        health_runtime["openai_base_url"] = ""
+        health_runtime["anthropic_base_url"] = route.get("anthropic_base_url") or health_runtime.get("anthropic_base_url")
+    else:
+        health_runtime["openai_base_url"] = route.get("openai_base_url") or health_runtime.get("openai_base_url")
+        health_runtime["anthropic_base_url"] = ""
+    health_runtime["api_key"] = route.get("api_key") or health_runtime.get("api_key")
+    health_runtime["gateway_health_timeout_sec"] = timeout_sec
+    health_runtime["gateway_health_source"] = "opencode"
+    return health_runtime
+
 
 def opencode_gateway_health_check(
     runtime,
@@ -12,29 +160,21 @@ def opencode_gateway_health_check(
     gateway_health_check,
 ):
     runtime = runtime if isinstance(runtime, dict) else {}
+    if not _opencode_health_check_enabled(runtime):
+        return
+    timeout_sec = _opencode_health_check_timeout(runtime)
     routes = runtime_routes(runtime, resolve_model(runtime))
-    if len(routes) > 1:
-        seen = set()
-        for route in routes:
-            protocol = str(route.get("protocol") or "openai_chat_completions").strip()
-            route_base_url = route.get("anthropic_base_url") if protocol == "anthropic_messages" else route.get("openai_base_url")
-            key = (route.get("provider_id"), protocol, route_base_url)
-            if key in seen:
-                continue
-            seen.add(key)
-            health_runtime = dict(runtime)
-            health_runtime["id"] = route.get("provider_id") or health_runtime.get("id")
-            if protocol == "anthropic_messages":
-                health_runtime["openai_base_url"] = ""
-                health_runtime["anthropic_base_url"] = route.get("anthropic_base_url") or health_runtime.get("anthropic_base_url")
-            else:
-                health_runtime["openai_base_url"] = route.get("openai_base_url") or health_runtime.get("openai_base_url")
-                health_runtime["anthropic_base_url"] = ""
-            health_runtime["api_key"] = route.get("api_key") or health_runtime.get("api_key")
-            gateway_health_check(health_runtime)
+    checked_routes = _opencode_health_check_routes(runtime, routes)
+    if checked_routes:
+        for route in checked_routes:
+            gateway_health_check(_opencode_route_health_runtime(runtime, route, timeout_sec=timeout_sec))
+        return
+    if routes:
         return
     health_runtime = dict(runtime)
     health_runtime["openai_base_url"] = provider_base_url(runtime)
+    health_runtime["gateway_health_timeout_sec"] = timeout_sec
+    health_runtime["gateway_health_source"] = "opencode"
     gateway_health_check(health_runtime)
 
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1115,6 +1115,66 @@ def test_opencode_health_check_can_probe_more_routes_with_short_timeout(monkeypa
     assert calls[1]["anthropic_base_url"] == "https://fallback.example/v1"
 
 
+def test_opencode_health_check_max_routes_zero_falls_back_to_default(monkeypatch):
+    import mms_opencode_launch
+
+    monkeypatch.setenv("MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES", "0")
+    calls = []
+    routes = [
+        {
+            "id": "builder_primary",
+            "provider_id": "primary",
+            "protocol": "openai_responses",
+            "openai_base_url": "https://primary.example/v1",
+            "api_key": "sk-primary",
+            "model": "gpt-5.4",
+        },
+        {
+            "id": "builder_fallback",
+            "provider_id": "fallback",
+            "protocol": "anthropic_messages",
+            "anthropic_base_url": "https://fallback.example/v1",
+            "api_key": "sk-fallback",
+            "model": "gpt-5.5",
+        },
+    ]
+
+    mms_opencode_launch.opencode_gateway_health_check(
+        {"model": "gpt-5.4", "opencode_default_route_key": "builder_primary"},
+        runtime_routes=lambda _runtime, _model: routes,
+        resolve_model=lambda runtime: runtime.get("model"),
+        provider_base_url=lambda _runtime: "https://default.example/v1",
+        gateway_health_check=lambda runtime: calls.append(runtime),
+    )
+
+    assert [call["id"] for call in calls] == ["primary"]
+
+
+def test_opencode_health_check_nan_timeout_falls_back_to_default(monkeypatch):
+    import mms_opencode_launch
+
+    monkeypatch.setenv("MMS_OPENCODE_HEALTHCHECK_TIMEOUT", "nan")
+    calls = []
+
+    mms_opencode_launch.opencode_gateway_health_check(
+        {"model": "gpt-5.4"},
+        runtime_routes=lambda _runtime, _model: [
+            {
+                "id": "builder_primary",
+                "provider_id": "primary",
+                "openai_base_url": "https://primary.example/v1",
+                "api_key": "sk-primary",
+                "model": "gpt-5.4",
+            }
+        ],
+        resolve_model=lambda runtime: runtime.get("model"),
+        provider_base_url=lambda _runtime: "https://default.example/v1",
+        gateway_health_check=lambda runtime: calls.append(runtime),
+    )
+
+    assert calls[0]["gateway_health_timeout_sec"] == 2.0
+
+
 def test_opencode_health_check_env_can_disable_probe(monkeypatch):
     import mms_opencode_launch
 
@@ -1163,6 +1223,29 @@ def test_gateway_ping_uses_runtime_health_timeout(monkeypatch):
 
     assert ok is True
     assert captured["timeout"] == 1.25
+
+
+def test_gateway_ping_nan_timeout_falls_back_to_default(monkeypatch):
+    import mms_launchers
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+    def fake_request(method, url, runtime=None, headers=None, timeout=None):
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(mms_launchers, "_runtime_httpx_request", fake_request)
+    monkeypatch.setattr(mms_launchers, "_build_gateway_url", lambda base_url, path: f"{base_url.rstrip('/')}{path}")
+
+    assert mms_launchers._gateway_ping(
+        "https://gateway.example/v1",
+        "sk-test",
+        runtime={"gateway_health_timeout_sec": "nan"},
+    ) is True
+    assert captured["timeout"] == 8
 
 
 def test_core_opencode_lite_pro_orchestrated_delegates_to_executor_chain(monkeypatch):

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1029,6 +1029,142 @@ def test_opencode_lite_pro_preflight_is_opt_in(monkeypatch):
     assert mms_launchers._opencode_launch_preflight_enabled(runtime) is True
 
 
+def test_opencode_health_check_uses_primary_route_only_by_default(monkeypatch):
+    import mms_opencode_launch
+
+    monkeypatch.delenv("MMS_OPENCODE_HEALTHCHECK", raising=False)
+    monkeypatch.delenv("MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES", raising=False)
+    monkeypatch.delenv("MMS_OPENCODE_HEALTHCHECK_TIMEOUT", raising=False)
+    calls = []
+    routes = [
+        {
+            "id": "builder_primary",
+            "provider_id": "primary",
+            "protocol": "openai_responses",
+            "openai_base_url": "https://primary.example/v1",
+            "api_key": "sk-primary",
+            "model": "gpt-5.4",
+        },
+        {
+            "id": "builder_fallback",
+            "provider_id": "fallback",
+            "protocol": "anthropic_messages",
+            "anthropic_base_url": "https://fallback.example/v1",
+            "api_key": "sk-fallback",
+            "model": "gpt-5.5",
+        },
+    ]
+
+    mms_opencode_launch.opencode_gateway_health_check(
+        {
+            "model": "gpt-5.4",
+            "opencode_default_route_key": "builder_primary",
+            "opencode_launch_fallback_route_keys": ["builder_primary", "builder_fallback"],
+        },
+        runtime_routes=lambda _runtime, _model: routes,
+        resolve_model=lambda runtime: runtime.get("model"),
+        provider_base_url=lambda _runtime: "https://default.example/v1",
+        gateway_health_check=lambda runtime: calls.append(runtime),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["id"] == "primary"
+    assert calls[0]["openai_base_url"] == "https://primary.example/v1"
+    assert calls[0]["anthropic_base_url"] == ""
+    assert calls[0]["gateway_health_timeout_sec"] == 2.0
+    assert calls[0]["gateway_health_source"] == "opencode"
+
+
+def test_opencode_health_check_can_probe_more_routes_with_short_timeout(monkeypatch):
+    import mms_opencode_launch
+
+    monkeypatch.setenv("MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES", "2")
+    monkeypatch.setenv("MMS_OPENCODE_HEALTHCHECK_TIMEOUT", "0.5")
+    calls = []
+    routes = [
+        {
+            "id": "builder_primary",
+            "provider_id": "primary",
+            "protocol": "openai_responses",
+            "openai_base_url": "https://primary.example/v1",
+            "api_key": "sk-primary",
+            "model": "gpt-5.4",
+        },
+        {
+            "id": "builder_fallback",
+            "provider_id": "fallback",
+            "protocol": "anthropic_messages",
+            "anthropic_base_url": "https://fallback.example/v1",
+            "api_key": "sk-fallback",
+            "model": "gpt-5.5",
+        },
+    ]
+
+    mms_opencode_launch.opencode_gateway_health_check(
+        {"model": "gpt-5.4", "opencode_default_route_key": "builder_primary"},
+        runtime_routes=lambda _runtime, _model: routes,
+        resolve_model=lambda runtime: runtime.get("model"),
+        provider_base_url=lambda _runtime: "https://default.example/v1",
+        gateway_health_check=lambda runtime: calls.append(runtime),
+    )
+
+    assert [call["id"] for call in calls] == ["primary", "fallback"]
+    assert calls[0]["gateway_health_timeout_sec"] == 0.5
+    assert calls[1]["gateway_health_timeout_sec"] == 0.5
+    assert calls[1]["openai_base_url"] == ""
+    assert calls[1]["anthropic_base_url"] == "https://fallback.example/v1"
+
+
+def test_opencode_health_check_env_can_disable_probe(monkeypatch):
+    import mms_opencode_launch
+
+    monkeypatch.setenv("MMS_OPENCODE_HEALTHCHECK", "0")
+    calls = []
+
+    mms_opencode_launch.opencode_gateway_health_check(
+        {"model": "gpt-5.4"},
+        runtime_routes=lambda _runtime, _model: [
+            {
+                "id": "builder_primary",
+                "provider_id": "primary",
+                "openai_base_url": "https://primary.example/v1",
+                "api_key": "sk-primary",
+                "model": "gpt-5.4",
+            }
+        ],
+        resolve_model=lambda runtime: runtime.get("model"),
+        provider_base_url=lambda _runtime: "https://default.example/v1",
+        gateway_health_check=lambda runtime: calls.append(runtime),
+    )
+
+    assert calls == []
+
+
+def test_gateway_ping_uses_runtime_health_timeout(monkeypatch):
+    import mms_launchers
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+    def fake_request(method, url, runtime=None, headers=None, timeout=None):
+        captured.update({"method": method, "url": url, "timeout": timeout})
+        return FakeResponse()
+
+    monkeypatch.setattr(mms_launchers, "_runtime_httpx_request", fake_request)
+    monkeypatch.setattr(mms_launchers, "_build_gateway_url", lambda base_url, path: f"{base_url.rstrip('/')}{path}")
+
+    ok = mms_launchers._gateway_ping(
+        "https://gateway.example/v1",
+        "sk-test",
+        runtime={"gateway_health_timeout_sec": 1.25},
+    )
+
+    assert ok is True
+    assert captured["timeout"] == 1.25
+
+
 def test_core_opencode_lite_pro_orchestrated_delegates_to_executor_chain(monkeypatch):
     import mms_core
     import mms_launchers


### PR DESCRIPTION
## What changed

- Bound OpenCode launch health checks for multi-route profiles to the selected/default route by default.
- Added OpenCode-specific health probe controls:
  - `MMS_OPENCODE_HEALTHCHECK=0` disables the launch health check.
  - `MMS_OPENCODE_HEALTHCHECK_TIMEOUT` overrides the OpenCode health timeout, capped at 8s.
  - `MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES` opts into probing more than the default route.
- Clarified setting semantics after committee review:
  - `MMS_OPENCODE_HEALTHCHECK_MAX_ROUTES` only accepts positive route counts.
  - `0`, negative, or invalid route counts fall back to the default `1` route instead of silently disabling checks.
  - `nan` / non-finite health timeout values fall back to safe defaults.
- Kept the shared gateway health default at 8s for non-OpenCode callers while allowing runtime-specific timeout overrides.
- Added targeted regression coverage for default route-only probing, opt-in multi-route probing, `MAX_ROUTES=0`, bypass, timeout forwarding, and `nan` timeout fallback.

## Why

`mmf opencode --profile committee` can resolve multiple launch routes. Before this patch, OpenCode startup health checks serially probed each route before the actual OpenCode CLI appeared. With the shared 8s `/models` timeout, a cache miss or slow upstream could turn into visible `N * timeout` startup delay.

Committee review then identified an ambiguous `MAX_ROUTES=0` edge case. This PR now makes the disable path explicit: use `MMS_OPENCODE_HEALTHCHECK=0`; `MAX_ROUTES` is only a positive route-count setting.

## Validation

- `git diff --check`
- `python3 -m py_compile mms_opencode_launch.py mms_launchers.py tests/test_opencode_launcher.py`
- Targeted pytest after initial patch: 10 passed
- Targeted pytest after committee follow-up: 13 passed
- `python3 scripts/regression_fresh_user_gate.py`: 368 passed, fresh-user regression PASS
- Review Hub / MMF dispatch before follow-up: qwen3.7-max, kimi-k2.6, MiniMax-M3 all complete; aggregate `ok=true`, `reviewers_incomplete=0`
- Committee Gate mode after PR publication: 4 modify / 1 approve / 0 veto; follow-up commit addresses the reported `MAX_ROUTES=0` and `nan` timeout issues.

Known unrelated issue:

- Full `python3 -m pytest -q tests/test_opencode_launcher.py` currently has one unrelated MiMo attachment expectation failure: `test_core_opencode_lite_pro_builds_multi_model_roster`.

Fixes #31
