### PR TITLE
feat: add OpenCode debate profile

### DIFF
--- a/mms_core.py
+++ b/mms_core.py
@@ -124,6 +124,7 @@ from mms_opencode_profiles import (
     OPENCODE_AGENT_PROFILE_ID as _OPENCODE_AGENT_PROFILE_ID,
     OPENCODE_BASE_PROFILE_OPTIONS as _OPENCODE_BASE_PROFILE_OPTIONS,
     OPENCODE_COMMITTEE_PROFILE_ID as _OPENCODE_COMMITTEE_PROFILE_ID,
+    OPENCODE_DEBATE_PROFILE_ID as _OPENCODE_DEBATE_PROFILE_ID,
     OPENCODE_DEFAULT_MODEL_PREFERENCES as _OPENCODE_DEFAULT_MODEL_PREFERENCES,
     OPENCODE_DEFAULT_PROFILE_ID as _OPENCODE_DEFAULT_PROFILE_ID,
     OPENCODE_LITE_PRO_ORCHESTRATED_EXTRA_SPECS as _OPENCODE_LITE_PRO_ORCHESTRATED_EXTRA_SPECS,
@@ -10293,6 +10294,7 @@ _OPENCODE_REVIEW_DEFAULT_TOKENS = ("qwen", "kimi", "glm", "deepseek", "mimo")
 _OPENCODE_REVIEW_DOMESTIC_TOKENS = ("qwen", "kimi", "glm", "minimax", "deepseek", "mimo")
 _OPENCODE_COMMITTEE_DEFAULT_TOKENS = ("gpt-5.4",)
 _OPENCODE_COMMITTEE_OPTION_TOKENS = ("gpt-5.4", "gpt-5.5", "deepseek", "glm", "mimo", "kimi", "minimax")
+_OPENCODE_DEBATE_DEFAULT_TOKENS = ("gpt-5.4", "gpt-5.5", "deepseek")
 _OPENCODE_REVIEW_BASE_REVIEWER_AGENTS = (
     "review-qwen",
     "review-kimi",
@@ -11359,6 +11361,149 @@ def _opencode_committee_tui_options(cfg, default_provider, default_models):
     return pool
 
 
+def _opencode_debate_config(cfg):
+    opencode = cfg.get("opencode") if isinstance(cfg, dict) and isinstance(cfg.get("opencode"), dict) else {}
+    debate = opencode.get("debate") if isinstance(opencode.get("debate"), dict) else {}
+    return debate
+
+
+def _opencode_debate_saved_model_tokens(cfg):
+    debate = _opencode_debate_config(cfg)
+    for key in ("models", "model_tokens", "selected_models"):
+        tokens = _split_opencode_review_model_tokens(debate.get(key))
+        if tokens:
+            return tokens
+    opencode = cfg.get("opencode") if isinstance(cfg, dict) and isinstance(cfg.get("opencode"), dict) else {}
+    return _split_opencode_review_model_tokens(opencode.get("debate_models"))
+
+
+def _opencode_debate_saved_agent_ids(cfg):
+    debate = _opencode_debate_config(cfg)
+    agents = debate.get("selected_agents")
+    if not isinstance(agents, (list, tuple)):
+        return []
+    return [str(agent_id or "").strip() for agent_id in agents if str(agent_id or "").strip()]
+
+
+def _opencode_debate_saved_host_model(cfg):
+    debate = _opencode_debate_config(cfg)
+    host = debate.get("host") if isinstance(debate.get("host"), dict) else {}
+    for value in (
+        host.get("model"),
+        host.get("primary_model"),
+        debate.get("host_model"),
+    ):
+        text = str(value or "").strip()
+        if text:
+            return text
+    for value in (host.get("primary_models"), host.get("models")):
+        models = _split_opencode_review_model_tokens(value)
+        if models:
+            return models[0]
+    return ""
+
+
+def _opencode_debate_saved_host_selection(cfg):
+    debate = _opencode_debate_config(cfg)
+    host = debate.get("host") if isinstance(debate.get("host"), dict) else {}
+    roster_entry = _opencode_agent_roster_config(cfg).get("debate-host")
+    if not isinstance(roster_entry, dict):
+        roster_entry = {}
+    model = _opencode_debate_saved_host_model(cfg) or str(roster_entry.get("model") or "").strip() or "gpt-5.4"
+    selection = {"model": model}
+    provider_id = str(host.get("provider_id") or roster_entry.get("provider_id") or "").strip()
+    if provider_id:
+        selection["provider_id"] = provider_id
+    return selection
+
+
+def _resolve_opencode_debate_models(cfg, default_provider, default_models, tokens):
+    return _resolve_opencode_committee_models(cfg, default_provider, default_models, tokens)
+
+
+def _opencode_debate_agent_id_for_model(model_name, existing):
+    base = f"debate-{_opencode_review_slug(model_name)}"
+    agent_id = base
+    suffix = 2
+    while agent_id in existing:
+        agent_id = f"{base}-{suffix}"
+        suffix += 1
+    existing.add(agent_id)
+    return agent_id
+
+
+def _inject_opencode_debate_roster(cfg, selected_models, tokens, *, host_model="", host_selection=None):
+    next_cfg = copy.deepcopy(cfg)
+    opencode = next_cfg.setdefault("opencode", {})
+    if not isinstance(opencode, dict):
+        opencode = {}
+        next_cfg["opencode"] = opencode
+    roster = opencode.setdefault("agent_roster", {})
+    if not isinstance(roster, dict):
+        roster = {}
+        opencode["agent_roster"] = roster
+
+    for agent_id in list(roster):
+        if str(agent_id).startswith("debate-") and agent_id not in {"debate-host", "debate-host-pro"}:
+            entry = roster.get(agent_id) if isinstance(roster.get(agent_id), dict) else {}
+            entry = dict(entry)
+            entry["enabled"] = False
+            roster[agent_id] = entry
+
+    existing = set(roster)
+    selected_agents = []
+    resolved_models = []
+    for index, item in enumerate(selected_models):
+        model_name = str(item.get("model") or "").strip()
+        if not model_name:
+            continue
+        agent_id = _opencode_debate_agent_id_for_model(model_name, existing)
+        lower = model_name.lower()
+        entry = {
+            "enabled": True,
+            "custom": True,
+            "preset": "reviewer",
+            "model": model_name,
+            "priority": 350 + index,
+            "description": f"Debate member for {model_name}",
+        }
+        provider_id = str(item.get("provider_id") or "").strip()
+        if provider_id:
+            entry["provider_id"] = provider_id
+        if lower.startswith("mimo-"):
+            entry["route_policy"] = "mimo_direct"
+        roster[agent_id] = entry
+        selected_agents.append(agent_id)
+        resolved_models.append(model_name)
+
+    debate = opencode.setdefault("debate", {})
+    if not isinstance(debate, dict):
+        debate = {}
+        opencode["debate"] = debate
+    if host_selection is None and host_model:
+        host_selection = {"model": str(host_model).strip()}
+    resolved_host_model = _opencode_selection_model(host_selection) or str(host_model or "").strip()
+    if resolved_host_model:
+        host_payload = {"model": resolved_host_model}
+        host_provider = _opencode_selection_provider_id(host_selection)
+        if host_provider:
+            host_payload["provider_id"] = host_provider
+        debate["host"] = host_payload
+        host_entry = dict(roster.get("debate-host") if isinstance(roster.get("debate-host"), dict) else {})
+        host_entry.update({"enabled": True, "model": resolved_host_model})
+        if host_provider:
+            host_entry["provider_id"] = host_provider
+        roster["debate-host"] = host_entry
+    debate["models"] = list(tokens)
+    debate["selected_agents"] = selected_agents
+    debate["resolved_models"] = resolved_models
+    return next_cfg
+
+
+def _opencode_debate_tui_options(cfg, default_provider, default_models):
+    return _opencode_committee_tui_options(cfg, default_provider, default_models)
+
+
 def _select_opencode_host_model_tui(cfg, default_provider, default_models, *, saved_selection, title):
     saved_selection = dict(saved_selection or {})
     saved_model = str(saved_selection.get("model") or "gpt-5.4").strip() or "gpt-5.4"
@@ -11621,6 +11766,209 @@ def _prepare_opencode_committee_profile_config(
     if resolved_host_model:
         console.print(f"[green]Committee host:[/green] {resolved_host_model}")
     console.print(f"[green]Committee members:[/green] {selected_text}")
+    return next_cfg, {
+        "host": resolved_host_model,
+        "host_token": host_token,
+        "tokens": tokens,
+        "selected": selected,
+        "unresolved": unresolved,
+        "unresolved_host": unresolved_host,
+        "source": source,
+    }
+
+
+def _select_opencode_debate_host_tui(cfg, default_provider, default_models):
+    selection = _opencode_debate_saved_host_selection(cfg)
+    return _select_opencode_host_model_tui(
+        cfg,
+        default_provider,
+        default_models,
+        saved_selection=selection,
+        title="OpenCode Debate host",
+    )
+
+
+def _select_opencode_debate_models_tui(cfg, default_provider, default_models):
+    options = _opencode_debate_tui_options(cfg, default_provider, default_models)
+    if not options:
+        console.print("[yellow]没有可用于 OpenCode debate 的模型池；将只尝试 debate host。[/yellow]")
+        return []
+    saved_tokens = _opencode_debate_saved_model_tokens(cfg)
+    default_tokens = saved_tokens or list(_OPENCODE_DEBATE_DEFAULT_TOKENS)
+    if saved_tokens:
+        selected_models = _opencode_saved_model_selections(
+            cfg,
+            saved_tokens,
+            prefix="debate-",
+            agent_ids=_opencode_debate_saved_agent_ids(cfg),
+        )
+    else:
+        selected, _unresolved = _resolve_opencode_debate_models(cfg, default_provider, default_models, default_tokens)
+        selected_models = _opencode_enrich_selected_with_saved_providers(selected, cfg, prefix="debate-")
+    options = _opencode_with_saved_selection_options(cfg, options, selected_models)
+    try:
+        from mms_tui import select_review_models_tui
+    except Exception:
+        return selected_models
+    return select_review_models_tui(
+        options,
+        selected_models=selected_models,
+        title="OpenCode Debate members",
+        return_provider=True,
+    )
+
+
+def _save_opencode_debate_model_tokens(cfg, tokens, *, host_model="", host_selection=None, selected_models=None):
+    base_cfg = cfg
+    if _preview_root_mode():
+        try:
+            loaded_cfg = _load_toml_file(_config_write_target_path())
+        except Exception:
+            loaded_cfg = None
+        if isinstance(loaded_cfg, dict):
+            base_cfg = loaded_cfg
+    next_cfg = copy.deepcopy(base_cfg)
+    opencode = next_cfg.setdefault("opencode", {})
+    if not isinstance(opencode, dict):
+        opencode = {}
+        next_cfg["opencode"] = opencode
+    debate = opencode.setdefault("debate", {})
+    if not isinstance(debate, dict):
+        debate = {}
+        opencode["debate"] = debate
+    debate["models"] = list(tokens)
+    if host_selection is None and host_model:
+        host_selection = {"model": str(host_model).strip()}
+    resolved_host_model = _opencode_selection_model(host_selection) or str(host_model or "").strip()
+    if resolved_host_model:
+        host_payload = {"model": resolved_host_model}
+        host_provider = _opencode_selection_provider_id(host_selection)
+        if host_provider:
+            host_payload["provider_id"] = host_provider
+        debate["host"] = host_payload
+    if selected_models or host_selection or host_model:
+        next_cfg = _inject_opencode_debate_roster(
+            next_cfg,
+            selected_models or [],
+            tokens,
+            host_model=resolved_host_model,
+            host_selection=host_selection,
+        )
+    save_config(next_cfg, reason="opencode:save_debate_models")
+    return next_cfg
+
+
+def _prepare_opencode_debate_profile_config(
+    cfg,
+    default_provider,
+    default_models,
+    *,
+    host_model=None,
+    model_tokens=None,
+    interactive=False,
+    save_selected=False,
+    save_cfg=None,
+    ask_to_save=False,
+):
+    explicit_host_entry = _opencode_model_selection_entries(host_model)
+    explicit_host = _opencode_selection_model(explicit_host_entry[0]) if explicit_host_entry else str(host_model or "").strip()
+    saved_host = _opencode_debate_saved_host_model(cfg)
+    host_token = explicit_host or saved_host or "gpt-5.4"
+    explicit_entries = _opencode_model_selection_entries(model_tokens)
+    explicit_tokens = [item["model"] for item in explicit_entries] if explicit_entries else _split_opencode_review_model_tokens(model_tokens)
+    saved_tokens = _opencode_debate_saved_model_tokens(cfg)
+    tokens = explicit_tokens or saved_tokens or list(_OPENCODE_DEBATE_DEFAULT_TOKENS)
+    source = "cli" if explicit_tokens else ("saved" if saved_tokens else "default")
+
+    if interactive and not explicit_host and not saved_host:
+        _ensure_rich()
+        host_token = Prompt.ask(
+            "Debate host model（默认 gpt-5.4；可填 gpt-5.5 或任意可用模型）",
+            default="gpt-5.4",
+        ).strip() or "gpt-5.4"
+
+    if explicit_host_entry:
+        selected_host = explicit_host_entry
+        unresolved_host = []
+        resolved_host_model = explicit_host
+    else:
+        selected_host, unresolved_host = _resolve_opencode_debate_models(cfg, default_provider, default_models, [host_token])
+        resolved_host_model = selected_host[0]["model"] if selected_host else ""
+    host_selection = explicit_host_entry[0] if explicit_host_entry else ({"model": resolved_host_model} if resolved_host_model else None)
+    if unresolved_host:
+        console.print(f"[yellow]Debate host 未解析: {host_token}；将使用 profile 默认 host。[/yellow]")
+
+    if interactive and not explicit_tokens and not saved_tokens:
+        _ensure_rich()
+        default_text = " ".join(_OPENCODE_DEBATE_DEFAULT_TOKENS)
+        answer = Prompt.ask(
+            "Debate models（空格/逗号分隔；支持 gpt-5.4、gpt-5.5、deepseek、glm、mimo、kimi、minimax、domestic、all）",
+            default=default_text,
+        )
+        tokens = _split_opencode_review_model_tokens(answer) or list(_OPENCODE_DEBATE_DEFAULT_TOKENS)
+        source = "prompt"
+
+    if explicit_entries:
+        selected = [
+            {
+                **entry,
+                "family": entry.get("family") or _infer_model_family(entry.get("model"))[0],
+                "token": entry.get("model"),
+            }
+            for entry in explicit_entries
+        ]
+        unresolved = []
+    else:
+        selected, unresolved = _resolve_opencode_debate_models(cfg, default_provider, default_models, tokens)
+        selected = _opencode_enrich_selected_with_saved_providers(
+            selected,
+            cfg,
+            prefix="debate-",
+            agent_ids=_opencode_debate_saved_agent_ids(cfg),
+        )
+    if unresolved:
+        console.print(f"[yellow]Debate models 未解析: {', '.join(unresolved)}[/yellow]")
+    if not selected:
+        return cfg, {
+            "host": resolved_host_model,
+            "host_token": host_token,
+            "tokens": tokens,
+            "selected": [],
+            "unresolved": unresolved,
+            "unresolved_host": unresolved_host,
+            "source": source,
+        }
+
+    if save_selected:
+        _save_opencode_debate_model_tokens(
+            save_cfg or cfg,
+            tokens,
+            host_model=resolved_host_model,
+            host_selection=host_selection,
+            selected_models=selected,
+        )
+    elif ask_to_save and source == "prompt":
+        _ensure_rich()
+        if Confirm.ask("保存这次 Debate models 为下次默认？", default=False):
+            _save_opencode_debate_model_tokens(
+                save_cfg or cfg,
+                tokens,
+                host_model=resolved_host_model,
+                host_selection=host_selection,
+                selected_models=selected,
+            )
+
+    next_cfg = _inject_opencode_debate_roster(
+        cfg,
+        selected,
+        tokens,
+        host_model=resolved_host_model,
+        host_selection=host_selection,
+    )
+    selected_text = ", ".join(f"{item['model']} -> debate-{_opencode_review_slug(item['model'])}" for item in selected)
+    if resolved_host_model:
+        console.print(f"[green]Debate host:[/green] {resolved_host_model}")
+    console.print(f"[green]Debate members:[/green] {selected_text}")
     return next_cfg, {
         "host": resolved_host_model,
         "host_token": host_token,
@@ -12204,6 +12552,31 @@ def _handle_tui_launcher_selection(cfg, provider, once, cli_names, account_id=No
                     model_tokens=selected_committee_models,
                     interactive=False,
                     save_selected=bool(selected_committee_models or selected_committee_host),
+                    save_cfg=current_cfg,
+                )
+            elif canonical_profile == _OPENCODE_DEBATE_PROFILE_ID:
+                selected_debate_host = _select_opencode_debate_host_tui(
+                    current_cfg,
+                    current_provider,
+                    default_models,
+                )
+                if selected_debate_host is None:
+                    continue
+                selected_debate_models = _select_opencode_debate_models_tui(
+                    current_cfg,
+                    current_provider,
+                    default_models,
+                )
+                if selected_debate_models is None:
+                    continue
+                profile_cfg, _debate_selection = _prepare_opencode_debate_profile_config(
+                    current_cfg,
+                    current_provider,
+                    default_models,
+                    host_model=selected_debate_host,
+                    model_tokens=selected_debate_models,
+                    interactive=False,
+                    save_selected=bool(selected_debate_models or selected_debate_host),
                     save_cfg=current_cfg,
                 )
             if profile_cfg is not current_cfg:
@@ -15022,13 +15395,14 @@ def _merge_preview_local_launch_preferences(cfg):
     local_opencode = local_cfg.get("opencode") if isinstance(local_cfg.get("opencode"), dict) else {}
     local_review = local_opencode.get("review") if isinstance(local_opencode.get("review"), dict) else {}
     local_committee = local_opencode.get("committee") if isinstance(local_opencode.get("committee"), dict) else {}
+    local_debate = local_opencode.get("debate") if isinstance(local_opencode.get("debate"), dict) else {}
     local_roster = local_opencode.get("agent_roster") if isinstance(local_opencode.get("agent_roster"), dict) else {}
     local_opencode_defaults = {
         key: local_opencode.get(key)
         for key in ("default_profile", "profile")
         if str(local_opencode.get(key) or "").strip()
     }
-    if not local_review and not local_committee and not local_roster and not local_opencode_defaults:
+    if not local_review and not local_committee and not local_debate and not local_roster and not local_opencode_defaults:
         return cfg
 
     next_cfg = copy.deepcopy(cfg)
@@ -15055,6 +15429,8 @@ def _merge_preview_local_launch_preferences(cfg):
             review.setdefault(key, copy.deepcopy(value))
     if local_committee:
         opencode["committee"] = copy.deepcopy(local_committee)
+    if local_debate:
+        opencode["debate"] = copy.deepcopy(local_debate)
     if local_roster:
         roster = opencode.setdefault("agent_roster", {})
         if not isinstance(roster, dict):
@@ -15065,7 +15441,8 @@ def _merge_preview_local_launch_preferences(cfg):
             if not (
                 agent_key.startswith("review-")
                 or agent_key.startswith("committee-")
-                or agent_key in {"review-hub-host", "committee-host", "committee-host-pro"}
+                or agent_key.startswith("debate-")
+                or agent_key in {"review-hub-host", "committee-host", "committee-host-pro", "debate-host", "debate-host-pro"}
             ):
                 continue
             if isinstance(entry, dict):
@@ -16683,7 +17060,7 @@ def main():
                         help="配合 --export 使用，写入 ~/.config/mms/env/<cli>.sh")
     parser.add_argument("--account", help="临时使用指定官方账号档案启动")
     parser.add_argument("--provider", help="临时使用指定模型源启动")
-    parser.add_argument("--profile", dest="opencode_profile", help="直接指定 OpenCode mode，例如 agent / review / committee / omo / raw")
+    parser.add_argument("--profile", dest="opencode_profile", help="直接指定 OpenCode mode，例如 agent / review / committee / debate / omo / raw")
     parser.add_argument(
         "--review-models",
         nargs="+",
@@ -16717,6 +17094,23 @@ def main():
         "--committee-save",
         action="store_true",
         help="把本次 --committee-host-model / --committee-models 保存为下次 committee profile 默认",
+    )
+    parser.add_argument(
+        "--debate-models",
+        nargs="+",
+        help="OpenCode debate profile 使用的成员模型/家族，支持 gpt-5.4 gpt-5.5 deepseek glm mimo kimi minimax domestic all",
+    )
+    parser.add_argument(
+        "--debate-host-model",
+        "--debate-host",
+        dest="debate_host_model",
+        help="OpenCode debate profile 使用的 host 模型，例如 gpt-5.4 / gpt-5.5 / 任意可用模型",
+    )
+    parser.add_argument(
+        "--save-debate-models",
+        "--debate-save",
+        action="store_true",
+        help="把本次 --debate-host-model / --debate-models 保存为下次 debate profile 默认",
     )
     parser.add_argument(
         "--opencode-entrypoint",
@@ -16768,6 +17162,8 @@ def main():
         parser.error("--review-host-model / --review-models / --save-review-models 仅支持 --profile review")
     if (args.committee_models or args.committee_host_model or args.save_committee_models) and requested_opencode_profile and requested_opencode_profile != _OPENCODE_COMMITTEE_PROFILE_ID:
         parser.error("--committee-host-model / --committee-models / --save-committee-models 仅支持 --profile committee")
+    if (args.debate_models or args.debate_host_model or args.save_debate_models) and requested_opencode_profile and requested_opencode_profile != _OPENCODE_DEBATE_PROFILE_ID:
+        parser.error("--debate-host-model / --debate-models / --save-debate-models 仅支持 --profile debate")
     if requested_opencode_profile and args.account:
         parser.error("--profile 是 OpenCode 专用参数，不支持同时使用 --account")
     requested_opencode_entrypoints = []
@@ -16913,6 +17309,8 @@ def main():
                 profile_to_launch = _OPENCODE_REVIEW_PROFILE_ID
             if not profile_to_launch and (args.committee_models or args.committee_host_model or args.save_committee_models):
                 profile_to_launch = _OPENCODE_COMMITTEE_PROFILE_ID
+            if not profile_to_launch and (args.debate_models or args.debate_host_model or args.save_debate_models):
+                profile_to_launch = _OPENCODE_DEBATE_PROFILE_ID
 
         if target == "opencode" and profile_to_launch:
             cli = "opencode"
@@ -16946,10 +17344,24 @@ def main():
                     save_cfg=user_cfg,
                     ask_to_save=not bool(args.committee_models or args.committee_host_model),
                 )
+            elif profile_to_launch == _OPENCODE_DEBATE_PROFILE_ID:
+                profile_cfg, _debate_selection = _prepare_opencode_debate_profile_config(
+                    cfg,
+                    profile_provider,
+                    profile_models,
+                    host_model=args.debate_host_model,
+                    model_tokens=args.debate_models,
+                    interactive=sys.stdin.isatty() and not bool(args.debate_models or args.debate_host_model),
+                    save_selected=bool(args.save_debate_models),
+                    save_cfg=user_cfg,
+                    ask_to_save=not bool(args.debate_models or args.debate_host_model),
+                )
             elif args.review_models or args.review_host_model or args.save_review_models:
                 parser.error("--review-host-model / --review-models / --save-review-models 仅支持 --profile review")
             elif args.committee_models or args.committee_host_model or args.save_committee_models:
                 parser.error("--committee-host-model / --committee-models / --save-committee-models 仅支持 --profile committee")
+            elif args.debate_models or args.debate_host_model or args.save_debate_models:
+                parser.error("--debate-host-model / --debate-models / --save-debate-models 仅支持 --profile debate")
             model_info, runtime = _resolve_opencode_profile_runtime(
                 profile_cfg,
                 profile_provider,

--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -1071,6 +1071,256 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
     return agents
 
 
+def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_policies=None):
+    """Return a debate-only roster with host-authored v1 artifacts."""
+    agent_models = agent_models if isinstance(agent_models, dict) else {}
+    roster_config = roster_config if isinstance(roster_config, dict) else {}
+    agent_policies = agent_policies if isinstance(agent_policies, dict) else {}
+    host_model = (
+        agent_models.get("debate-host")
+        or agent_models.get("debate-host-pro")
+        or next(iter(agent_models.values()), "")
+    )
+    if not host_model:
+        return {}
+
+    safe_read_bash = {
+        "*": "ask",
+        "pwd": "allow",
+        "ls *": "allow",
+        "rg *": "allow",
+        "git status*": "allow",
+        "git diff*": "allow",
+        "git log*": "allow",
+    }
+    artifact_bash = {
+        **safe_read_bash,
+        "mkdir *": "ask",
+        "cat *": "ask",
+        "python*": "ask",
+        "node *": "ask",
+    }
+    common_permissions = {
+        "read": "allow",
+        "grep": "allow",
+        "glob": "allow",
+        "list": "allow",
+    }
+    member_permission = {
+        **common_permissions,
+        "edit": "ask",
+        "bash": safe_read_bash,
+        "task": "deny",
+        "webfetch": "ask",
+        "websearch": "ask",
+        "external_directory": "ask",
+    }
+    host_permission = {
+        **common_permissions,
+        "edit": "ask",
+        "bash": artifact_bash,
+        "task": {"*": "deny"},
+        "webfetch": "ask",
+        "websearch": "ask",
+        "external_directory": "ask",
+    }
+    member_names = sorted(
+        name for name in agent_models
+        if str(name).startswith("debate-") and name not in {"debate-host", "debate-host-pro"}
+    )
+    for name in member_names:
+        host_permission["task"][name] = "allow"
+
+    def _agent_model(name, fallback=host_model):
+        return str(agent_models.get(name) or fallback or host_model)
+
+    def _merge_dict(base, override):
+        merged = dict(base or {})
+        for key, value in (override or {}).items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                merged[key] = _merge_dict(merged[key], value)
+            else:
+                merged[key] = value
+        return merged
+
+    def _agent_policy(name):
+        policy = agent_policies.get(name) if isinstance(agent_policies.get(name), dict) else {}
+        roster_entry = roster_config.get(name) if isinstance(roster_config.get(name), dict) else {}
+        roster_policy = roster_entry.get("opencode_policy")
+        if isinstance(roster_policy, dict):
+            policy = _merge_dict(policy, roster_policy)
+        return policy
+
+    def _search_tools_fallback_only(policy):
+        raw = str((policy or {}).get("builtin_search_tools") or "").strip().lower()
+        return raw in {"disabled", "deny", "off", "shell", "shell_only", "fallback_only"}
+
+    def _permission_for_agent(base_permission, policy):
+        permission = copy.deepcopy(base_permission)
+        if not _search_tools_fallback_only(policy):
+            return permission
+        for tool_name in ("grep", "glob", "list"):
+            permission[tool_name] = "deny"
+        bash_permission = permission.get("bash")
+        if isinstance(bash_permission, dict):
+            bash_permission = dict(bash_permission)
+            bash_permission.update({
+                "pwd": "allow",
+                "ls *": "allow",
+                "rg *": "allow",
+            })
+            permission["bash"] = bash_permission
+        return permission
+
+    def _prompt_with_tool_policy(prompt, policy):
+        if not _search_tools_fallback_only(policy):
+            return prompt
+        return (
+            f"{prompt} "
+            "Tool policy: do not call built-in grep/glob/list for search or file "
+            "listing on this route; use shell commands instead (`rg --files`, "
+            "`rg -n`, `ls`, `pwd`; request `find` only when needed). If a "
+            "built-in search tool returns a schema error, switch to shell fallback."
+        )
+
+    member_list_text = ", ".join(member_names) or "no debate-* subagents"
+    host_prompt = (
+        "You are debate-host for the MMS OpenCode debate profile. This profile is "
+        "not committee, not review-hub, and not legacy discuss. Do not use "
+        "committee vote files, committee verdict vocabulary, committee decision "
+        "artifacts, review-hub request roots, or legacy mms discuss semantics. "
+        "Use only the selected debate subagents available in this session: "
+        f"{member_list_text}. Do not invent missing agents or model aliases. "
+        "If the user has not supplied a concrete question, ask for one concise "
+        "debate question and a decision boundary. Otherwise start immediately. "
+        "Create one thread_id and write all durable output under "
+        "`.ai/debate/<thread-id>/`. The v1 required files are `brief.md`, "
+        "`state.json`, `round-1-seed.json`, `round-2-clusters.json`, "
+        "`round-3-crossfire.json`, `round-4-revision.json`, `resolution.json`, "
+        "and `resolution.md`. The host writes these artifacts directly; there is "
+        "no helper command or validator program in v1. "
+        "Run the v1 regulation mechanic: blind seed -> crossfire -> revision. "
+        "First, send every selected member the same compact packet and require a "
+        "blind seed with stance, claim, evidence, risks, recommended_path, "
+        "confidence, pushback, quality_gate, and provenance. Do not expose other "
+        "members' arguments during this first pass. Then write `round-2-clusters.json` "
+        "as a host-owned clustering artifact with camps, strongest evidence, and "
+        "open_conflicts. Next, run crossfire by giving each member only strongest "
+        "opposing-case summaries, not full transcripts, and require "
+        "opponent_strongest_point, my_rebuttal, what_i_accept, "
+        "what_i_still_reject, what_evidence_would_change_my_mind, quality_gate, "
+        "and provenance. Finally, request revision with final_stance, stance_shift "
+        "(unchanged|softened|switched), shift_reason, confidence, quality_gate, "
+        "and provenance. "
+        "No extra time: never auto-append more crossfire rounds after the revision "
+        "round. Golden-goal early stop is allowed only with deterministic triggers: "
+        "positive when all valid final stances are in the same camp and at least "
+        "one stance_shift is not unchanged; negative when crossfire shows every "
+        "member's what_evidence_would_change_my_mind is empty or unreachable and "
+        "there are at least two camps with high-confidence members. If an early "
+        "stop happens, still write the required artifact files; for a negative "
+        "stop after crossfire, write `round-4-revision.json` as a skipped revision "
+        "artifact with unchanged final stances and the checkable stop reason. "
+        "Record the stop reason in state and resolution. "
+        "Before writing `resolution.json`, perform the required v1 self-check from "
+        "`docs/DEBATE_STATE_RESULT_CONTRACT_v1.md` and "
+        "`docs/DEBATE_HOST_RESOLUTION_RUBRIC_v1.md`: at least 2 valid members, "
+        "all required resolution fields present, `converged` is mutually exclusive "
+        "with `conclusion_opposite`, unresolved `fix_conflict`, and "
+        "`deterministic_vs_opinion`, deterministic facts outrank model opinion, "
+        "and missing required artifacts force `insufficient_evidence` with "
+        "quality_gate=fail. Use the conservative priority order "
+        "insufficient_evidence > split_human_required > converged > leaning. "
+        "Always set `synthesis_strategy` to `host_authored` in v1 and record "
+        "`synthesized_by` and `synthesis_attempted_by` honestly. Preserve minority "
+        "pushback; never flatten disagreement into fake consensus. The final chat "
+        "reply should be compact: resolution_state, quality_gate, recommended_next_step, "
+        "key pushback, and artifact paths."
+    )
+    agents = {
+        "debate-host": {
+            "description": "Structured debate host that runs blind seed, crossfire, revision, and host-authored resolution",
+            "mode": "primary",
+            "model": _agent_model("debate-host"),
+            "variant": "high",
+            "temperature": 0.1,
+            "permission": _permission_for_agent(host_permission, _agent_policy("debate-host")),
+            "prompt": _prompt_with_tool_policy(host_prompt, _agent_policy("debate-host")),
+        },
+        "debate-host-pro": {
+            "description": "Higher-depth fallback debate host",
+            "mode": "primary",
+            "model": _agent_model("debate-host-pro"),
+            "variant": "high",
+            "temperature": 0.1,
+            "permission": _permission_for_agent(host_permission, _agent_policy("debate-host-pro")),
+            "prompt": _prompt_with_tool_policy(
+                (
+                    "Fallback debate host. Continue the same debate thread, preserve "
+                    "selected debate members, keep debate separate from committee, "
+                    "write only `.ai/debate/<thread-id>/` artifacts, enforce the "
+                    "fixed blind seed -> crossfire -> revision mechanic, apply the "
+                    "v1 self-check checklist, use host_authored synthesis only, and "
+                    "preserve real disagreement instead of claiming fake convergence."
+                ),
+                _agent_policy("debate-host-pro"),
+            ),
+        },
+    }
+
+    def _member_prompt(name, model_ref):
+        lower = f"{name} {model_ref}".lower()
+        if "deepseek" in lower:
+            lens = "counterexamples, hidden failure modes, and hard technical objections"
+        elif "glm" in lower:
+            lens = "structured logic, Chinese technical nuance, and explicit tradeoffs"
+        elif "mimo" in lower:
+            lens = "divergent critique, product risk, and multimodal/visual concerns when present"
+        elif "kimi" in lower or "k2" in lower:
+            lens = "long-context reading, repo/document evidence, and source provenance"
+        elif "minimax" in lower:
+            lens = "pragmatic alternatives, low-cost paths, and user-facing product feel"
+        elif "5.5" in lower:
+            lens = "highest-risk architecture, adversarial planning, and final-quality judgment"
+        else:
+            lens = "independent engineering judgment, implementation risk, and validation strategy"
+        return (
+            f"You are {name}, an independent debate member focused on {lens}. "
+            "You are not a committee voter and must not write committee vote files, "
+            "decision.md, or ratification markers. Do not call other agents. Do not "
+            "edit product/source files unless the user explicitly assigns a separate "
+            "implementation task; normal debate outputs go back to debate-host. "
+            "For blind seed, answer without considering other members: stance, claim, "
+            "evidence, risks, recommended_path, confidence, pushback, quality_gate, "
+            "and provenance. For crossfire, engage only the strongest opposing-case "
+            "summary provided by the host and return opponent_strongest_point, "
+            "my_rebuttal, what_i_accept, what_i_still_reject, "
+            "what_evidence_would_change_my_mind, quality_gate, and provenance. "
+            "For revision, return final_stance, stance_shift "
+            "(unchanged|softened|switched), shift_reason, confidence, quality_gate, "
+            "and provenance. Be willing to switch when evidence warrants it, but "
+            "do not soften merely to create consensus. Separate deterministic facts "
+            "from model opinion and name uncertainty plainly."
+        )
+
+    for name in member_names:
+        roster_entry = roster_config.get(name) if isinstance(roster_config.get(name), dict) else {}
+        model_ref = _agent_model(name)
+        policy = _agent_policy(name)
+        agents[name] = {
+            "description": str(roster_entry.get("description") or f"Debate member {name}"),
+            "mode": "subagent",
+            "model": model_ref,
+            "temperature": 0.1,
+            "permission": _permission_for_agent(member_permission, policy),
+            "prompt": _prompt_with_tool_policy(
+                str(roster_entry.get("prompt") or _member_prompt(name, model_ref)),
+                policy,
+            ),
+        }
+    return agents
+
+
 def opencode_permission_bypass_value(value):
     if isinstance(value, dict):
         return {
@@ -1103,6 +1353,7 @@ def opencode_apply_agent_bypass_permissions(agents):
 __all__ = [
     "opencode_apply_agent_bypass_permissions",
     "opencode_committee_agent_configs",
+    "opencode_debate_agent_configs",
     "opencode_lite_agent_configs",
     "opencode_lite_pro_agent_configs",
     "opencode_permission_bypass_value",

--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -1108,7 +1108,7 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
     }
     member_permission = {
         **common_permissions,
-        "edit": "ask",
+        "edit": "deny",
         "bash": safe_read_bash,
         "task": "deny",
         "webfetch": "ask",

--- a/mms_opencode_config.py
+++ b/mms_opencode_config.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 from mms_opencode_agents import (
     opencode_apply_agent_bypass_permissions,
     opencode_committee_agent_configs,
+    opencode_debate_agent_configs,
     opencode_lite_agent_configs,
     opencode_lite_pro_agent_configs,
     opencode_review_hub_agent_configs,
@@ -971,6 +972,12 @@ def opencode_build_config_payload(runtime, model_name="", *, context_window_reso
                     roster_config=runtime.get("opencode_agent_roster"),
                     agent_policies=opencode_agent_opencode_policies(runtime, routes),
                 )
+            elif roster == "debate":
+                payload["agent"] = opencode_debate_agent_configs(
+                    opencode_agent_model_refs(runtime, routes),
+                    roster_config=runtime.get("opencode_agent_roster"),
+                    agent_policies=opencode_agent_opencode_policies(runtime, routes),
+                )
             elif roster in {"lite_pro", "lite_pro_orchestrated"}:
                 payload["agent"] = opencode_lite_pro_agent_configs(
                     opencode_agent_model_refs(runtime, routes),
@@ -982,6 +989,8 @@ def opencode_build_config_payload(runtime, model_name="", *, context_window_reso
             payload["agent"] = opencode_apply_agent_model_variants(payload.get("agent"), runtime, routes)
             if roster == "committee" and payload.get("default_agent") not in payload.get("agent", {}):
                 payload["default_agent"] = "committee-host"
+            if roster == "debate" and payload.get("default_agent") not in payload.get("agent", {}):
+                payload["default_agent"] = "debate-host"
     if opencode_bypass_enabled(runtime):
         payload["permission"] = "allow"
         if "agent" in payload:

--- a/mms_opencode_profiles.py
+++ b/mms_opencode_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 OPENCODE_AGENT_PROFILE_ID = "lite_pro_orchestrated"
 OPENCODE_REVIEW_PROFILE_ID = "review_hub"
 OPENCODE_COMMITTEE_PROFILE_ID = "committee"
+OPENCODE_DEBATE_PROFILE_ID = "debate"
 OPENCODE_DEFAULT_PROFILE_ID = "agent"
 
 OPENCODE_PROFILE_OPTIONS = [
@@ -28,6 +29,13 @@ OPENCODE_PROFILE_OPTIONS = [
         "label": "Committee",
         "badge": "委员会",
         "summary": "通用委员会：GPT-5.4 host 默认派发给所选 subagent，最后汇总共识/分歧；默认只选 GPT-5.4，可加 GPT-5.5、DeepSeek、GLM、MiMo、Kimi、MiniMax。",
+    },
+    {
+        "id": "debate",
+        "profile_id": OPENCODE_DEBATE_PROFILE_ID,
+        "label": "Debate",
+        "badge": "辩论",
+        "summary": "结构化辩论：独立于 Committee；blind seed -> crossfire -> revision，由 debate-host 写 .ai/debate/<thread-id>/ artifacts 并按 rubric 输出 resolution。",
     },
     {
         "id": "omo",
@@ -94,6 +102,11 @@ OPENCODE_COMMITTEE_SPECS = (
     {"key": "builder_fallback", "agent": "committee-host-pro", "models": ("gpt-5.5", "gpt-5.4", "gpt-5.3-codex")},
 )
 
+OPENCODE_DEBATE_SPECS = (
+    {"key": "builder_primary", "agent": "debate-host", "models": ("gpt-5.4", "gpt-5.5", "gpt-5.3-codex")},
+    {"key": "builder_fallback", "agent": "debate-host-pro", "models": ("gpt-5.5", "gpt-5.4", "gpt-5.3-codex")},
+)
+
 
 def _opencode_model_list(value):
     if isinstance(value, str):
@@ -154,6 +167,26 @@ def opencode_committee_host_config(cfg):
     return result
 
 
+def opencode_debate_host_config(cfg):
+    cfg = cfg if isinstance(cfg, dict) else {}
+    opencode = cfg.get("opencode") if isinstance(cfg.get("opencode"), dict) else {}
+    debate = opencode.get("debate") if isinstance(opencode.get("debate"), dict) else {}
+    host = debate.get("host") if isinstance(debate.get("host"), dict) else {}
+    primary_models = _opencode_model_list(
+        host.get("primary_models")
+        or host.get("models")
+        or host.get("model")
+        or debate.get("host_model")
+    )
+    fallback_models = _opencode_model_list(host.get("fallback_models") or host.get("fallback"))
+    result = {}
+    if primary_models:
+        result["primary_models"] = primary_models
+    if fallback_models:
+        result["fallback_models"] = fallback_models
+    return result
+
+
 def opencode_lite_pro_specs_for_config(cfg, profile_id=OPENCODE_AGENT_PROFILE_ID):
     specs = [dict(spec) for spec in opencode_lite_pro_specs(profile_id)]
     normalized_profile = normalize_opencode_profile_id(profile_id)
@@ -161,6 +194,8 @@ def opencode_lite_pro_specs_for_config(cfg, profile_id=OPENCODE_AGENT_PROFILE_ID
         host = opencode_review_host_config(cfg)
     elif normalized_profile == OPENCODE_COMMITTEE_PROFILE_ID:
         host = opencode_committee_host_config(cfg)
+    elif normalized_profile == OPENCODE_DEBATE_PROFILE_ID:
+        host = opencode_debate_host_config(cfg)
     else:
         return tuple(specs)
     if not host:
@@ -201,6 +236,9 @@ def normalize_opencode_profile_id(value):
         "council": OPENCODE_COMMITTEE_PROFILE_ID,
         "board": OPENCODE_COMMITTEE_PROFILE_ID,
         "multi_committee": OPENCODE_COMMITTEE_PROFILE_ID,
+        "debate": OPENCODE_DEBATE_PROFILE_ID,
+        "debates": OPENCODE_DEBATE_PROFILE_ID,
+        "structured_debate": OPENCODE_DEBATE_PROFILE_ID,
         # Legacy pro spellings now fold into the single Agent profile.
         "pro": OPENCODE_AGENT_PROFILE_ID,
         "pro_solo": OPENCODE_AGENT_PROFILE_ID,
@@ -258,6 +296,7 @@ def opencode_profile_selection(value):
         "review_backend": (OPENCODE_REVIEW_PROFILE_ID, "serve"),
         "review_hub_backend": (OPENCODE_REVIEW_PROFILE_ID, "serve"),
         "committee_backend": (OPENCODE_COMMITTEE_PROFILE_ID, "serve"),
+        "debate_backend": (OPENCODE_DEBATE_PROFILE_ID, "serve"),
         "acp_multi": (OPENCODE_AGENT_PROFILE_ID, "acp"),
         "multi_acp": (OPENCODE_AGENT_PROFILE_ID, "acp"),
         "multi_agent_acp": (OPENCODE_AGENT_PROFILE_ID, "acp"),
@@ -266,6 +305,7 @@ def opencode_profile_selection(value):
         "review_acp": (OPENCODE_REVIEW_PROFILE_ID, "acp"),
         "review_hub_acp": (OPENCODE_REVIEW_PROFILE_ID, "acp"),
         "committee_acp": (OPENCODE_COMMITTEE_PROFILE_ID, "acp"),
+        "debate_acp": (OPENCODE_DEBATE_PROFILE_ID, "acp"),
     }
     if normalized in aliases:
         return aliases[normalized]
@@ -292,6 +332,8 @@ def opencode_lite_pro_specs(profile_id=OPENCODE_AGENT_PROFILE_ID):
         return OPENCODE_REVIEW_HUB_SPECS
     if normalized_profile == OPENCODE_COMMITTEE_PROFILE_ID:
         return OPENCODE_COMMITTEE_SPECS
+    if normalized_profile == OPENCODE_DEBATE_PROFILE_ID:
+        return OPENCODE_DEBATE_SPECS
     specs = list(OPENCODE_LITE_PRO_SPECS)
     if normalized_profile == "lite_pro_orchestrated":
         insert_at = next(
@@ -376,6 +418,22 @@ def apply_opencode_profile(runtime, profile_id):
             "builder_primary": "committee-host",
             "builder_fallback": "committee-host-pro",
         }
+    elif profile_id == OPENCODE_DEBATE_PROFILE_ID:
+        runtime["opencode_use_global_config"] = False
+        runtime["opencode_pure"] = True
+        runtime["opencode_lite_agents"] = True
+        runtime["opencode_agent"] = "debate-host"
+        runtime["opencode_default_agent"] = "debate-host"
+        runtime["opencode_roster"] = profile_id
+        runtime["opencode_contract_workflow"] = "debate"
+        runtime["opencode_backend_agent_capable"] = True
+        runtime["opencode_acp_capable"] = True
+        runtime["opencode_launch_preflight"] = False
+        runtime["opencode_launch_fallback_route_keys"] = ["builder_primary", "builder_fallback"]
+        runtime["opencode_launch_fallback_agents"] = {
+            "builder_primary": "debate-host",
+            "builder_fallback": "debate-host-pro",
+        }
     else:
         runtime["opencode_use_global_config"] = False
         runtime["opencode_pure"] = True
@@ -391,6 +449,8 @@ __all__ = [
     "OPENCODE_BASE_PROFILE_OPTIONS",
     "OPENCODE_COMMITTEE_PROFILE_ID",
     "OPENCODE_COMMITTEE_SPECS",
+    "OPENCODE_DEBATE_PROFILE_ID",
+    "OPENCODE_DEBATE_SPECS",
     "OPENCODE_DEFAULT_MODEL_PREFERENCES",
     "OPENCODE_DEFAULT_PROFILE_ID",
     "OPENCODE_LITE_PRO_ORCHESTRATED_EXTRA_SPECS",
@@ -405,6 +465,7 @@ __all__ = [
     "opencode_lite_pro_specs",
     "opencode_lite_pro_specs_for_config",
     "opencode_committee_host_config",
+    "opencode_debate_host_config",
     "opencode_profile_label",
     "opencode_profile_selection",
     "opencode_profile_selection_ids",

--- a/mms_opencode_resolver.py
+++ b/mms_opencode_resolver.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from mms_opencode_profiles import (
     OPENCODE_AGENT_PROFILE_ID,
     OPENCODE_COMMITTEE_PROFILE_ID,
+    OPENCODE_DEBATE_PROFILE_ID,
     OPENCODE_DEFAULT_MODEL_PREFERENCES,
     OPENCODE_REVIEW_PROFILE_ID,
     opencode_lite_pro_specs_for_config,
@@ -290,7 +291,12 @@ def resolve_opencode_profile_runtime(cfg, default_provider, default_models, prof
         }
         runtime = deps.apply_profile(runtime, profile_id)
         return {"model": "global-omo"}, deps.apply_entrypoint(runtime, selection_entrypoint)
-    if profile_id in {OPENCODE_AGENT_PROFILE_ID, OPENCODE_REVIEW_PROFILE_ID, OPENCODE_COMMITTEE_PROFILE_ID}:
+    if profile_id in {
+        OPENCODE_AGENT_PROFILE_ID,
+        OPENCODE_REVIEW_PROFILE_ID,
+        OPENCODE_COMMITTEE_PROFILE_ID,
+        OPENCODE_DEBATE_PROFILE_ID,
+    }:
         model_info, runtime = resolve_opencode_lite_pro_runtime(
             cfg,
             default_provider,

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -2666,7 +2666,7 @@ def test_config_web_snapshot_and_plan_persist_opencode_review_host(tmp_path):
     }
     snapshot = mms_config_web.build_config_snapshot(cfg, config_path=str(tmp_path / "config.toml"))
 
-    assert snapshot["opencode"]["profiles"] == ["agent", "review", "committee", "omo", "raw"]
+    assert snapshot["opencode"]["profiles"] == ["agent", "review", "committee", "debate", "omo", "raw"]
     assert snapshot["opencode"]["review"]["host"] == {
         "primary_models": ["glm-5-turbo"],
         "fallback_models": ["gpt-5.4"],

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1050,16 +1050,20 @@ def test_core_opencode_profiles_are_fixed_launch_shapes():
     assert mms_core._normalize_opencode_profile_id("review") == "review_hub"
     assert mms_core._normalize_opencode_profile_id("multi-review") == "review_hub"
     assert mms_core._normalize_opencode_profile_id("committee") == "committee"
+    assert mms_core._normalize_opencode_profile_id("debate") == "debate"
     assert mms_core._normalize_opencode_profile_id("omo") == "heavy_omo"
     assert mms_core._opencode_profile_selection("lite_pro_orchestrated_backend") == ("lite_pro_orchestrated", "serve")
     assert mms_core._opencode_profile_selection("lite_pro_orchestrated_acp") == ("lite_pro_orchestrated", "acp")
     assert mms_core._opencode_profile_selection("review_backend") == ("review_hub", "serve")
     assert mms_core._opencode_profile_selection("committee_backend") == ("committee", "serve")
+    assert mms_core._opencode_profile_selection("debate_backend") == ("debate", "serve")
+    assert mms_core._opencode_profile_selection("debate_acp") == ("debate", "acp")
 
     lite = mms_core._apply_opencode_profile(_runtime(), "lite")
     agent = mms_core._apply_opencode_profile(_runtime(), "agent")
     review = mms_core._apply_opencode_profile(_runtime(), "review")
     committee = mms_core._apply_opencode_profile(_runtime(), "committee")
+    debate = mms_core._apply_opencode_profile(_runtime(), "debate")
     backend_multi = mms_core._apply_opencode_profile(_runtime(), "lite_pro_orchestrated_backend")
     heavy = mms_core._apply_opencode_profile(_runtime(), "omo")
     raw = mms_core._apply_opencode_profile(_runtime(), "raw")
@@ -1082,6 +1086,11 @@ def test_core_opencode_profiles_are_fixed_launch_shapes():
     assert committee["opencode_roster"] == "committee"
     assert committee["opencode_profile_label"] == "Committee"
     assert committee["opencode_launch_fallback_agents"]["builder_fallback"] == "committee-host-pro"
+    assert debate["opencode_agent"] == "debate-host"
+    assert debate["opencode_roster"] == "debate"
+    assert debate["opencode_profile_label"] == "Debate"
+    assert debate["opencode_contract_workflow"] == "debate"
+    assert debate["opencode_launch_fallback_agents"]["builder_fallback"] == "debate-host-pro"
     assert backend_multi["opencode_profile"] == "lite_pro_orchestrated"
     assert backend_multi["opencode_entrypoint"] == "serve"
     assert heavy["opencode_use_global_config"] is True
@@ -2048,6 +2057,109 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert mimo_route["provider_id"] == "mimo-direct-anthropic"
 
 
+def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatch):
+    import mms_core
+    import mms_launchers
+
+    cfg = {
+        "providers": [],
+        "account": {"defaults": {}},
+        "accounts": [],
+        "opencode": {"debate": {"models": ["gpt-5.4", "gpt-5.5", "deepseek", "glm", "mimo", "kimi"]}},
+    }
+    provider = _runtime(
+        id="mixed",
+        name="Mixed",
+        supported_clis=["codex", "opencode"],
+        protocols=["anthropic_messages", "openai_chat_completions"],
+    )
+    mimo_direct = _runtime(
+        id="mimo-direct-anthropic",
+        name="MiMo Direct",
+        supported_clis=["opencode"],
+        protocols=["anthropic_messages"],
+        openai_base_url="",
+        anthropic_base_url="https://token-plan-cn.xiaomimimo.com/anthropic",
+    )
+    models = [
+        "gpt-5.5",
+        "gpt-5.4",
+        "kimi-k2.6",
+        "glm-5.1",
+        "deepseek-v4-pro",
+    ]
+    monkeypatch.setattr(
+        mms_core,
+        "_provider_candidates",
+        lambda *_args: [(provider, models), (mimo_direct, ["mimo-v2.5-pro", "mimo-v2.5"])],
+    )
+
+    debate_cfg, selection = mms_core._prepare_opencode_debate_profile_config(
+        cfg,
+        provider,
+        models,
+        host_model="gpt-5.5",
+        interactive=False,
+    )
+    model_info, runtime = mms_core._resolve_opencode_profile_runtime(
+        debate_cfg,
+        provider,
+        models,
+        "debate",
+    )
+    payload = mms_launchers._build_opencode_config_payload(runtime, model_info["model"])
+
+    assert model_info == {"model": "gpt-5.5", "profile": "debate"}
+    assert selection["host"] == "gpt-5.5"
+    assert [item["model"] for item in selection["selected"]] == [
+        "gpt-5.4",
+        "gpt-5.5",
+        "deepseek-v4-pro",
+        "glm-5.1",
+        "mimo-v2.5-pro",
+        "kimi-k2.6",
+    ]
+    assert runtime["opencode_agent"] == "debate-host"
+    assert runtime["opencode_roster"] == "debate"
+    assert payload["default_agent"] == "debate-host"
+    assert payload["agent"]["debate-host"]["mode"] == "primary"
+    assert payload["agent"]["debate-host"]["permission"]["task"]["debate-gpt-5-5"] == "allow"
+    assert payload["agent"]["debate-deepseek-v4-pro"]["model"].endswith("/deepseek-v4-pro")
+    assert payload["agent"]["debate-glm-5-1"]["model"].endswith("/glm-5.1")
+    assert payload["agent"]["debate-mimo-v2-5-pro"]["model"].endswith("/mimo-v2.5-pro")
+    assert payload["agent"]["debate-kimi-k2-6"]["model"].endswith("/kimi-k2.6")
+
+    host_prompt = payload["agent"]["debate-host"]["prompt"]
+    host_prompt_lower = host_prompt.lower()
+    assert "not committee" in host_prompt_lower
+    assert "not legacy discuss" in host_prompt_lower
+    assert ".ai/debate/<thread-id>/" in host_prompt
+    assert "blind seed -> crossfire -> revision" in host_prompt_lower
+    assert "round-1-seed.json" in host_prompt
+    assert "round-2-clusters.json" in host_prompt
+    assert "round-3-crossfire.json" in host_prompt
+    assert "round-4-revision.json" in host_prompt
+    assert "resolution.json" in host_prompt
+    assert "skipped revision" in host_prompt_lower
+    assert "no helper command or validator program in v1" in host_prompt_lower
+    assert "self-check" in host_prompt_lower
+    assert "insufficient_evidence > split_human_required > converged > leaning" in host_prompt
+    assert "host_authored" in host_prompt
+    assert "fake consensus" in host_prompt_lower
+    assert "committee vote files" in host_prompt_lower
+    assert "review-hub request roots" in host_prompt_lower
+
+    member_prompt = payload["agent"]["debate-deepseek-v4-pro"]["prompt"].lower()
+    assert "independent debate member" in member_prompt
+    assert "not a committee voter" in member_prompt
+    assert "blind seed" in member_prompt
+    assert "stance_shift" in member_prompt
+    assert "deterministic facts" in member_prompt
+    assert payload["agent"]["debate-deepseek-v4-pro"]["permission"]["task"] == "deny"
+    mimo_route = next(route for route in runtime["opencode_routes"] if route["id"] == "custom_debate-mimo-v2-5-pro")
+    assert mimo_route["provider_id"] == "mimo-direct-anthropic"
+
+
 def test_core_opencode_review_host_models_are_configurable(monkeypatch):
     import mms_core
     import mms_launchers
@@ -2641,15 +2753,16 @@ def test_core_tui_opencode_profile_action_resolves_before_model_channel(monkeypa
     monkeypatch.setattr(mms_tui, "confirm_tui", fake_confirm_tui)
 
     assert mms_core._handle_tui_launcher_selection(cfg, provider, False, ["opencode"]) is True
-    assert [item["id"] for item in captured["profile_options"]["opencode"]] == ["agent", "review", "committee", "omo", "raw"]
+    assert [item["id"] for item in captured["profile_options"]["opencode"]] == ["agent", "review", "committee", "debate", "omo", "raw"]
     assert [item["profile_id"] for item in captured["profile_options"]["opencode"]] == [
         "lite_pro_orchestrated",
         "review_hub",
         "committee",
+        "debate",
         "heavy_omo",
         "raw",
     ]
-    assert [item["label"] for item in captured["profile_options"]["opencode"]] == ["Agent", "Review", "Committee", "OMO", "Raw"]
+    assert [item["label"] for item in captured["profile_options"]["opencode"]] == ["Agent", "Review", "Committee", "Debate", "OMO", "Raw"]
     assert captured["cli"] == "opencode"
     assert captured["model_info"] == {"model": "gpt-5.4", "profile": "lite_pro_orchestrated"}
     assert captured["runtime"]["id"] == "dual-protocol"
@@ -3081,9 +3194,10 @@ def test_core_opencode_profile_menu_includes_lite_pro_health_summary(monkeypatch
     options = mms_core._opencode_profile_menu_options()
     agent = next(option for option in options if option["id"] == "agent")
 
-    assert [option["id"] for option in options] == ["agent", "review", "committee", "omo", "raw"]
+    assert [option["id"] for option in options] == ["agent", "review", "committee", "debate", "omo", "raw"]
     assert next(option for option in options if option["id"] == "review")["profile_id"] == "review_hub"
     assert next(option for option in options if option["id"] == "committee")["profile_id"] == "committee"
+    assert next(option for option in options if option["id"] == "debate")["profile_id"] == "debate"
     assert agent["label"] == "Agent"
     assert agent["badge"] == "默认"
     assert "health: 1/18 healthy" in agent["summary"]

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -2155,6 +2155,7 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     assert "blind seed" in member_prompt
     assert "stance_shift" in member_prompt
     assert "deterministic facts" in member_prompt
+    assert payload["agent"]["debate-deepseek-v4-pro"]["permission"]["edit"] == "deny"
     assert payload["agent"]["debate-deepseek-v4-pro"]["permission"]["task"] == "deny"
     mimo_route = next(route for route in runtime["opencode_routes"] if route["id"] == "custom_debate-mimo-v2-5-pro")
     assert mimo_route["provider_id"] == "mimo-direct-anthropic"


### PR DESCRIPTION
## Summary

Implements Issue #11 Phase 1: a public OpenCode `debate` profile.

- Adds `debate` to OpenCode profile selection and direct `--profile debate` launch.
- Adds `debate-host`, `debate-host-pro`, and `debate-*` member roster generation.
- Keeps debate state isolated under `opencode.debate` and `debate-*`, separate from committee.
- Wires the v1 prompt contract: blind seed -> crossfire -> revision, bidirectional deterministic golden-goal early stop, no extra time, host-authored resolution, `.ai/debate/<thread-id>/` artifacts, and anti-fake-convergence self-check.
- Adds targeted regression coverage for profile selection, generated roster/prompt contract, profile menu, and config web profile surface.

## Boundaries

- Does not change `committee` host workflow or committee artifacts.
- Does not revive legacy `mms discuss`.
- Does not add a validator program or MMS helper command for `.ai/debate/`; v1 uses host prompt enforcement per `docs/DEBATE_V1_SCOPE_DECISIONS_2026-06-15.md`.
- Does not change bridge/provider priority/default route behavior.

## Validation

- `PYTHONPATH=. /opt/homebrew/bin/python3 -m py_compile mms_opencode_profiles.py mms_opencode_agents.py mms_opencode_config.py mms_opencode_resolver.py mms_core.py` ✅
- `PYTHONPATH=. /opt/homebrew/bin/python3 -m pytest -q tests/test_opencode_launcher.py` ✅ 76 passed
- `PYTHONPATH=. /opt/homebrew/bin/python3 -m pytest -q tests/test_opencode_launcher.py tests/test_config_web.py::test_config_web_snapshot_uses_selected_opencode_profile_catalog tests/test_config_web.py::test_config_web_snapshot_maps_internal_opencode_profile_ids_to_surface_ids` ✅ 78 passed after rebase
- `git diff --check` ✅

Known local env note: full `tests/test_config_web.py` on `/opt/homebrew/bin/python3` produced 109 passed / 3 skipped / 2 failures due missing `tomli_w` in that Python env; the failures are save/migration paths unrelated to debate profile generation.

## Regression Report

- `.ai/regression-reports/2026-06-15-issue-11-opencode-debate-profile.md` (local ignored evidence)
- `/Users/xin/issue-tracking/issues/multi-model-switch/issue-11-opencode-debate-profile-20260615/issue.md` (local worklog)

Closes #11 when merged.
