### PR TITLE
fix: harden opencode legacy migration

### DIFF
--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -20,12 +20,19 @@ def opencode_write_config(path, runtime, model, *, build_config_content, atomic_
 
 _OPENCODE_SHARED_STATE_MIGRATION_MARKER = ".mms-shared-state-migration-v1"
 _OPENCODE_PROFILE_MARKER = ".mms/opencode-profile"
+_OPENCODE_ISOLATE_DATA_MARKER = ".mms/opencode-isolate-data"
 
 
 def _write_opencode_profile_marker(session_home, profile_slug):
     marker = Path(session_home) / _OPENCODE_PROFILE_MARKER
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(profile_slug + "\n", encoding="utf-8")
+
+
+def _write_opencode_isolate_data_marker(session_home):
+    marker = Path(session_home) / _OPENCODE_ISOLATE_DATA_MARKER
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("1\n", encoding="utf-8")
 
 
 def opencode_profile_state_slug(profile_id):
@@ -63,15 +70,8 @@ def _copy_missing_tree(src, dst):
     return copied
 
 
-def _opencode_profile_slug_from_session(session_dir):
+def _opencode_profile_slug_from_config(session_dir):
     session_dir = Path(session_dir)
-    marker = session_dir / _OPENCODE_PROFILE_MARKER
-    if marker.is_file():
-        try:
-            return opencode_profile_state_slug(marker.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return ""
-
     config_path = session_dir / ".config" / "opencode" / "opencode.json"
     if not config_path.is_file():
         return ""
@@ -108,16 +108,338 @@ def _opencode_profile_slug_from_session(session_dir):
     return ""
 
 
-def _migrate_opencode_data_to_shared_state(session_home, state_root):
-    sessions_dir = Path(session_home).parent
-    state_root = Path(state_root)
+def _opencode_profile_slug_from_session(session_dir):
+    session_dir = Path(session_dir)
+    marker = session_dir / _OPENCODE_PROFILE_MARKER
+    if marker.is_file():
+        try:
+            return opencode_profile_state_slug(marker.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return ""
+    return _opencode_profile_slug_from_config(session_dir)
+
+
+def _opencode_legacy_profile_slug_from_session(session_dir):
+    session_dir = Path(session_dir)
+    if (session_dir / _OPENCODE_PROFILE_MARKER).exists():
+        return ""
+    if (session_dir / _OPENCODE_ISOLATE_DATA_MARKER).exists():
+        return ""
+    return _opencode_profile_slug_from_config(session_dir)
+
+
+def _opencode_profile_state_root(real_user_path, profile_slug):
+    return Path(real_user_path(".local", "share", "mms-opencode", "state", profile_slug))
+
+
+def _write_opencode_shared_state_marker(state_root, *, migrated):
+    state_root.mkdir(parents=True, exist_ok=True)
     marker = state_root / _OPENCODE_SHARED_STATE_MIGRATION_MARKER
-    if marker.exists() or not sessions_dir.is_dir():
+    marker.write_text("migrated=1\n" if migrated else "migrated=0\n", encoding="utf-8")
+
+
+def _is_sqlite_db(path):
+    try:
+        with Path(path).open("rb") as handle:
+            return handle.read(16) == b"SQLite format 3\x00"
+    except OSError:
         return False
 
-    candidates = []
+
+def _sqlite_quote_ident(name):
+    return '"' + str(name).replace('"', '""') + '"'
+
+
+def _sqlite_table_names(conn):
+    return [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+    ]
+
+
+def _sqlite_table_info(conn, table_name):
+    table_sql = _sqlite_quote_ident(table_name)
+    return conn.execute(f"PRAGMA table_info({table_sql})").fetchall()
+
+
+def _sqlite_table_exists(conn, table_name):
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone() is not None
+
+
+def _sqlite_ensure_table(dst_conn, src_conn, table_name):
+    if _sqlite_table_exists(dst_conn, table_name):
+        return False
+    create_row = src_conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    create_sql = str(create_row[0] or "").strip() if create_row else ""
+    if not create_sql:
+        return False
+    dst_conn.execute(create_sql)
+    return True
+
+
+def _sqlite_column_default_sql(table_name, info_row):
+    column_name = str(info_row[1] or "")
+    column_type = str(info_row[2] or "")
+    default_sql = info_row[4]
+    if default_sql is not None:
+        return str(default_sql)
+    if table_name == "session":
+        if column_name == "project_id":
+            return "'legacy-migrated-project'"
+        if column_name == "slug":
+            return "''"
+        if column_name == "version":
+            return "'1'"
+    normalized_type = column_type.upper()
+    if any(token in normalized_type for token in ("INT", "REAL", "NUM")):
+        return "0"
+    return "''"
+
+
+def _sqlite_sync_existing_table_columns(dst_conn, src_conn, table_name):
+    src_info = _sqlite_table_info(src_conn, table_name)
+    dst_columns = {row[1] for row in _sqlite_table_info(dst_conn, table_name)}
+    changed = False
+    table_sql = _sqlite_quote_ident(table_name)
+    for info_row in src_info:
+        column_name = str(info_row[1] or "")
+        if not column_name or column_name in dst_columns:
+            continue
+        if int(info_row[5] or 0) > 0:
+            continue
+        column_type = str(info_row[2] or "").strip() or "TEXT"
+        column_sql = f"{_sqlite_quote_ident(column_name)} {column_type}"
+        not_null = int(info_row[3] or 0) > 0
+        if not_null:
+            column_sql += f" NOT NULL DEFAULT {_sqlite_column_default_sql(table_name, info_row)}"
+        elif info_row[4] is not None:
+            column_sql += f" DEFAULT {info_row[4]}"
+        dst_conn.execute(f"ALTER TABLE {table_sql} ADD COLUMN {column_sql}")
+        changed = True
+    if changed and table_name == "session" and _sqlite_table_exists(dst_conn, "project"):
+        project_table_info = _sqlite_table_info(dst_conn, "project")
+        project_columns = [row[1] for row in project_table_info]
+        legacy_values = {
+            "id": "legacy-migrated-project",
+            "worktree": "",
+            "name": "Legacy Migrated Project",
+            "sandboxes": "[]",
+            "time_created": 0,
+            "time_updated": 0,
+            "time_initialized": 0,
+        }
+        insert_columns = []
+        insert_values = []
+        for info_row in project_table_info:
+            column_name = str(info_row[1] or "")
+            if not column_name:
+                continue
+            insert_columns.append(_sqlite_quote_ident(column_name))
+            if column_name in legacy_values:
+                insert_values.append(legacy_values[column_name])
+                continue
+            if int(info_row[3] or 0) > 0:
+                column_type = str(info_row[2] or "").upper()
+                insert_values.append(0 if any(token in column_type for token in ("INT", "REAL", "NUM")) else "")
+                continue
+            insert_values.append(None)
+        dst_conn.execute(
+            f"INSERT OR IGNORE INTO project ({', '.join(insert_columns)}) VALUES ({', '.join('?' for _ in insert_values)})",
+            tuple(insert_values),
+        )
+        dst_conn.execute(
+            "UPDATE session SET project_id = COALESCE(NULLIF(project_id, ''), ?), slug = COALESCE(NULLIF(slug, ''), id), version = COALESCE(NULLIF(version, ''), ?) WHERE project_id IS NULL OR project_id = '' OR slug IS NULL OR slug = '' OR version IS NULL OR version = ''",
+            ("legacy-migrated-project", "1"),
+        )
+    return changed
+
+
+def _sqlite_row_signature(row):
+    return tuple(row) if row is not None else None
+
+
+def _sqlite_time_updated_value(columns, row):
+    try:
+        idx = columns.index("time_updated")
+    except ValueError:
+        return None
+    return int(row[idx] or 0)
+
+
+def _sync_sqlite_table_rows(src_conn, dst_conn, table_name):
+    schema_changed = _sqlite_sync_existing_table_columns(dst_conn, src_conn, table_name)
+    src_table_info = _sqlite_table_info(src_conn, table_name)
+    dst_table_info = _sqlite_table_info(dst_conn, table_name)
+    dst_columns = {row[1] for row in dst_table_info}
+    table_info = [row for row in src_table_info if row[1] in dst_columns]
+    columns = [row[1] for row in table_info]
+    if not columns:
+        return schema_changed
+    pk_columns = [
+        info_row[1]
+        for info_row in sorted(table_info, key=lambda item: item[5] or 0)
+        if int(info_row[5] or 0) > 0
+    ]
+    table_sql = _sqlite_quote_ident(table_name)
+    column_sql = ", ".join(_sqlite_quote_ident(column) for column in columns)
+    src_rows = src_conn.execute(f"SELECT {column_sql} FROM {table_sql}").fetchall()
+    if not src_rows:
+        return schema_changed
+
+    changed = schema_changed
+    select_existing_sql = ""
+    if pk_columns:
+        where_sql = " AND ".join(f"{_sqlite_quote_ident(column)} = ?" for column in pk_columns)
+        select_existing_sql = f"SELECT {column_sql} FROM {table_sql} WHERE {where_sql}"
+    insert_sql = f"INSERT INTO {table_sql} ({column_sql}) VALUES ({', '.join('?' for _ in columns)})"
+    non_pk_columns = [column for column in columns if column not in pk_columns]
+    if pk_columns and non_pk_columns:
+        set_sql = ", ".join(f"{_sqlite_quote_ident(column)} = ?" for column in non_pk_columns)
+        where_sql = " AND ".join(f"{_sqlite_quote_ident(column)} = ?" for column in pk_columns)
+        update_sql = f"UPDATE {table_sql} SET {set_sql} WHERE {where_sql}"
+    else:
+        update_sql = ""
+
+    for row in src_rows:
+        existing = None
+        if select_existing_sql:
+            pk_values = tuple(row[columns.index(column)] for column in pk_columns)
+            existing = dst_conn.execute(select_existing_sql, pk_values).fetchone()
+        if existing is None:
+            dst_conn.execute(insert_sql, row)
+            changed = True
+            continue
+        if _sqlite_row_signature(existing) == _sqlite_row_signature(row):
+            continue
+        src_updated = _sqlite_time_updated_value(columns, row)
+        dst_updated = _sqlite_time_updated_value(columns, existing)
+        if src_updated is not None and dst_updated is not None and src_updated < dst_updated:
+            continue
+        if update_sql:
+            non_pk_values = [row[columns.index(column)] for column in non_pk_columns]
+            dst_conn.execute(update_sql, tuple(non_pk_values) + pk_values)
+            changed = True
+            continue
+    return changed
+
+
+def _sync_opencode_sqlite_db(src, dst):
+    import sqlite3
+
+    src = Path(src)
+    dst = Path(dst)
+    if not src.exists():
+        return False, False, False
+    if not _is_sqlite_db(src):
+        return False, False, False
+    if dst.exists() and not _is_sqlite_db(dst):
+        return True, False, True
+
+    changed = False
+    src_conn = sqlite3.connect(str(src))
+    try:
+        if not dst.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst_conn = sqlite3.connect(str(dst))
+            try:
+                src_conn.backup(dst_conn)
+                dst_conn.commit()
+                return True, True, False
+            finally:
+                dst_conn.close()
+
+        dst_conn = sqlite3.connect(str(dst))
+        try:
+            for table_name in _sqlite_table_names(src_conn):
+                changed = _sqlite_ensure_table(dst_conn, src_conn, table_name) or changed
+                changed = _sync_sqlite_table_rows(src_conn, dst_conn, table_name) or changed
+            if changed:
+                dst_conn.commit()
+            return True, changed, False
+        finally:
+            dst_conn.close()
+    except sqlite3.DatabaseError:
+        return True, False, True
+    finally:
+        src_conn.close()
+
+
+def _sync_opencode_db(src, dst):
+    src = Path(src)
+    dst = Path(dst)
+    if not src.exists():
+        return False, False
+    src_is_sqlite = _is_sqlite_db(src)
+    dst_is_sqlite = dst.exists() and _is_sqlite_db(dst)
+    if not src_is_sqlite and dst_is_sqlite:
+        return False, True
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    handled, changed, failed = _sync_opencode_sqlite_db(src, dst)
+    if handled:
+        return changed, failed
+    if not dst.exists():
+        shutil.copy2(src, dst)
+        return True, False
+    try:
+        src_stat = src.stat()
+        dst_stat = dst.stat()
+    except OSError:
+        return False, True
+    if src_stat.st_mtime_ns <= dst_stat.st_mtime_ns:
+        return False, False
+    shutil.copy2(src, dst)
+    return True, False
+
+
+def _sync_opencode_tree(src, dst):
+    src = Path(src)
+    dst = Path(dst)
+    if not src.is_dir():
+        return False, False
+    changed = False
+    failed = False
+    for path in sorted(src.rglob("*")):
+        rel = path.relative_to(src)
+        target = dst / rel
+        if path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if path.name in {"opencode.db-wal", "opencode.db-shm"}:
+            continue
+        if path.name == "opencode.db":
+            db_changed, db_failed = _sync_opencode_db(path, target)
+            changed = db_changed or changed
+            failed = db_failed or failed
+            continue
+        if target.exists():
+            try:
+                if path.stat().st_mtime_ns <= target.stat().st_mtime_ns:
+                    continue
+            except OSError:
+                continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, target)
+        changed = True
+    return changed, failed
+
+
+def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
+    sessions_dir = Path(session_home).parent
+    if not sessions_dir.is_dir():
+        return False, False
+
+    candidates_by_profile = {}
     for session_dir in sessions_dir.iterdir():
-        if _opencode_profile_slug_from_session(session_dir) != state_root.name:
+        profile_slug = _opencode_legacy_profile_slug_from_session(session_dir)
+        if not profile_slug:
             continue
         data_dir = session_dir / ".local" / "share" / "opencode"
         if not data_dir.is_dir():
@@ -126,37 +448,49 @@ def _migrate_opencode_data_to_shared_state(session_home, state_root):
             mtime = data_dir.stat().st_mtime
         except OSError:
             mtime = 0
-        candidates.append((mtime, data_dir))
+        candidates_by_profile.setdefault(profile_slug, []).append((mtime, data_dir))
 
     copied = False
-    target_opencode_dir = state_root / "opencode"
-    for _mtime, data_dir in sorted(candidates, reverse=True):
-        copied = _copy_missing_tree(data_dir, target_opencode_dir) or copied
-
-    state_root.mkdir(parents=True, exist_ok=True)
-    marker.write_text("migrated=1\n" if copied else "migrated=0\n", encoding="utf-8")
-    return copied
+    failed = False
+    for profile_slug, candidates in candidates_by_profile.items():
+        state_root = _opencode_profile_state_root(real_user_path, profile_slug)
+        target_opencode_dir = state_root / "opencode"
+        profile_migrated = False
+        profile_failed = False
+        for _mtime, data_dir in sorted(candidates, reverse=True):
+            tree_changed, tree_failed = _sync_opencode_tree(data_dir, target_opencode_dir)
+            profile_migrated = tree_changed or profile_migrated
+            profile_failed = tree_failed or profile_failed
+        _write_opencode_shared_state_marker(state_root, migrated=bool(candidates) and not profile_failed)
+        copied = profile_migrated or copied
+        failed = profile_failed or failed
+    return copied, failed
 
 
 def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_home_hint, profile_id):
     """Keep real HOME/config soft; share OpenCode data/state by profile."""
     profile_slug = opencode_profile_state_slug(profile_id)
     real_home = real_user_path()
-    state_root = real_user_path(".local", "share", "mms-opencode", "state", profile_slug)
+    state_root = _opencode_profile_state_root(real_user_path, profile_slug)
     _write_opencode_profile_marker(session_home, profile_slug)
     env["HOME"] = real_home
     env["XDG_CONFIG_HOME"] = os.path.join(session_home, ".config")
     env["XDG_CACHE_HOME"] = os.path.join(session_home, ".cache")
     if _opencode_isolate_data_enabled(env):
+        _write_opencode_isolate_data_marker(session_home)
         env["XDG_DATA_HOME"] = os.path.join(session_home, ".local", "share")
         env["XDG_STATE_HOME"] = os.path.join(session_home, ".local", "state")
         env.pop("MMS_OPENCODE_STATE_SHARED", None)
     else:
         os.makedirs(state_root, exist_ok=True)
-        _migrate_opencode_data_to_shared_state(session_home, state_root)
-        env["XDG_DATA_HOME"] = state_root
-        env["XDG_STATE_HOME"] = state_root
+        _migrated, migration_failed = _migrate_opencode_data_to_shared_state(session_home, real_user_path=real_user_path)
+        env["XDG_DATA_HOME"] = str(state_root)
+        env["XDG_STATE_HOME"] = str(state_root)
         env["MMS_OPENCODE_STATE_SHARED"] = "1"
+        if migration_failed:
+            env["MMS_OPENCODE_MIGRATION_FAILED"] = "1"
+        else:
+            env.pop("MMS_OPENCODE_MIGRATION_FAILED", None)
     env["MMS_HOME_ISOLATION_MODE"] = "soft"
     env["MMS_SOFT_HOME"] = "1"
     env["MMS_OPENCODE_SOFT_HOME"] = "1"
@@ -236,7 +570,8 @@ def opencode_gateway_env(
     inject_real_home_hints(env)
     inject_selected_model_name(env, model, model_info=model_info)
     set_opencode_soft_home(env, session_home, profile_id=opencode_profile_id)
-    cleanup_stale_sessions(sessions_dir)
+    if env.get("MMS_OPENCODE_MIGRATION_FAILED") != "1":
+        cleanup_stale_sessions(sessions_dir)
 
     config_dir = os.path.join(env["XDG_CONFIG_HOME"], "opencode")
     os.makedirs(config_dir, exist_ok=True)

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -25,6 +26,183 @@ def _write_skill(root: Path, name: str) -> Path:
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
     return skill_dir
+
+
+def _write_opencode_session_db(
+    path: Path,
+    *,
+    sessions: list[dict],
+    messages: list[dict] | None = None,
+    parts: list[dict] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("DROP TABLE IF EXISTS part")
+        conn.execute("DROP TABLE IF EXISTS message")
+        conn.execute("DROP TABLE IF EXISTS session")
+        conn.execute("DROP TABLE IF EXISTS project")
+        conn.execute(
+            "CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, vcs TEXT, name TEXT, icon_url TEXT, icon_color TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_initialized INTEGER, sandboxes TEXT NOT NULL, commands TEXT, icon_url_override TEXT)"
+        )
+        conn.execute("DROP TABLE IF EXISTS session")
+        conn.execute(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER, summary_files INTEGER, summary_diffs TEXT, revert TEXT, permission TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_compacting INTEGER, time_archived INTEGER, workspace_id TEXT, path TEXT, agent TEXT, model TEXT, cost REAL DEFAULT 0 NOT NULL, tokens_input INTEGER DEFAULT 0 NOT NULL, tokens_output INTEGER DEFAULT 0 NOT NULL, tokens_reasoning INTEGER DEFAULT 0 NOT NULL, tokens_cache_read INTEGER DEFAULT 0 NOT NULL, tokens_cache_write INTEGER DEFAULT 0 NOT NULL, metadata TEXT, FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE)"
+        )
+        conn.execute(
+            "CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (message_id) REFERENCES message(id) ON DELETE CASCADE)"
+        )
+        project_rows = {}
+        for row in sessions:
+            project_id = row.get("project_id", "project-1")
+            project_rows[project_id] = {
+                "id": project_id,
+                "worktree": row.get("worktree", "/tmp/worktree"),
+                "vcs": row.get("vcs"),
+                "name": row.get("project_name", "Test Project"),
+                "time_created": row.get("project_time_created", row["time_created"]),
+                "time_updated": row.get("project_time_updated", row["time_updated"]),
+            }
+        for project in project_rows.values():
+            conn.execute(
+                "INSERT INTO project (id, worktree, vcs, name, icon_url, icon_color, time_created, time_updated, time_initialized, sandboxes, commands, icon_url_override) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    project["id"],
+                    project["worktree"],
+                    project["vcs"],
+                    project["name"],
+                    None,
+                    None,
+                    project["time_created"],
+                    project["time_updated"],
+                    None,
+                    json.dumps([]),
+                    None,
+                    None,
+                ),
+            )
+        for row in sessions:
+            conn.execute(
+                "INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path, agent, model, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    row["id"],
+                    row.get("project_id", "project-1"),
+                    row.get("parent_id"),
+                    row.get("slug", row["id"]),
+                    row["directory"],
+                    row["title"],
+                    row.get("version", "1"),
+                    row.get("share_url"),
+                    row.get("summary_additions"),
+                    row.get("summary_deletions"),
+                    row.get("summary_files"),
+                    row.get("summary_diffs"),
+                    row.get("revert"),
+                    row.get("permission"),
+                    row["time_created"],
+                    row["time_updated"],
+                    row.get("time_compacting"),
+                    row.get("time_archived"),
+                    row.get("workspace_id"),
+                    row.get("path"),
+                    row.get("agent"),
+                    json.dumps(row["model"]),
+                    row.get("cost", 0),
+                    row.get("tokens_input", 0),
+                    row.get("tokens_output", 0),
+                    row.get("tokens_reasoning", 0),
+                    row.get("tokens_cache_read", 0),
+                    row.get("tokens_cache_write", 0),
+                    json.dumps(row.get("metadata", {})),
+                ),
+            )
+        for row in messages or []:
+            conn.execute(
+                "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+                (
+                    row["id"],
+                    row["session_id"],
+                    row["time_created"],
+                    row["time_updated"],
+                    json.dumps(row["data"]),
+                ),
+            )
+        for row in parts or []:
+            conn.execute(
+                "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    row["id"],
+                    row["message_id"],
+                    row["session_id"],
+                    row["time_created"],
+                    row["time_updated"],
+                    json.dumps(row["data"]),
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_opencode_session_db(path: Path) -> dict[str, dict]:
+    conn = sqlite3.connect(path)
+    try:
+        def _table_exists(name: str) -> bool:
+            return conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (name,),
+            ).fetchone() is not None
+
+        def _session_rows() -> dict[str, dict]:
+            if not _table_exists("session"):
+                return {}
+            columns = [row[1] for row in conn.execute("PRAGMA table_info(session)").fetchall()]
+            return {
+                row_dict["id"]: {
+                    "id": row_dict.get("id"),
+                    "title": row_dict.get("title"),
+                    "directory": row_dict.get("directory"),
+                    "time_created": row_dict.get("time_created"),
+                    "time_updated": row_dict.get("time_updated"),
+                    "model": json.loads(row_dict["model"]) if row_dict.get("model") else None,
+                    "metadata": json.loads(row_dict["metadata"]) if row_dict.get("metadata") else {},
+                }
+                for row_dict in (
+                    dict(zip(columns, row))
+                    for row in conn.execute("SELECT * FROM session ORDER BY id").fetchall()
+                )
+            }
+
+        return {
+            "sessions": _session_rows(),
+            "messages": {
+                row[0]: {
+                    "id": row[0],
+                    "session_id": row[1],
+                    "time_created": row[2],
+                    "time_updated": row[3],
+                    "data": json.loads(row[4]),
+                }
+                for row in (conn.execute("SELECT * FROM message ORDER BY id").fetchall() if _table_exists("message") else [])
+            },
+            "parts": {
+                row[0]: {
+                    "id": row[0],
+                    "message_id": row[1],
+                    "session_id": row[2],
+                    "time_created": row[3],
+                    "time_updated": row[4],
+                    "data": json.loads(row[5]),
+                }
+                for row in (conn.execute("SELECT * FROM part ORDER BY id").fetchall() if _table_exists("part") else [])
+            },
+        }
+    finally:
+        conn.close()
 
 
 def test_opencode_config_uses_openai_compatible_provider():
