### PR TITLE
fix: share OpenCode profile state

### DIFF
--- a/mms_core.py
+++ b/mms_core.py
@@ -10141,6 +10141,20 @@ def _opencode_default_profile_from_config(cfg):
     return _opencode_profile_selection(opencode.get("default_profile") or opencode.get("profile"))
 
 
+def _opencode_profile_for_preset(cfg, preset, requested_profile=""):
+    requested_profile = str(requested_profile or "").strip()
+    if requested_profile:
+        return requested_profile
+    if isinstance(preset, dict):
+        preset_profile = str(preset.get("opencode_profile") or preset.get("profile") or "").strip()
+        if preset_profile:
+            profile_id, _entrypoint = _opencode_profile_selection(preset_profile)
+            if profile_id:
+                return profile_id
+    profile_id, _entrypoint = _opencode_default_profile_from_config(cfg)
+    return profile_id or _OPENCODE_AGENT_PROFILE_ID
+
+
 def _opencode_default_model_rank(model_name):
     return _opencode_default_model_rank_impl(
         model_name,
@@ -16882,6 +16896,7 @@ def main():
             console.print(f"[red]{cli} 当前没有可用运行来源[/red]")
             return
         if cli == "opencode":
+            runtime = _apply_opencode_profile(runtime, _opencode_profile_for_preset(cfg, p, requested_opencode_profile))
             runtime = _apply_opencode_entrypoint(runtime, requested_opencode_entrypoint)
         _launch_with_tracking(cli, model_info, runtime, once=once)
         return

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -1228,12 +1228,13 @@ def _set_codex_soft_home(env, session_home):
     return env
 
 
-def _set_opencode_soft_home(env, session_home):
+def _set_opencode_soft_home(env, session_home, *, profile_id):
     return _opencode_set_soft_home_impl(
         env,
         session_home,
         real_user_path=_real_user_path,
         set_session_home_hint=_set_session_home_hint,
+        profile_id=profile_id,
     )
 
 

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import os
+import re
+import shutil
+from pathlib import Path
 
 from mms_opencode_config import opencode_config_slug
 
@@ -14,17 +17,94 @@ def opencode_write_config(path, runtime, model, *, build_config_content, atomic_
     return config_content
 
 
-def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_home_hint):
-    """Keep real HOME for GUI/Keychain; keep OpenCode XDG state session-local."""
+_OPENCODE_SHARED_STATE_MIGRATION_MARKER = ".mms-shared-state-migration-v1"
+
+
+def opencode_profile_state_slug(profile_id):
+    raw = str(profile_id or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9._-]+", "-", raw).strip("._-")
+    if not slug:
+        raise ValueError("opencode profile_id is required for shared OpenCode state")
+    if slug == "default":
+        raise ValueError("opencode profile_id must not use the reserved default namespace")
+    return slug
+
+
+def _opencode_isolate_data_enabled(env):
+    raw = str(env.get("MMS_OPENCODE_ISOLATE_DATA") or os.environ.get("MMS_OPENCODE_ISOLATE_DATA") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _copy_missing_tree(src, dst):
+    src = Path(src)
+    dst = Path(dst)
+    if not src.is_dir():
+        return False
+    copied = False
+    for path in sorted(src.rglob("*")):
+        rel = path.relative_to(src)
+        target = dst / rel
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+        copied = True
+    return copied
+
+
+def _migrate_opencode_data_to_shared_state(session_home, state_root):
+    sessions_dir = Path(session_home).parent
+    state_root = Path(state_root)
+    marker = state_root / _OPENCODE_SHARED_STATE_MIGRATION_MARKER
+    if marker.exists() or not sessions_dir.is_dir():
+        return False
+
+    candidates = []
+    for session_dir in sessions_dir.iterdir():
+        data_dir = session_dir / ".local" / "share" / "opencode"
+        if not data_dir.is_dir():
+            continue
+        try:
+            mtime = data_dir.stat().st_mtime
+        except OSError:
+            mtime = 0
+        candidates.append((mtime, data_dir))
+
+    copied = False
+    target_opencode_dir = state_root / "opencode"
+    for _mtime, data_dir in sorted(candidates, reverse=True):
+        copied = _copy_missing_tree(data_dir, target_opencode_dir) or copied
+
+    state_root.mkdir(parents=True, exist_ok=True)
+    marker.write_text("migrated=1\n" if copied else "migrated=0\n", encoding="utf-8")
+    return copied
+
+
+def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_home_hint, profile_id):
+    """Keep real HOME/config soft; share OpenCode data/state by profile."""
+    profile_slug = opencode_profile_state_slug(profile_id)
     real_home = real_user_path()
+    state_root = real_user_path(".local", "share", "mms-opencode", "state", profile_slug)
     env["HOME"] = real_home
     env["XDG_CONFIG_HOME"] = os.path.join(session_home, ".config")
     env["XDG_CACHE_HOME"] = os.path.join(session_home, ".cache")
-    env["XDG_DATA_HOME"] = os.path.join(session_home, ".local", "share")
-    env["XDG_STATE_HOME"] = os.path.join(session_home, ".local", "state")
+    if _opencode_isolate_data_enabled(env):
+        env["XDG_DATA_HOME"] = os.path.join(session_home, ".local", "share")
+        env["XDG_STATE_HOME"] = os.path.join(session_home, ".local", "state")
+        env.pop("MMS_OPENCODE_STATE_SHARED", None)
+    else:
+        os.makedirs(state_root, exist_ok=True)
+        _migrate_opencode_data_to_shared_state(session_home, state_root)
+        env["XDG_DATA_HOME"] = state_root
+        env["XDG_STATE_HOME"] = state_root
+        env["MMS_OPENCODE_STATE_SHARED"] = "1"
     env["MMS_HOME_ISOLATION_MODE"] = "soft"
     env["MMS_SOFT_HOME"] = "1"
     env["MMS_OPENCODE_SOFT_HOME"] = "1"
+    env["MMS_OPENCODE_PROFILE"] = profile_slug
     set_session_home_hint(env, session_home)
     return env
 
@@ -79,6 +159,11 @@ def opencode_gateway_env(
 ):
     runtime = runtime if isinstance(runtime, dict) else {}
     model = resolve_model(model_info or runtime)
+    opencode_profile_id = str(runtime.get("opencode_profile") or "").strip()
+    if not opencode_profile_id and isinstance(model_info, dict):
+        opencode_profile_id = str(model_info.get("opencode_profile") or "").strip()
+    if not opencode_profile_id:
+        raise ValueError("opencode_profile is required for MMS-managed OpenCode shared state")
     disabled_session_surfaces = runtime.get("disabled_session_surfaces")
     enable_caveman = runtime_caveman_enabled(runtime)
     gateway_base = real_user_path(".config", "mms", "opencode-gateway")
@@ -95,7 +180,7 @@ def opencode_gateway_env(
     clear_opencode_config_env(env)
     inject_real_home_hints(env)
     inject_selected_model_name(env, model, model_info=model_info)
-    set_opencode_soft_home(env, session_home)
+    set_opencode_soft_home(env, session_home, profile_id=opencode_profile_id)
 
     config_dir = os.path.join(env["XDG_CONFIG_HOME"], "opencode")
     os.makedirs(config_dir, exist_ok=True)
@@ -204,6 +289,7 @@ __all__ = [
     "opencode_gateway_env",
     "opencode_global_export_env",
     "opencode_global_omo_env",
+    "opencode_profile_state_slug",
     "opencode_provider_export_env",
     "opencode_set_soft_home",
     "opencode_write_config",

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -18,6 +19,13 @@ def opencode_write_config(path, runtime, model, *, build_config_content, atomic_
 
 
 _OPENCODE_SHARED_STATE_MIGRATION_MARKER = ".mms-shared-state-migration-v1"
+_OPENCODE_PROFILE_MARKER = ".mms/opencode-profile"
+
+
+def _write_opencode_profile_marker(session_home, profile_slug):
+    marker = Path(session_home) / _OPENCODE_PROFILE_MARKER
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(profile_slug + "\n", encoding="utf-8")
 
 
 def opencode_profile_state_slug(profile_id):
@@ -55,6 +63,51 @@ def _copy_missing_tree(src, dst):
     return copied
 
 
+def _opencode_profile_slug_from_session(session_dir):
+    session_dir = Path(session_dir)
+    marker = session_dir / _OPENCODE_PROFILE_MARKER
+    if marker.is_file():
+        try:
+            return opencode_profile_state_slug(marker.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ""
+
+    config_path = session_dir / ".config" / "opencode" / "opencode.json"
+    if not config_path.is_file():
+        return ""
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+
+    default_agent = str(payload.get("default_agent") or payload.get("agent") or "").strip()
+    agent_map = {
+        "mobius-builder-pro": "lite_pro_orchestrated",
+        "mobius-builder-stable": "lite_pro_orchestrated",
+        "mobius-builder": "lite",
+        "review-hub-host": "review_hub",
+        "review-hub-host-stable": "review_hub",
+        "committee-host": "committee",
+        "committee-host-pro": "committee",
+    }
+    if default_agent in agent_map:
+        return agent_map[default_agent]
+
+    agents = payload.get("agent")
+    agent_keys = set(agents) if isinstance(agents, dict) else set()
+    if any(str(key).startswith("review-") for key in agent_keys):
+        return "review_hub"
+    if any(str(key).startswith("committee-") for key in agent_keys):
+        return "committee"
+    if any(str(key).startswith("mobius-") for key in agent_keys):
+        return "lite_pro_orchestrated"
+    if not default_agent and not agent_keys:
+        return "raw"
+    return ""
+
+
 def _migrate_opencode_data_to_shared_state(session_home, state_root):
     sessions_dir = Path(session_home).parent
     state_root = Path(state_root)
@@ -64,6 +117,8 @@ def _migrate_opencode_data_to_shared_state(session_home, state_root):
 
     candidates = []
     for session_dir in sessions_dir.iterdir():
+        if _opencode_profile_slug_from_session(session_dir) != state_root.name:
+            continue
         data_dir = session_dir / ".local" / "share" / "opencode"
         if not data_dir.is_dir():
             continue
@@ -88,6 +143,7 @@ def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_hom
     profile_slug = opencode_profile_state_slug(profile_id)
     real_home = real_user_path()
     state_root = real_user_path(".local", "share", "mms-opencode", "state", profile_slug)
+    _write_opencode_profile_marker(session_home, profile_slug)
     env["HOME"] = real_home
     env["XDG_CONFIG_HOME"] = os.path.join(session_home, ".config")
     env["XDG_CACHE_HOME"] = os.path.join(session_home, ".cache")
@@ -171,7 +227,6 @@ def opencode_gateway_env(
     sessions_dir = os.path.join(gateway_base, "s")
     session_home = os.path.join(sessions_dir, str(getpid()))
     os.makedirs(session_home, exist_ok=True)
-    cleanup_stale_sessions(sessions_dir)
 
     link_shared_dotfiles(session_home)
 
@@ -181,6 +236,7 @@ def opencode_gateway_env(
     inject_real_home_hints(env)
     inject_selected_model_name(env, model, model_info=model_info)
     set_opencode_soft_home(env, session_home, profile_id=opencode_profile_id)
+    cleanup_stale_sessions(sessions_dir)
 
     config_dir = os.path.join(env["XDG_CONFIG_HOME"], "opencode")
     os.makedirs(config_dir, exist_ok=True)

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 
 def _runtime(**overrides):
     runtime = {
@@ -646,7 +648,7 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
 
     env = mms_launchers._opencode_gateway_env(
-        _runtime(),
+        _runtime(opencode_profile="lite_pro_orchestrated"),
         model_info={"model": "deepseek-chat"},
     )
 
@@ -659,17 +661,118 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     assert env["HOME"] == str(real_home)
     assert env["XDG_CONFIG_HOME"] == str(session_home / ".config")
     assert env["XDG_CACHE_HOME"] == str(session_home / ".cache")
-    assert env["XDG_DATA_HOME"] == str(session_home / ".local" / "share")
-    assert env["XDG_STATE_HOME"] == str(session_home / ".local" / "state")
+    shared_state = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated"
+    assert env["XDG_DATA_HOME"] == str(shared_state)
+    assert env["XDG_STATE_HOME"] == str(shared_state)
     assert env["MMS_SESSION_HOME"] == str(session_home)
     assert env["MMS_HOME_ISOLATION_MODE"] == "soft"
     assert env["MMS_OPENCODE_SOFT_HOME"] == "1"
+    assert env["MMS_OPENCODE_STATE_SHARED"] == "1"
+    assert env["MMS_OPENCODE_PROFILE"] == "lite_pro_orchestrated"
     assert env["MMS_OPENCODE_API_KEY"] == "sk-runtime"
     assert env["OPENAI_BASE_URL"] == "https://api.deepseek.com/v1"
     assert env["OPENCODE_CLIENT"] == "mms"
     assert env["OPENCODE_PERMISSION"] == mms_launchers.OPENCODE_BYPASS_PERMISSION_ENV
     assert env["MMS_OPENCODE_BYPASS"] == "1"
     assert "OPENCODE_CONFIG_CONTENT" not in env
+
+
+def test_opencode_gateway_env_requires_explicit_profile(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+
+    with pytest.raises(ValueError, match="opencode_profile is required"):
+        mms_launchers._opencode_gateway_env(
+            _runtime(),
+            model_info={"model": "deepseek-chat"},
+        )
+
+
+def test_opencode_gateway_env_profiles_get_isolated_shared_state(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    agent_env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+    review_env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="review_hub"),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert agent_env["XDG_DATA_HOME"].endswith("/mms-opencode/state/lite_pro_orchestrated")
+    assert review_env["XDG_DATA_HOME"].endswith("/mms-opencode/state/review_hub")
+    assert agent_env["XDG_DATA_HOME"] != review_env["XDG_DATA_HOME"]
+    assert agent_env["XDG_STATE_HOME"] == agent_env["XDG_DATA_HOME"]
+    assert review_env["XDG_STATE_HOME"] == review_env["XDG_DATA_HOME"]
+
+
+def test_opencode_gateway_env_isolate_data_kill_switch_restores_session_local_state(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setenv("MMS_OPENCODE_ISOLATE_DATA", "1")
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+    session_home = Path(env["MMS_SESSION_HOME"])
+
+    assert env["XDG_DATA_HOME"] == str(session_home / ".local" / "share")
+    assert env["XDG_STATE_HOME"] == str(session_home / ".local" / "state")
+    assert "MMS_OPENCODE_STATE_SHARED" not in env
+    assert env["MMS_OPENCODE_PROFILE"] == "lite_pro_orchestrated"
+
+
+def test_opencode_gateway_env_migrates_existing_session_local_opencode_data(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    old_opencode_dir = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123" / ".local" / "share" / "opencode"
+    old_opencode_dir.mkdir(parents=True)
+    (old_opencode_dir / "opencode.db").write_text("old-session-db", encoding="utf-8")
+    real_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+    shared_state = Path(env["XDG_DATA_HOME"])
+
+    assert (shared_state / "opencode" / "opencode.db").read_text(encoding="utf-8") == "old-session-db"
+    assert (shared_state / ".mms-shared-state-migration-v1").read_text(encoding="utf-8") == "migrated=1\n"
 
 
 def test_opencode_gateway_env_materializes_session_assets(monkeypatch, tmp_path):
@@ -704,7 +807,7 @@ def test_opencode_gateway_env_materializes_session_assets(monkeypatch, tmp_path)
     monkeypatch.setattr(mms_launchers, "_opencode_rtk_plugin_path", lambda _runtime=None: str(rtk_plugin))
 
     env = mms_launchers._opencode_gateway_env(
-        _runtime(caveman_mode="enable"),
+        _runtime(caveman_mode="enable", opencode_profile="lite_pro_orchestrated"),
         model_info={"model": "deepseek-chat"},
     )
 
@@ -740,7 +843,7 @@ def test_opencode_gateway_env_can_disable_bypass(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENCODE_PERMISSION", mms_launchers.OPENCODE_BYPASS_PERMISSION_ENV)
 
     env = mms_launchers._opencode_gateway_env(
-        _runtime(bypass=False),
+        _runtime(bypass=False, opencode_profile="lite_pro_orchestrated"),
         model_info={"model": "deepseek-chat"},
     )
     config_payload = json.loads(Path(env["OPENCODE_CONFIG"]).read_text(encoding="utf-8"))

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -752,12 +752,25 @@ def test_opencode_gateway_env_migrates_existing_session_local_opencode_data(monk
     import mms_launchers
 
     real_home = tmp_path / "real-home"
-    old_opencode_dir = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123" / ".local" / "share" / "opencode"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_opencode_dir = old_session / ".local" / "share" / "opencode"
     old_opencode_dir.mkdir(parents=True)
     (old_opencode_dir / "opencode.db").write_text("old-session-db", encoding="utf-8")
     real_home.mkdir(exist_ok=True)
     monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
-    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+
+    def fake_cleanup(*_args, **_kwargs):
+        shared_db = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode" / "opencode.db"
+        assert shared_db.read_text(encoding="utf-8") == "old-session-db"
+        assert old_opencode_dir.exists()
+
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", fake_cleanup)
     monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
@@ -773,6 +786,49 @@ def test_opencode_gateway_env_migrates_existing_session_local_opencode_data(monk
 
     assert (shared_state / "opencode" / "opencode.db").read_text(encoding="utf-8") == "old-session-db"
     assert (shared_state / ".mms-shared-state-migration-v1").read_text(encoding="utf-8") == "migrated=1\n"
+
+
+def test_opencode_gateway_env_migrates_only_matching_profile_data(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    sessions_dir = real_home / ".config" / "mms" / "opencode-gateway" / "s"
+    agent_session = sessions_dir / "123"
+    review_session = sessions_dir / "456"
+    for session, default_agent, db_text in (
+        (agent_session, "mobius-builder-pro", "agent-db"),
+        (review_session, "review-hub-host", "review-db"),
+    ):
+        config_dir = session / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.json").write_text(
+            json.dumps({"default_agent": default_agent}) + "\n",
+            encoding="utf-8",
+        )
+        opencode_dir = session / ".local" / "share" / "opencode"
+        opencode_dir.mkdir(parents=True)
+        (opencode_dir / "opencode.db").write_text(db_text, encoding="utf-8")
+
+    real_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="review_hub"),
+        model_info={"model": "deepseek-chat"},
+    )
+    shared_state = Path(env["XDG_DATA_HOME"])
+
+    assert shared_state.name == "review_hub"
+    assert (shared_state / "opencode" / "opencode.db").read_text(encoding="utf-8") == "review-db"
+    agent_shared_db = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode" / "opencode.db"
+    assert not agent_shared_db.exists()
 
 
 def test_opencode_gateway_env_materializes_session_assets(monkeypatch, tmp_path):
@@ -2873,6 +2929,60 @@ def test_main_uses_configured_opencode_default_profile_for_direct_target(monkeyp
     assert captured["profile_models"] == ["gpt-5.5"]
     assert captured["cli"] == "opencode"
     assert captured["runtime"]["opencode_profile"] == "lite_pro_orchestrated"
+
+
+def test_main_opencode_preset_applies_agent_profile_when_preset_has_no_profile(monkeypatch):
+    import mms_core
+
+    cfg = {
+        "providers": [],
+        "account": {"defaults": {}},
+        "accounts": [],
+        "presets": {
+            "fast-opencode": {
+                "cli": "opencode",
+                "provider": "default-provider",
+                "model": "deepseek-chat",
+            }
+        },
+    }
+    provider = _runtime(id="default-provider", name="Default Provider")
+    captured = {}
+
+    monkeypatch.setattr(mms_core.sys, "argv", ["mms", "--preset", "fast-opencode"])
+    monkeypatch.setattr(mms_core, "_extract_global_lang", lambda argv: (argv, None))
+    monkeypatch.setattr(mms_core, "load_config", lambda: cfg)
+    monkeypatch.setattr(mms_core, "_load_command_config", lambda: cfg)
+    monkeypatch.setattr(mms_core, "set_language", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_core, "_resolve_ui_language", lambda *_args, **_kwargs: "zh")
+    monkeypatch.setattr(mms_core, "_ensure_startup_snapshot_guard", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_core, "_refresh_routes_export_for_hive", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(mms_core, "_update_notice", lambda: None)
+    monkeypatch.setattr(mms_core, "_start_async_update_check", lambda: None)
+    monkeypatch.setattr(mms_core, "apply_local_overrides", lambda current_cfg: current_cfg)
+    monkeypatch.setattr(mms_core, "ensure_provider_credentials", lambda _cfg, provider_id=None: provider)
+    monkeypatch.setattr(mms_core, "ensure_models_ready", lambda _cfg, _provider: (provider, ["deepseek-chat"]))
+    monkeypatch.setattr(mms_core, "_warm_probe_cache_async", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_core, "_resolve_visible_clis", lambda *_args, **_kwargs: ["opencode"])
+    monkeypatch.setattr(
+        mms_core,
+        "_select_opencode_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("preset launch must not prompt for profile")),
+    )
+    monkeypatch.setattr(
+        mms_core,
+        "_launch_with_tracking",
+        lambda cli, model_info, runtime, once=False: captured.update(
+            {"cli": cli, "model_info": model_info, "runtime": runtime, "once": once}
+        ),
+    )
+
+    mms_core.main()
+
+    assert captured["cli"] == "opencode"
+    assert captured["model_info"] == {"model": "deepseek-chat"}
+    assert captured["runtime"]["opencode_profile"] == "lite_pro_orchestrated"
+    assert captured["runtime"]["opencode_agent"] == "mobius-builder-pro"
 
 
 def test_existing_openai_provider_lists_show_opencode_without_config_migration(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #8.

- Share MMS-managed OpenCode `XDG_DATA_HOME` and `XDG_STATE_HOME` per explicit OpenCode profile at `~/.local/share/mms-opencode/state/<profile_slug>`.
- Keep OpenCode config/cache session-local so generated `opencode.json` and transient session assets stay isolated.
- Add `MMS_OPENCODE_ISOLATE_DATA=1` rollback to restore old per-session data/state isolation.
- Migrate old per-PID `opencode` data into the new shared profile state root on first launch.
- Fail closed when no explicit `opencode_profile` is present instead of using a default shared namespace.

## Validation

- `PYTHONPATH=. pytest tests/test_opencode_launcher.py -q` — `79 passed`
- `python3 -m py_compile mms_opencode_env.py mms_launchers.py` — pass
- `PYTHONPATH=. /opt/homebrew/bin/python3 scripts/regression_fresh_user_gate.py --quick` — `fresh-user regression: PASS`, internal `61 passed`
- `git diff --check` — pass

## Notes

- No provider/account priority, model routing, bridge protocol, Claude/Codex auth, or real `~/.config/mms/**` config write behavior changed.
- Real interactive OpenCode smoke was not run to avoid mutating the user's live OpenCode runtime state.
- Local regression report: `.ai/regression-reports/2026-06-16-issue-8-opencode-session-switching.md`
- Cross-project worklog: `/Users/xin/issue-tracking/issues/multi-model-switch/issue-8-opencode-session-switching-20260616/issue.md`
