### PR TITLE
Add OpenCode mission trace IDs

### DIFF
--- a/docs/COMMITTEE_MODE_POLICY_v1.md
+++ b/docs/COMMITTEE_MODE_POLICY_v1.md
@@ -30,6 +30,12 @@ The host must declare all four axes before delegating non-trivial work. If a
 user or local project rule supplies a stricter contract, that contract overrides
 these defaults.
 
+Committee also follows the OpenCode review mission trace contract in
+`docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md`. The host must create or preserve a
+visible `MMS-MISSION` block before dispatch, include it in every member brief,
+begin final synthesis with it, and repeat at least `MMS-MISSION` plus
+`MMS-TARGET` at the end.
+
 ## Decision Modes
 
 ### `advisory`
@@ -230,6 +236,18 @@ committee_policy:
 
 The final synthesis must include assignments, member findings, disagreements,
 risks, a task-local member scorecard, and the recommended next action.
+
+The final synthesis must also include the mission block:
+
+```text
+MMS-MISSION: committee-20260616-091830-a8f31c2e
+MMS-TARGET: pr39@dc12352d
+MMS-MODE: gate
+MMS-SOURCE: github-pr
+```
+
+If the target is unclear, use `MMS-TARGET: unknown` instead of inventing a PR or
+commit.
 
 ## Non-Goals
 

--- a/docs/DEBATE_STATE_RESULT_CONTRACT_v1.md
+++ b/docs/DEBATE_STATE_RESULT_CONTRACT_v1.md
@@ -48,6 +48,10 @@ Minimum file set for v1:
 
 - Use distilled packets, not full transcript replay.
 - Keep one append-only `thread_id` per debate thread.
+- Create or preserve one `MMS-MISSION` block for each manual debate dispatch,
+  per `docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md`.
+- Include the unchanged mission block in every member packet and final chat
+  resolution. If the reviewed target is unclear, use `MMS-TARGET: unknown`.
 - Every round artifact must be valid JSON.
 - Every member result must carry provenance and quality metadata.
 - Deterministic facts must be stored separately from model opinion.

--- a/docs/DEBATE_STATE_RESULT_CONTRACT_v1.md
+++ b/docs/DEBATE_STATE_RESULT_CONTRACT_v1.md
@@ -52,6 +52,8 @@ Minimum file set for v1:
   per `docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md`.
 - Include the unchanged mission block in every member packet and final chat
   resolution. If the reviewed target is unclear, use `MMS-TARGET: unknown`.
+- In JSON artifacts, store the block as a `mission` object with literal keys
+  `MMS-MISSION`, `MMS-TARGET`, `MMS-MODE`, and `MMS-SOURCE`.
 - Every round artifact must be valid JSON.
 - Every member result must carry provenance and quality metadata.
 - Deterministic facts must be stored separately from model opinion.