@@ -788,7 +966,7 @@ def test_opencode_gateway_env_migrates_existing_session_local_opencode_data(monk
     assert (shared_state / ".mms-shared-state-migration-v1").read_text(encoding="utf-8") == "migrated=1\n"
 
 
-def test_opencode_gateway_env_migrates_only_matching_profile_data(monkeypatch, tmp_path):
+def test_opencode_gateway_env_migrates_all_legacy_profile_data_before_cleanup(monkeypatch, tmp_path):
     import mms_launchers
 
     real_home = tmp_path / "real-home"
@@ -811,7 +989,14 @@ def test_opencode_gateway_env_migrates_only_matching_profile_data(monkeypatch, t
 
     real_home.mkdir(exist_ok=True)
     monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
-    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+
+    def fake_cleanup(*_args, **_kwargs):
+        review_shared = real_home / ".local" / "share" / "mms-opencode" / "state" / "review_hub" / "opencode" / "opencode.db"
+        agent_shared = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode" / "opencode.db"
+        assert review_shared.read_text(encoding="utf-8") == "review-db"
+        assert agent_shared.read_text(encoding="utf-8") == "agent-db"
+
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", fake_cleanup)
     monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
@@ -828,7 +1013,646 @@ def test_opencode_gateway_env_migrates_only_matching_profile_data(monkeypatch, t
     assert shared_state.name == "review_hub"
     assert (shared_state / "opencode" / "opencode.db").read_text(encoding="utf-8") == "review-db"
     agent_shared_db = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode" / "opencode.db"
-    assert not agent_shared_db.exists()
+    assert agent_shared_db.read_text(encoding="utf-8") == "agent-db"
+
+
+def test_opencode_set_soft_home_replays_active_legacy_session_tail_writes(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "first pass",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 1,
+                "model": {"id": "gpt-5.4"},
+                "metadata": {"phase": "first"},
+            }
+        ],
+        messages=[
+            {
+                "id": "message-1",
+                "session_id": "session-1",
+                "time_created": 1,
+                "time_updated": 1,
+                "data": {"role": "user", "text": "hello"},
+            }
+        ],
+        parts=[
+            {
+                "id": "part-1",
+                "message_id": "message-1",
+                "session_id": "session-1",
+                "time_created": 1,
+                "time_updated": 1,
+                "data": {"type": "text", "text": "hello"},
+            }
+        ],
+    )
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_db = Path(env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    rows = _read_opencode_session_db(shared_db)
+    assert rows["sessions"]["session-1"]["title"] == "first pass"
+    assert rows["sessions"]["session-1"]["time_updated"] == 1
+    assert rows["messages"]["message-1"]["data"] == {"role": "user", "text": "hello"}
+    assert rows["parts"]["part-1"]["data"] == {"type": "text", "text": "hello"}
+
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "second pass",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 2,
+                "model": {"id": "gpt-5.5"},
+                "metadata": {"phase": "second"},
+            },
+            {
+                "id": "session-2",
+                "title": "new session",
+                "directory": "/tmp/project-b",
+                "time_created": 3,
+                "time_updated": 3,
+                "model": {"id": "deepseek-chat"},
+                "metadata": {"phase": "new"},
+            },
+        ],
+        messages=[
+            {
+                "id": "message-1",
+                "session_id": "session-1",
+                "time_created": 1,
+                "time_updated": 2,
+                "data": {"role": "assistant", "text": "updated"},
+            },
+            {
+                "id": "message-2",
+                "session_id": "session-2",
+                "time_created": 3,
+                "time_updated": 3,
+                "data": {"role": "user", "text": "new message"},
+            },
+        ],
+        parts=[
+            {
+                "id": "part-1",
+                "message_id": "message-1",
+                "session_id": "session-1",
+                "time_created": 1,
+                "time_updated": 2,
+                "data": {"type": "text", "text": "updated"},
+            },
+            {
+                "id": "part-2",
+                "message_id": "message-2",
+                "session_id": "session-2",
+                "time_created": 3,
+                "time_updated": 3,
+                "data": {"type": "text", "text": "new message"},
+            },
+        ],
+    )
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    rows = _read_opencode_session_db(shared_db)
+    assert rows["sessions"]["session-1"]["title"] == "second pass"
+    assert rows["sessions"]["session-1"]["time_updated"] == 2
+    assert rows["sessions"]["session-1"]["model"] == {"id": "gpt-5.5"}
+    assert rows["sessions"]["session-1"]["metadata"] == {"phase": "second"}
+    assert rows["sessions"]["session-2"]["title"] == "new session"
+    assert rows["messages"]["message-1"]["data"] == {"role": "assistant", "text": "updated"}
+    assert rows["messages"]["message-2"]["data"] == {"role": "user", "text": "new message"}
+    assert rows["parts"]["part-1"]["data"] == {"type": "text", "text": "updated"}
+    assert rows["parts"]["part-2"]["data"] == {"type": "text", "text": "new message"}
+
+
+def test_opencode_set_soft_home_does_not_overwrite_newer_shared_state_when_legacy_mtime_is_newer(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "legacy",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 1,
+                "model": {"id": "gpt-5.4"},
+            }
+        ],
+    )
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_db = Path(env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        shared_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "shared-newer",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 5,
+                "model": {"id": "gpt-5.5"},
+            },
+            {
+                "id": "session-2",
+                "title": "shared-only",
+                "directory": "/tmp/project-b",
+                "time_created": 2,
+                "time_updated": 2,
+                "model": {"id": "deepseek-chat"},
+            },
+        ],
+        messages=[
+            {
+                "id": "message-shared",
+                "session_id": "session-2",
+                "time_created": 2,
+                "time_updated": 2,
+                "data": {"role": "assistant", "text": "keep me"},
+            }
+        ],
+    )
+    old_db.touch()
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    rows = _read_opencode_session_db(shared_db)
+    assert rows["sessions"]["session-1"]["title"] == "shared-newer"
+    assert rows["sessions"]["session-1"]["time_updated"] == 5
+    assert rows["sessions"]["session-2"]["title"] == "shared-only"
+    assert rows["messages"]["message-shared"]["data"] == {"role": "assistant", "text": "keep me"}
+
+
+def test_opencode_set_soft_home_upgrades_existing_narrow_shared_schema(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "legacy source",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 2,
+                "model": {"id": "gpt-5.5"},
+            }
+        ],
+        messages=[
+            {
+                "id": "message-1",
+                "session_id": "session-1",
+                "time_created": 1,
+                "time_updated": 2,
+                "data": {"role": "assistant", "text": "migrated content"},
+            }
+        ],
+    )
+
+    shared_root = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode"
+    shared_root.mkdir(parents=True, exist_ok=True)
+    narrow_db = shared_root / "opencode.db"
+    conn = sqlite3.connect(narrow_db)
+    try:
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER, model TEXT)")
+        conn.execute(
+            "INSERT INTO session VALUES (?, ?, ?, ?, ?, ?)",
+            ("session-1", "narrow target", "/tmp/project-a", 1, 1, json.dumps({"id": "gpt-5.4"})),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    rows = _read_opencode_session_db(narrow_db)
+    session_columns_conn = sqlite3.connect(narrow_db)
+    try:
+        session_columns = [row[1] for row in session_columns_conn.execute("PRAGMA table_info(session)").fetchall()]
+        project_rows = session_columns_conn.execute("SELECT id, name FROM project ORDER BY id").fetchall()
+    finally:
+        session_columns_conn.close()
+
+    assert "project_id" in session_columns
+    assert "slug" in session_columns
+    assert "version" in session_columns
+    assert rows["sessions"]["session-1"]["title"] == "legacy source"
+    assert rows["sessions"]["session-1"]["time_updated"] == 2
+    assert rows["messages"]["message-1"]["data"] == {"role": "assistant", "text": "migrated content"}
+    assert project_rows[0][0] == "legacy-migrated-project"
+
+
+def test_opencode_set_soft_home_handles_narrow_source_project_schema(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    old_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(old_db)
+    try:
+        conn.execute("CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, name TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, sandboxes TEXT NOT NULL)")
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER, summary_files INTEGER, summary_diffs TEXT, revert TEXT, permission TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_compacting INTEGER, time_archived INTEGER, workspace_id TEXT, path TEXT, agent TEXT, model TEXT, cost REAL DEFAULT 0 NOT NULL, tokens_input INTEGER DEFAULT 0 NOT NULL, tokens_output INTEGER DEFAULT 0 NOT NULL, tokens_reasoning INTEGER DEFAULT 0 NOT NULL, tokens_cache_read INTEGER DEFAULT 0 NOT NULL, tokens_cache_write INTEGER DEFAULT 0 NOT NULL, metadata TEXT, FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE)")
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE)")
+        conn.execute("INSERT INTO project VALUES (?, ?, ?, ?, ?, ?)", ("project-1", "/tmp/worktree", "Legacy Narrow Project", 1, 1, json.dumps([])))
+        conn.execute("INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path, agent, model, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ("session-1", "project-1", None, "session-1", "/tmp/project-a", "legacy narrow source", "1", None, None, None, None, None, None, None, 1, 3, None, None, None, None, None, json.dumps({"id": "gpt-5.5"}), 0, 0, 0, 0, 0, 0, json.dumps({})))
+        conn.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("message-1", "session-1", 1, 3, json.dumps({"role": "assistant", "text": "from narrow project schema"})))
+        conn.commit()
+    finally:
+        conn.close()
+
+    shared_root = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode"
+    shared_root.mkdir(parents=True, exist_ok=True)
+    narrow_db = shared_root / "opencode.db"
+    conn = sqlite3.connect(narrow_db)
+    try:
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER, model TEXT)")
+        conn.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?)", ("session-1", "dst narrow", "/tmp/project-a", 1, 1, json.dumps({"id": "gpt-5.4"})))
+        conn.commit()
+    finally:
+        conn.close()
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    rows = _read_opencode_session_db(narrow_db)
+    assert rows["sessions"]["session-1"]["title"] == "legacy narrow source"
+    assert rows["sessions"]["session-1"]["time_updated"] == 3
+    assert rows["messages"]["message-1"]["data"] == {"role": "assistant", "text": "from narrow project schema"}
+
+
+def test_opencode_set_soft_home_commits_schema_backfill_when_source_tables_are_empty(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(old_db, sessions=[])
+
+    shared_root = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode"
+    shared_root.mkdir(parents=True, exist_ok=True)
+    narrow_db = shared_root / "opencode.db"
+    conn = sqlite3.connect(narrow_db)
+    try:
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER, model TEXT)")
+        conn.execute("INSERT INTO session VALUES (?, ?, ?, ?, ?, ?)", ("session-1", "dst narrow", "/tmp/project-a", 1, 1, json.dumps({"id": "gpt-5.4"})))
+        conn.commit()
+    finally:
+        conn.close()
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    conn = sqlite3.connect(narrow_db)
+    try:
+        session_columns = [row[1] for row in conn.execute("PRAGMA table_info(session)").fetchall()]
+        project_row = conn.execute("SELECT id FROM project WHERE id = ?", ("legacy-migrated-project",)).fetchone()
+        session_row = conn.execute("SELECT project_id, slug, version FROM session WHERE id = ?", ("session-1",)).fetchone()
+    finally:
+        conn.close()
+
+    assert "project_id" in session_columns
+    assert project_row == ("legacy-migrated-project",)
+    assert session_row == ("legacy-migrated-project", "session-1", "1")
+
+
+def test_opencode_gateway_env_skips_cleanup_when_migration_fails(monkeypatch, tmp_path):
+    import mms_launchers
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_opencode_dir = old_session / ".local" / "share" / "opencode"
+    old_opencode_dir.mkdir(parents=True)
+    (old_opencode_dir / "opencode.db").write_text("broken-sqlite", encoding="utf-8")
+
+    real_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(
+        mms_opencode_env,
+        "_sync_opencode_sqlite_db",
+        lambda _src, _dst: (True, False, True),
+    )
+    monkeypatch.setattr(
+        mms_launchers,
+        "_cleanup_stale_sessions",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("cleanup must be skipped on migration failure")),
+    )
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert env["MMS_OPENCODE_MIGRATION_FAILED"] == "1"
+
+
+def test_opencode_gateway_env_skips_cleanup_when_shared_target_is_non_sqlite(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "legacy source",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 2,
+                "model": {"id": "gpt-5.5"},
+            }
+        ],
+    )
+    shared_root = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode"
+    shared_root.mkdir(parents=True, exist_ok=True)
+    (shared_root / "opencode.db").write_text("corrupt-target", encoding="utf-8")
+
+    real_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(
+        mms_launchers,
+        "_cleanup_stale_sessions",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("cleanup must be skipped for corrupt shared target")),
+    )
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert env["MMS_OPENCODE_MIGRATION_FAILED"] == "1"
+
+
+def test_opencode_gateway_env_skips_cleanup_when_legacy_source_is_non_sqlite_and_shared_target_is_valid(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_opencode_dir = old_session / ".local" / "share" / "opencode"
+    old_opencode_dir.mkdir(parents=True)
+    (old_opencode_dir / "opencode.db").write_text("corrupt-source", encoding="utf-8")
+
+    shared_root = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode"
+    shared_root.mkdir(parents=True, exist_ok=True)
+    shared_db = shared_root / "opencode.db"
+    _write_opencode_session_db(
+        shared_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "shared state",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 3,
+                "model": {"id": "gpt-5.5"},
+            }
+        ],
+    )
+
+    real_home.mkdir(exist_ok=True)
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(
+        mms_launchers,
+        "_cleanup_stale_sessions",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("cleanup must be skipped for corrupt legacy source")),
+    )
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated"),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert env["MMS_OPENCODE_MIGRATION_FAILED"] == "1"
+    rows = _read_opencode_session_db(shared_db)
+    assert rows["sessions"]["session-1"]["title"] == "shared state"
+
+
+def test_opencode_set_soft_home_initial_sqlite_backup_reads_wal_state(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    old_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(old_db)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, vcs TEXT, name TEXT, icon_url TEXT, icon_color TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_initialized INTEGER, sandboxes TEXT NOT NULL, commands TEXT, icon_url_override TEXT)")
+        conn.execute("CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, parent_id TEXT, slug TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, version TEXT NOT NULL, share_url TEXT, summary_additions INTEGER, summary_deletions INTEGER, summary_files INTEGER, summary_diffs TEXT, revert TEXT, permission TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, time_compacting INTEGER, time_archived INTEGER, workspace_id TEXT, path TEXT, agent TEXT, model TEXT, cost REAL DEFAULT 0 NOT NULL, tokens_input INTEGER DEFAULT 0 NOT NULL, tokens_output INTEGER DEFAULT 0 NOT NULL, tokens_reasoning INTEGER DEFAULT 0 NOT NULL, tokens_cache_read INTEGER DEFAULT 0 NOT NULL, tokens_cache_write INTEGER DEFAULT 0 NOT NULL, metadata TEXT, FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE)")
+        conn.execute("CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL, FOREIGN KEY (session_id) REFERENCES session(id) ON DELETE CASCADE)")
+        conn.execute("INSERT INTO project VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ("project-1", "/tmp/worktree", None, "WAL Project", None, None, 1, 1, None, json.dumps([]), None, None))
+        conn.execute("INSERT INTO session (id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path, agent, model, cost, tokens_input, tokens_output, tokens_reasoning, tokens_cache_read, tokens_cache_write, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", ("session-1", "project-1", None, "session-1", "/tmp/project-a", "wal source", "1", None, None, None, None, None, None, None, 1, 1, None, None, None, None, None, json.dumps({"id": "gpt-5.4"}), 0, 0, 0, 0, 0, 0, json.dumps({})))
+        conn.execute("INSERT INTO message VALUES (?, ?, ?, ?, ?)", ("message-wal", "session-1", 1, 1, json.dumps({"role": "assistant", "text": "from wal"})))
+        conn.commit()
+
+        def _real_user_path(*parts):
+            return str(real_home.joinpath(*parts))
+
+        env = {}
+        mms_opencode_env.opencode_set_soft_home(
+            env,
+            str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+            real_user_path=_real_user_path,
+            set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+            profile_id="lite_pro_orchestrated",
+        )
+    finally:
+        conn.close()
+
+    shared_db = Path(env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    rows = _read_opencode_session_db(shared_db)
+    assert rows["sessions"]["session-1"]["title"] == "wal source"
+    assert rows["messages"]["message-wal"]["data"] == {"role": "assistant", "text": "from wal"}
+
+
+def test_opencode_set_soft_home_skips_intentionally_isolated_session_data(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    isolated_env = {"MMS_OPENCODE_ISOLATE_DATA": "1"}
+    isolated_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    mms_opencode_env.opencode_set_soft_home(
+        isolated_env,
+        str(isolated_session),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    isolated_db = Path(isolated_env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    isolated_db.parent.mkdir(parents=True, exist_ok=True)
+    isolated_db.write_text("intentional-isolation", encoding="utf-8")
+
+    shared_env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        shared_env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    shared_db = Path(shared_env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    assert not shared_db.exists()
 
 
 def test_opencode_gateway_env_materializes_session_assets(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes #44.

This follow-up hardens the remaining OpenCode legacy migration gaps left after #39:

- preserve legacy data for all profiles before stale cleanup runs
- replay active legacy-session tail writes into shared state
- upgrade narrow shared/source SQLite schemas in place
- fail closed when migration hits corrupt SQLite source/target paths so cleanup never deletes recoverable legacy data
- keep `MMS_OPENCODE_ISOLATE_DATA=1` session-local state out of shared-state auto-import

## Validation

- `PYTHONPATH=. pytest tests/test_opencode_launcher.py -q` — `92 passed`
- `python3 -m py_compile mms_core.py mms_launchers.py mms_opencode_env.py` — pass
- `PYTHONPATH=. /opt/homebrew/bin/python3 scripts/regression_fresh_user_gate.py --quick` — `fresh-user regression: PASS`, internal `61 passed`
- `git diff --check` — pass

## Notes

- Final local advisory rereview converged to approve after iterative fixes across GPT-5.5, DeepSeek, GLM, and Qwen committee members.
- Local regression report: `.ai/regression-reports/2026-06-16-issue-44-opencode-migration-harden.md`
- This PR does **not** claim a real interactive OpenCode smoke against the live runtime state; if the actual session switcher still regresses in a real launch, reopen #8 or file a fresh follow-up.
- #8 is left as the umbrella bug until merge + human closeout confirm the remaining migration gap is really done.