@@ -110,6 +112,12 @@ Thread-local durable state for resume and status inspection.
 {
   "schema": "opencode.debate.state.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "status": "running",
   "round": 1,
   "goal": "decide whether to add a new debate profile",
@@ -133,6 +141,7 @@ Thread-local durable state for resume and status inspection.
 
 - `schema`
 - `thread_id`
+- `mission`
 - `status`
 - `round`
 - `goal`
@@ -181,10 +190,22 @@ Stores blind first pass outputs from all selected members.
 {
   "schema": "opencode.debate.round1.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "round": 1,
   "member_results": [
     {
       "member_id": "debate-gpt-5-5",
+      "mission": {
+        "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+        "MMS-TARGET": "unknown",
+        "MMS-MODE": "debate",
+        "MMS-SOURCE": "user-pasted"
+      },
       "lens": "proponent",
       "stance": "independent debate profile",
       "claim": "debate should be separate from committee",
@@ -207,6 +228,7 @@ Stores blind first pass outputs from all selected members.
 ### Required per-member fields
 
 - `member_id`
+- `mission`
 - `stance`
 - `claim`
 - `evidence`
@@ -235,6 +257,12 @@ Host-owned clustering result after blind first pass.
 {
   "schema": "opencode.debate.round2.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "round": 2,
   "clusters": [
     {
@@ -261,10 +289,22 @@ Stores opponent-summary rebuttal outputs.
 {
   "schema": "opencode.debate.round3.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "round": 3,
   "member_results": [
     {
       "member_id": "debate-gpt-5-5",
+      "mission": {
+        "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+        "MMS-TARGET": "unknown",
+        "MMS-MODE": "debate",
+        "MMS-SOURCE": "user-pasted"
+      },
       "opponent_strongest_point": "skill-first rollout reduces risk",
       "my_rebuttal": "it weakens public product surface",
       "what_i_accept": ["risk is lower"],
@@ -296,10 +336,22 @@ Stores stance updates after crossfire.
 {
   "schema": "opencode.debate.round4.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "round": 4,
   "member_results": [
     {
       "member_id": "debate-gpt-5-5",
+      "mission": {
+        "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+        "MMS-TARGET": "unknown",
+        "MMS-MODE": "debate",
+        "MMS-SOURCE": "user-pasted"
+      },
       "final_stance": "independent profile",
       "stance_shift": "unchanged",
       "shift_reason": "opposing case lowered risk concerns but not enough to change boundary judgment",
@@ -325,6 +377,12 @@ Final machine-readable outcome of the debate thread.
 {
   "schema": "opencode.debate.result.v1",
   "thread_id": "20260615-example",
+  "mission": {
+    "MMS-MISSION": "debate-20260615-example-a8f31c2e",
+    "MMS-TARGET": "unknown",
+    "MMS-MODE": "debate",
+    "MMS-SOURCE": "user-pasted"
+  },
   "status": "resolved",
   "resolution_state": "leaning",
   "quality_gate": "pass",
@@ -366,6 +424,7 @@ Final machine-readable outcome of the debate thread.
 
 - `schema`
 - `thread_id`
+- `mission`
 - `status`
 - `resolution_state`
 - `quality_gate`

--- a/docs/OPENCODE_LITE_LAUNCHER.md
+++ b/docs/OPENCODE_LITE_LAUNCHER.md
@@ -100,6 +100,25 @@ models = ["qwen", "kimi2.5", "minimax2.7", "glm5-turbo"]
 
 The host does not copy dispatcher context into memory. It expects a durable Review Hub request root, gives each preloaded reviewer the same request-root command, and relies on runner-local MCP/skills during each reviewer preflight.
 
+### Review Mission Trace
+
+The `review`, `committee`, and `debate` profiles must create a visible mission
+block for each manual dispatch so humans can paste findings back into the right
+executor window:
+
+```text
+MMS-MISSION: review-20260616-091830-a8f31c2e
+MMS-TARGET: pr39@dc12352d
+MMS-MODE: review
+MMS-SOURCE: review-hub-request
+```
+
+`MMS-MISSION` identifies this manual review dispatch. `MMS-TARGET` identifies
+the reviewed PR, commit, branch, or diff when known. The host repeats the full
+block at the top of final synthesis and repeats at least `MMS-MISSION` plus
+`MMS-TARGET` at the bottom. See
+`docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md`.
+
 ## Configurable Agent Roster
 
 Supported config shape:

--- a/docs/OPENCODE_LITE_LAUNCHER.md
+++ b/docs/OPENCODE_LITE_LAUNCHER.md
@@ -113,7 +113,7 @@ MMS-MODE: review
 MMS-SOURCE: review-hub-request
 ```
 
-`MMS-MISSION` identifies this manual review dispatch. `MMS-TARGET` identifies
+`MMS-MISSION` identifies this manual dispatch. `MMS-TARGET` identifies
 the reviewed PR, commit, branch, or diff when known. The host repeats the full
 block at the top of final synthesis and repeats at least `MMS-MISSION` plus
 `MMS-TARGET` at the bottom. See

--- a/docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md
+++ b/docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md
@@ -1,0 +1,62 @@
+# OpenCode Review Mission Trace v1
+
+Status: draft implementation contract
+Issue: https://github.com/CtriXin/multi-model-switch/issues/40
+Profiles: `review`, `committee`, `debate`
+
+## Purpose
+
+MMS-managed OpenCode review flows need a human-visible correlation anchor for
+parallel windows and repeated review/fix cycles. A commit hash identifies the
+code target. It does not identify a specific manual review dispatch.
+
+This contract adds a dispatch-local mission block that Review Hub, Committee,
+and Debate hosts must create and repeat in chat output and delegated briefs.
+
+## Mission Block
+
+Required fields:
+
+```text
+MMS-MISSION: <profile>-<stable-source-or-date>-<hash-or-nonce>
+MMS-TARGET: <pr/commit/branch/diff target, or unknown>
+MMS-MODE: <review|committee-gate|committee-review|debate|...>
+MMS-SOURCE: <review-hub-request|github-pr|local-diff|commit|user-pasted|unknown>
+```
+
+Rules:
+
+- `MMS-MISSION` identifies this manual review dispatch, not the code commit.
+- `MMS-TARGET` identifies the reviewed object when known.
+- If the target is unclear, write exactly `MMS-TARGET: unknown` and describe
+  the observed source evidence. Do not invent a PR or commit.
+- Prefer an existing stable request id, request-root basename, PR plus commit,
+  or branch plus commit when constructing the mission id.
+- If no stable source exists, generate a compact id using the profile name,
+  current date/time if known, and an 8-character nonce/hash.
+
+## Host Requirements
+
+For every non-trivial `review`, `committee`, or `debate` task, the host must:
+
+1. create or preserve one mission block before delegation;
+2. include the unchanged mission block in every delegated reviewer/member brief;
+3. begin the final chat synthesis with the mission block;
+4. end the final chat synthesis with at least `MMS-MISSION` and `MMS-TARGET`;
+5. preserve the same mission id across retries within the same manual dispatch.
+
+Every new manual dispatch after executor repair should get a new
+`MMS-MISSION`, even if it belongs to the same issue or PR. The `MMS-TARGET`
+usually changes when the PR head commit changes.
+
+## Member Requirements
+
+Reviewers, committee members, and debate members must copy any host-provided
+mission block unchanged into their artifact or compact chat response.
+
+## Non-Goals
+
+- No automatic executor session routing in v1.
+- No requirement that executor/planner sessions pre-generate mission ids.
+- No changes to merge authority, formal vote rules, or real `~/.config/mms/**`
+  config.

--- a/docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md
+++ b/docs/OPENCODE_REVIEW_MISSION_TRACE_v1.md
@@ -8,7 +8,7 @@ Profiles: `review`, `committee`, `debate`
 
 MMS-managed OpenCode review flows need a human-visible correlation anchor for
 parallel windows and repeated review/fix cycles. A commit hash identifies the
-code target. It does not identify a specific manual review dispatch.
+code target. It does not identify a specific manual dispatch.
 
 This contract adds a dispatch-local mission block that Review Hub, Committee,
 and Debate hosts must create and repeat in chat output and delegated briefs.
@@ -26,7 +26,7 @@ MMS-SOURCE: <review-hub-request|github-pr|local-diff|commit|user-pasted|unknown>
 
 Rules:
 
-- `MMS-MISSION` identifies this manual review dispatch, not the code commit.
+- `MMS-MISSION` identifies this manual dispatch, not the code commit.
 - `MMS-TARGET` identifies the reviewed object when known.
 - If the target is unclear, write exactly `MMS-TARGET: unknown` and describe
   the observed source evidence. Do not invent a PR or commit.

--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -6,8 +6,8 @@ import copy
 
 
 OPENCODE_REVIEW_MISSION_CONTRACT = (
-    "MMS mission correlation contract: for every manual review dispatch in a "
-    "review, committee, or debate task, create one visible MMS-MISSION id before "
+    "MMS mission correlation contract: for every manual dispatch in a review, "
+    "committee, or debate task, create one visible MMS-MISSION id before "
     "delegating. Keep it separate from the reviewed code target. Emit fields "
     "MMS-MISSION, MMS-TARGET, MMS-MODE, and MMS-SOURCE. Prefer a stable source "
     "identifier such as a Review Hub request id/root basename, PR plus commit, "
@@ -744,10 +744,13 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
             },
             "prompt": (
                 "Fallback Review Hub host. Continue only if the primary host is "
-                "unavailable or low-confidence. Preserve the same request root, model "
+                "unavailable or low-confidence. "
+                + OPENCODE_REVIEW_MISSION_CONTRACT + " "
+                "Preserve the same request root, model "
                 "selection, MMS-MISSION block, preflight-first behavior, and slot-only "
                 "write boundary. If no MMS-MISSION exists yet, create it before any "
-                "delegation and repeat it in the final synthesis."
+                "delegation. Send the unchanged mission block in every reviewer brief "
+                "and repeat it in the final synthesis."
             ),
         },
     }
@@ -1010,6 +1013,7 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
             "prompt": _prompt_with_tool_policy(
                 (
                     "Fallback committee host. Continue the same deliberation flow, "
+                    + OPENCODE_REVIEW_MISSION_CONTRACT + " "
                     "preserve or create the MMS-MISSION block before delegation, "
                     "preserve selected members, re-read and obey target project local "
                     "instructions before dispatching, apply all committee decision "
@@ -1024,8 +1028,9 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
                     "keep durable ballot provenance honest, include the same "
                     "separation from Debate semantics, include the same "
                     "task-local subagent scorecard, and summarize only "
-                    "evidence-backed conclusions. Repeat the MMS-MISSION block at "
-                    "the top and MMS-MISSION plus MMS-TARGET at the bottom."
+                    "evidence-backed conclusions. Send the unchanged mission block "
+                    "in every member brief. Repeat the MMS-MISSION block at the top "
+                    "and MMS-MISSION plus MMS-TARGET at the bottom."
                 ),
                 _agent_policy("committee-host-pro"),
             ),
@@ -1232,7 +1237,9 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
         "`state.json`, `round-1-seed.json`, `round-2-clusters.json`, "
         "`round-3-crossfire.json`, `round-4-revision.json`, `resolution.json`, "
         "and `resolution.md`. The host writes these artifacts directly; there is "
-        "no helper command or validator program in v1. "
+        "no helper command or validator program in v1. In JSON artifacts, store "
+        "the mission block as a mission object with literal keys MMS-MISSION, "
+        "MMS-TARGET, MMS-MODE, and MMS-SOURCE. "
         "Run the v1 regulation mechanic: blind seed -> crossfire -> revision. "
         "First, send every selected member the same compact packet and require a "
         "blind seed with the unchanged MMS-MISSION block, stance, claim, evidence, "
@@ -1293,12 +1300,14 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
             "prompt": _prompt_with_tool_policy(
                 (
                     "Fallback debate host. Continue the same debate thread, preserve "
+                    + OPENCODE_REVIEW_MISSION_CONTRACT + " "
                     "or create the MMS-MISSION block before any delegation, preserve "
                     "selected debate members, keep debate separate from committee, "
                     "write only `.ai/debate/<thread-id>/` artifacts, enforce the "
                     "fixed blind seed -> crossfire -> revision mechanic, apply the "
                     "v1 self-check checklist, use host_authored synthesis only, and "
                     "preserve real disagreement instead of claiming fake convergence. "
+                    "Send the unchanged mission block in every debate member packet. "
                     "Repeat the MMS-MISSION block at the top and MMS-MISSION plus "
                     "MMS-TARGET at the bottom."
                 ),

--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 import copy
 
 
+OPENCODE_REVIEW_MISSION_CONTRACT = (
+    "MMS mission correlation contract: for every manual review dispatch in a "
+    "review, committee, or debate task, create one visible MMS-MISSION id before "
+    "delegating. Keep it separate from the reviewed code target. Emit fields "
+    "MMS-MISSION, MMS-TARGET, MMS-MODE, and MMS-SOURCE. Prefer a stable source "
+    "identifier such as a Review Hub request id/root basename, PR plus commit, "
+    "or branch plus commit; otherwise generate a compact id using the profile "
+    "name, current date/time if known, and an 8-character nonce/hash. If the "
+    "reviewed target is unclear, write exactly MMS-TARGET: unknown and describe "
+    "the source evidence instead of inventing a PR or commit. Include the same "
+    "mission block in every delegated member brief. Final chat synthesis must "
+    "repeat the mission block at the top and repeat at least MMS-MISSION and "
+    "MMS-TARGET at the bottom so pasted findings remain traceable."
+)
+
+
 def opencode_lite_agent_configs(model_ref):
     """Return session-local OpenCode agents for the MMS lite lane."""
     if not model_ref:
@@ -662,7 +678,10 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
             "prompt. Do environment preflight first. If required MCP/tools/skills/auth "
             "are missing, write the blocked preflight artifact and stop. Do not edit "
             "source files; write review artifacts only inside your assigned slot_root. "
-            "Lead with concrete findings, evidence, uncertainty, and missing tests."
+            "If the host provides an MMS-MISSION block, copy the unchanged "
+            "MMS-MISSION block into your review artifact and compact chat summary "
+            "unchanged. Lead with concrete findings, evidence, uncertainty, and "
+            "missing tests."
         )
 
     host_task_permission = {"*": "deny"}
@@ -687,6 +706,7 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
             },
             "prompt": (
                 "You are a Review Hub execution host, not the original dispatcher. "
+                + OPENCODE_REVIEW_MISSION_CONTRACT + " "
                 "Default host route prefers fast domestic GLM/Kimi/Qwen and falls back through MMS route "
                 "resolution. Start by asking the user for a Review Hub request root "
                 "or short command such as `/review-hub <request-root>` if it was not "
@@ -694,14 +714,17 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
                 f"unless the user narrows them: {reviewer_list_text}. If the user "
                 "does ask to narrow, only use agents already available in this "
                 "session; do not invent new model aliases inside OpenCode. Send every "
-                "selected reviewer the same request-root task, including its model name. "
+                "selected reviewer the same request-root task, including its model name "
+                "and the unchanged MMS-MISSION block. "
                 "Each reviewer must hydrate its own slot with `review-hub reviewer`, "
                 "read PROMPT.md, run preflight first, and write only inside slot_root. "
                 "MCP and skills are session-local runner capabilities; do not claim a "
                 "tool exists unless the reviewer preflight confirms it. After reviewers "
                 "finish, run `review-hub aggregate --request <request-root>` when "
                 "available, then report blockers, consensus findings, disagreements, "
-                "and the aggregate path. Do not edit product/source files."
+                "and the aggregate path. Put the MMS-MISSION block before the verdict "
+                "and repeat MMS-MISSION plus MMS-TARGET at the end. Do not edit "
+                "product/source files."
             ),
         },
         "review-hub-host-stable": {
@@ -722,7 +745,9 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
             "prompt": (
                 "Fallback Review Hub host. Continue only if the primary host is "
                 "unavailable or low-confidence. Preserve the same request root, model "
-                "selection, preflight-first behavior, and slot-only write boundary."
+                "selection, MMS-MISSION block, preflight-first behavior, and slot-only "
+                "write boundary. If no MMS-MISSION exists yet, create it before any "
+                "delegation and repeat it in the final synthesis."
             ),
         },
     }
@@ -898,11 +923,13 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
     member_list_text = ", ".join(member_names) or "no committee-* subagents"
     host_prompt = (
         "You are a general committee host, not a specialized review dispatcher. "
+        + OPENCODE_REVIEW_MISSION_CONTRACT + " "
         "For any user request, restate the goal, classify the request type, and "
         "choose the right committee mode. "
         + committee_policy_contract + " "
-        "When dispatching, include the declared committee policy in each member "
-        "brief and adapt the requested output to that decision mode and playbook. "
+        "When dispatching, include the declared committee policy and the unchanged "
+        "MMS-MISSION block in each member brief and adapt the requested output to "
+        "that decision mode and playbook. "
         "For checker_only or checker_run work, treat command exits and provided "
         "checker output as deterministic evidence that model votes must not "
         "override without explicit human direction. "
@@ -947,8 +974,10 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
         "full artifact there, and require the chat reply to contain only the path, "
         "a compact summary, and any blocked/missing sections. "
         "Synthesize only after member outputs are in. The final answer or packet "
-        "must include assignments, member findings, disagreements, risks, a "
-        "subagent scorecard, and a recommended next action. In the scorecard, "
+        "must begin with the MMS-MISSION block and include assignments, member "
+        "findings, disagreements, risks, a subagent scorecard, and a recommended "
+        "next action. Repeat MMS-MISSION plus MMS-TARGET at the very end. In the "
+        "scorecard, "
         "rate each delegated member for this task only on a 1-5 scale for "
         "usefulness, evidence quality, relevance, and independence; include one "
         "objective sentence of rationale. Mark selected but non-dispatched members "
@@ -981,6 +1010,7 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
             "prompt": _prompt_with_tool_policy(
                 (
                     "Fallback committee host. Continue the same deliberation flow, "
+                    "preserve or create the MMS-MISSION block before delegation, "
                     "preserve selected members, re-read and obey target project local "
                     "instructions before dispatching, apply all committee decision "
                     "mode contracts (advisory, gate, estimate, review, and "
@@ -994,7 +1024,8 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
                     "keep durable ballot provenance honest, include the same "
                     "separation from Debate semantics, include the same "
                     "task-local subagent scorecard, and summarize only "
-                    "evidence-backed conclusions."
+                    "evidence-backed conclusions. Repeat the MMS-MISSION block at "
+                    "the top and MMS-MISSION plus MMS-TARGET at the bottom."
                 ),
                 _agent_policy("committee-host-pro"),
             ),
@@ -1022,6 +1053,8 @@ def opencode_committee_agent_configs(agent_models, *, roster_config=None, agent_
             "Obey target project local instructions and the host-assigned artifact "
             "contract; if those local rules require a durable formal artifact, write "
             "that artifact exactly as assigned. "
+            "If the host provides an MMS-MISSION block, copy it unchanged in your "
+            "ballot, artifact, or chat response. "
             "Follow the host-declared committee_policy, including decision_mode, "
             "playbook, artifact_mode, and permission_profile. Treat playbooks such "
             "as git_ci_security as evidence checklists, not as hidden decision "
@@ -1189,6 +1222,7 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
         "not committee, not review-hub, and not legacy discuss. Do not use "
         "committee vote files, committee verdict vocabulary, committee decision "
         "artifacts, review-hub request roots, or legacy mms discuss semantics. "
+        + OPENCODE_REVIEW_MISSION_CONTRACT + " "
         "Use only the selected debate subagents available in this session: "
         f"{member_list_text}. Do not invent missing agents or model aliases. "
         "If the user has not supplied a concrete question, ask for one concise "
@@ -1201,7 +1235,8 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
         "no helper command or validator program in v1. "
         "Run the v1 regulation mechanic: blind seed -> crossfire -> revision. "
         "First, send every selected member the same compact packet and require a "
-        "blind seed with stance, claim, evidence, risks, recommended_path, "
+        "blind seed with the unchanged MMS-MISSION block, stance, claim, evidence, "
+        "risks, recommended_path, "
         "confidence, pushback, quality_gate, and provenance. Do not expose other "
         "members' arguments during this first pass. Then write `round-2-clusters.json` "
         "as a host-owned clustering artifact with camps, strongest evidence, and "
@@ -1234,8 +1269,9 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
         "Always set `synthesis_strategy` to `host_authored` in v1 and record "
         "`synthesized_by` and `synthesis_attempted_by` honestly. Preserve minority "
         "pushback; never flatten disagreement into fake consensus. The final chat "
-        "reply should be compact: resolution_state, quality_gate, recommended_next_step, "
-        "key pushback, and artifact paths."
+        "reply should begin with the MMS-MISSION block and stay compact: "
+        "resolution_state, quality_gate, recommended_next_step, key pushback, "
+        "and artifact paths. Repeat MMS-MISSION plus MMS-TARGET at the bottom."
     )
     agents = {
         "debate-host": {
@@ -1257,11 +1293,14 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
             "prompt": _prompt_with_tool_policy(
                 (
                     "Fallback debate host. Continue the same debate thread, preserve "
+                    "or create the MMS-MISSION block before any delegation, preserve "
                     "selected debate members, keep debate separate from committee, "
                     "write only `.ai/debate/<thread-id>/` artifacts, enforce the "
                     "fixed blind seed -> crossfire -> revision mechanic, apply the "
                     "v1 self-check checklist, use host_authored synthesis only, and "
-                    "preserve real disagreement instead of claiming fake convergence."
+                    "preserve real disagreement instead of claiming fake convergence. "
+                    "Repeat the MMS-MISSION block at the top and MMS-MISSION plus "
+                    "MMS-TARGET at the bottom."
                 ),
                 _agent_policy("debate-host-pro"),
             ),
@@ -1290,6 +1329,8 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
             "decision.md, or ratification markers. Do not call other agents. Do not "
             "edit product/source files unless the user explicitly assigns a separate "
             "implementation task; normal debate outputs go back to debate-host. "
+            "If the host provides an MMS-MISSION block, copy it unchanged in your "
+            "round response. "
             "For blind seed, answer without considering other members: stance, claim, "
             "evidence, risks, recommended_path, confidence, pushback, quality_gate, "
             "and provenance. For crossfire, engage only the strongest opposing-case "

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1773,11 +1773,16 @@ def test_core_opencode_review_profile_builds_review_hub_roster(monkeypatch):
     assert "mms-target" in review_host_prompt_lower
     assert "mms-mode" in review_host_prompt_lower
     assert "mms-source" in review_host_prompt_lower
-    assert "manual review dispatch" in review_host_prompt_lower
+    assert "manual dispatch" in review_host_prompt_lower
     assert "reviewed code target" in review_host_prompt_lower
     assert "repeat mms-mission plus mms-target at the end" in review_host_prompt_lower
     assert "unchanged mms-mission block" in payload["agent"]["review-qwen"]["prompt"].lower()
-    assert "mms-mission block" in payload["agent"]["review-hub-host-stable"]["prompt"].lower()
+    review_stable_prompt = payload["agent"]["review-hub-host-stable"]["prompt"].lower()
+    assert "mms-mission" in review_stable_prompt
+    assert "mms-target" in review_stable_prompt
+    assert "mms-mode" in review_stable_prompt
+    assert "mms-source" in review_stable_prompt
+    assert "every reviewer brief" in review_stable_prompt
     assert payload["agent"]["review-qwen"]["permission"]["edit"] == "allow"
     review_mimo_route = next(route for route in runtime["opencode_routes"] if route["id"] == "review_mimo")
     assert review_mimo_route["provider_id"] == "mimo-direct-anthropic"
@@ -2149,7 +2154,7 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert "mms-target" in host_prompt_lower
     assert "mms-mode" in host_prompt_lower
     assert "mms-source" in host_prompt_lower
-    assert "manual review dispatch" in host_prompt_lower
+    assert "manual dispatch" in host_prompt_lower
     assert "reviewed code target" in host_prompt_lower
     assert "unchanged mms-mission block in each member brief" in host_prompt_lower
     assert "repeat mms-mission plus mms-target at the very end" in host_prompt_lower
@@ -2189,7 +2194,11 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert "re-read and obey target project local" in host_pro_prompt
     assert "preserve the same host boundary" in host_pro_prompt
     assert "committee_policy fields" in host_pro_prompt
-    assert "mms-mission block" in host_pro_prompt
+    assert "mms-mission" in host_pro_prompt
+    assert "mms-target" in host_pro_prompt
+    assert "mms-mode" in host_pro_prompt
+    assert "mms-source" in host_pro_prompt
+    assert "every member brief" in host_pro_prompt
     assert "mms-target at the bottom" in host_pro_prompt
     assert "advisory, gate, estimate, review, and execution_packet" in host_pro_prompt
     assert "decision_mode, playbook, artifact_mode, permission_profile" in host_pro_prompt
@@ -2319,8 +2328,9 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     assert "mms-target" in host_prompt_lower
     assert "mms-mode" in host_prompt_lower
     assert "mms-source" in host_prompt_lower
-    assert "manual review dispatch" in host_prompt_lower
+    assert "manual dispatch" in host_prompt_lower
     assert "reviewed code target" in host_prompt_lower
+    assert "mission object" in host_prompt_lower
     assert "unchanged mms-mission block" in host_prompt_lower
     assert "repeat mms-mission plus mms-target at the bottom" in host_prompt_lower
     assert "blind seed -> crossfire -> revision" in host_prompt_lower
@@ -2337,6 +2347,12 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     assert "fake consensus" in host_prompt_lower
     assert "committee vote files" in host_prompt_lower
     assert "review-hub request roots" in host_prompt_lower
+    host_pro_prompt = payload["agent"]["debate-host-pro"]["prompt"].lower()
+    assert "mms-mission" in host_pro_prompt
+    assert "mms-target" in host_pro_prompt
+    assert "mms-mode" in host_pro_prompt
+    assert "mms-source" in host_pro_prompt
+    assert "every debate member packet" in host_pro_prompt
 
     member_prompt = payload["agent"]["debate-deepseek-v4-pro"]["prompt"].lower()
     assert "independent debate member" in member_prompt

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1766,7 +1766,18 @@ def test_core_opencode_review_profile_builds_review_hub_roster(monkeypatch):
     assert payload["agent"]["review-mimo-pro"]["model"].endswith("/mimo-v2.5-pro")
     assert "steps" not in payload["agent"]["review-qwen"]
     assert "steps" not in payload["agent"]["review-mimo-pro"]
-    assert "review-hub aggregate" in payload["agent"]["review-hub-host"]["prompt"]
+    review_host_prompt = payload["agent"]["review-hub-host"]["prompt"]
+    review_host_prompt_lower = review_host_prompt.lower()
+    assert "review-hub aggregate" in review_host_prompt
+    assert "mms-mission" in review_host_prompt_lower
+    assert "mms-target" in review_host_prompt_lower
+    assert "mms-mode" in review_host_prompt_lower
+    assert "mms-source" in review_host_prompt_lower
+    assert "manual review dispatch" in review_host_prompt_lower
+    assert "reviewed code target" in review_host_prompt_lower
+    assert "repeat mms-mission plus mms-target at the end" in review_host_prompt_lower
+    assert "unchanged mms-mission block" in payload["agent"]["review-qwen"]["prompt"].lower()
+    assert "mms-mission block" in payload["agent"]["review-hub-host-stable"]["prompt"].lower()
     assert payload["agent"]["review-qwen"]["permission"]["edit"] == "allow"
     review_mimo_route = next(route for route in runtime["opencode_routes"] if route["id"] == "review_mimo")
     assert review_mimo_route["provider_id"] == "mimo-direct-anthropic"
@@ -2134,6 +2145,14 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert "gate mode" in host_prompt_lower
     assert "estimate mode" in host_prompt_lower
     assert "committee_policy with decision_mode, playbook, artifact_mode" in host_prompt_lower
+    assert "mms-mission" in host_prompt_lower
+    assert "mms-target" in host_prompt_lower
+    assert "mms-mode" in host_prompt_lower
+    assert "mms-source" in host_prompt_lower
+    assert "manual review dispatch" in host_prompt_lower
+    assert "reviewed code target" in host_prompt_lower
+    assert "unchanged mms-mission block in each member brief" in host_prompt_lower
+    assert "repeat mms-mission plus mms-target at the very end" in host_prompt_lower
     assert "permission_profile" in host_prompt_lower
     assert "decision modes are advisory, gate, estimate, review, and execution_packet" in host_prompt_lower
     assert "playbooks are domain checklists, not decision modes" in host_prompt_lower
@@ -2170,6 +2189,8 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert "re-read and obey target project local" in host_pro_prompt
     assert "preserve the same host boundary" in host_pro_prompt
     assert "committee_policy fields" in host_pro_prompt
+    assert "mms-mission block" in host_pro_prompt
+    assert "mms-target at the bottom" in host_pro_prompt
     assert "advisory, gate, estimate, review, and execution_packet" in host_pro_prompt
     assert "decision_mode, playbook, artifact_mode, permission_profile" in host_pro_prompt
     assert "separation from debate semantics" in host_pro_prompt
@@ -2190,6 +2211,7 @@ def test_core_opencode_committee_profile_builds_general_committee_roster(monkeyp
     assert payload["agent"]["committee-deepseek-v4-pro"]["permission"]["edit"] == "deny"
     assert payload["agent"]["committee-deepseek-v4-pro"]["permission"]["task"] == "deny"
     assert "obey target project local instructions" in member_prompt
+    assert "copy it unchanged" in member_prompt
     assert "durable formal artifact" in member_prompt
     assert "follow the host-declared committee_policy" in member_prompt
     assert "decision_mode" in member_prompt
@@ -2293,6 +2315,14 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     assert "not committee" in host_prompt_lower
     assert "not legacy discuss" in host_prompt_lower
     assert ".ai/debate/<thread-id>/" in host_prompt
+    assert "mms-mission" in host_prompt_lower
+    assert "mms-target" in host_prompt_lower
+    assert "mms-mode" in host_prompt_lower
+    assert "mms-source" in host_prompt_lower
+    assert "manual review dispatch" in host_prompt_lower
+    assert "reviewed code target" in host_prompt_lower
+    assert "unchanged mms-mission block" in host_prompt_lower
+    assert "repeat mms-mission plus mms-target at the bottom" in host_prompt_lower
     assert "blind seed -> crossfire -> revision" in host_prompt_lower
     assert "round-1-seed.json" in host_prompt
     assert "round-2-clusters.json" in host_prompt
@@ -2311,6 +2341,8 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     member_prompt = payload["agent"]["debate-deepseek-v4-pro"]["prompt"].lower()
     assert "independent debate member" in member_prompt
     assert "not a committee voter" in member_prompt
+    assert "mms-mission block" in member_prompt
+    assert "copy it unchanged" in member_prompt
     assert "blind seed" in member_prompt
     assert "stance_shift" in member_prompt
     assert "deterministic facts" in member_prompt


### PR DESCRIPTION
## Summary

- add `MMS-MISSION` / `MMS-TARGET` / `MMS-MODE` / `MMS-SOURCE` prompt contract for OpenCode Review Hub, Committee, and Debate hosts
- require hosts to propagate the mission block into delegated reviewer/member briefs and repeat it in final synthesis
- document the mission trace convention and add prompt-contract assertions

Closes #40

## Verification

- `python3 -m py_compile mms_opencode_agents.py mms_opencode_config.py mms_opencode_profiles.py`
- `PYTHONPATH=. pytest tests/test_opencode_launcher.py -q` — 82 passed
- `PYTHONPATH=. pytest tests/test_opencode_launcher.py::test_core_opencode_review_profile_builds_review_hub_roster tests/test_opencode_launcher.py::test_core_opencode_committee_profile_builds_general_committee_roster tests/test_opencode_launcher.py::test_core_opencode_debate_profile_builds_structured_debate_roster -q` — 3 passed
- `git diff --check`

## Notes

- Prompt/docs/tests only; no launcher route selection, bridge, provider, account, or real `~/.config/mms/**` config behavior changed.
- No live OpenCode model smoke was run for this prompt-contract slice.
