### PR TITLE
[codex] fix opencode shared-state read-only copy

### DIFF
--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import tempfile
 from pathlib import Path
 
 from mms_opencode_config import opencode_config_slug
@@ -386,8 +387,7 @@ def _sync_opencode_db(src, dst):
     if handled:
         return changed, failed
     if not dst.exists():
-        shutil.copy2(src, dst)
-        return True, False
+        return _copy_opencode_file(src, dst)
     try:
         src_stat = src.stat()
         dst_stat = dst.stat()
@@ -395,8 +395,28 @@ def _sync_opencode_db(src, dst):
         return False, True
     if src_stat.st_mtime_ns <= dst_stat.st_mtime_ns:
         return False, False
-    shutil.copy2(src, dst)
-    return True, False
+    return _copy_opencode_file(src, dst)
+
+
+def _copy_opencode_file(src, dst):
+    src = Path(src)
+    dst = Path(dst)
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{dst.name}.", suffix=".tmp", dir=dst.parent)
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            shutil.copy2(src, tmp)
+            os.replace(tmp, dst)
+            return True, False
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
+    except OSError:
+        return False, True
 
 
 def _sync_opencode_tree(src, dst):
@@ -425,9 +445,9 @@ def _sync_opencode_tree(src, dst):
                     continue
             except OSError:
                 continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, target)
-        changed = True
+        file_changed, file_failed = _copy_opencode_file(path, target)
+        changed = file_changed or changed
+        failed = file_failed or failed
     return changed, failed
 
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1014,6 +1015,90 @@ def test_opencode_gateway_env_migrates_all_legacy_profile_data_before_cleanup(mo
     assert (shared_state / "opencode" / "opencode.db").read_text(encoding="utf-8") == "review-db"
     agent_shared_db = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated" / "opencode" / "opencode.db"
     assert agent_shared_db.read_text(encoding="utf-8") == "agent-db"
+
+
+def test_opencode_set_soft_home_replaces_read_only_shared_pack_file(tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    rel_pack = Path("snapshot/a/b/objects/pack/pack-test.idx")
+    old_pack = old_session / ".local" / "share" / "opencode" / rel_pack
+    old_pack.parent.mkdir(parents=True)
+    old_pack.write_text("new-pack", encoding="utf-8")
+    shared_pack = (
+        real_home
+        / ".local"
+        / "share"
+        / "mms-opencode"
+        / "state"
+        / "lite_pro_orchestrated"
+        / "opencode"
+        / rel_pack
+    )
+    shared_pack.parent.mkdir(parents=True)
+    shared_pack.write_text("old-pack", encoding="utf-8")
+    os.chmod(old_pack, 0o444)
+    os.chmod(shared_pack, 0o444)
+    os.utime(shared_pack, (1000, 1000))
+    os.utime(old_pack, (2000, 2000))
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env
+    assert shared_pack.read_text(encoding="utf-8") == "new-pack"
+    assert shared_pack.stat().st_mode & 0o777 == 0o444
+
+
+def test_opencode_set_soft_home_marks_generic_file_copy_failure_without_crashing(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_state = old_session / ".local" / "share" / "opencode" / "metadata.json"
+    old_state.parent.mkdir(parents=True)
+    old_state.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        mms_opencode_env.shutil,
+        "copy2",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(PermissionError("copy blocked")),
+    )
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert env["MMS_OPENCODE_MIGRATION_FAILED"] == "1"
 
 
 def test_opencode_set_soft_home_replays_active_legacy_session_tail_writes(tmp_path):


### PR DESCRIPTION
## Summary

- Fixes the OpenCode launch crash when shared-state migration overwrites an existing read-only Git pack/index file.
- Copies non-SQLite OpenCode migration files through a same-directory temp file, then atomically replaces the target.
- Marks generic file-copy failures as migration failures so launcher startup does not crash and stale-session cleanup is skipped.
- Speeds up `mmf` OpenCode profile startup by skipping full legacy migration scans after a profile has already been migrated and no durable checkpoint is newer.

## Root Cause

There were two related OpenCode shared-state launch problems:

1. `shutil.copy2(src, target)` opened an existing target with `wb`. If the target was a read-only Git pack/index file (`0444`), Python raised `PermissionError` even when the parent directory was writable.
2. After a successful migration marker existed, launch still scanned legacy OpenCode session trees every time. On this machine the shared state was about 950M and gateway session data about 727M, so repeated scans made `mmf` OpenCode profiles feel slow. Active log append churn could also invalidate the old migration check even though logs are not launch-critical durable state.

## What Changed

- Added atomic temp-file replacement for generic OpenCode migration file copies.
- Added marker-gated migration fast path:
  - if `.mms-shared-state-migration-v1` is `migrated=1`, unchanged legacy data skips `_sync_opencode_tree()`;
  - `opencode.db`, direct state files, and snapshot structure can still trigger replay;
  - log-file append alone no longer triggers full-tree migration.
- Added tests for read-only pack replacement, copy-failure handling, and skipping unchanged legacy migration after marker.

## Validation

- `python3 -m py_compile mms_opencode_env.py`
- `python3 -m pytest tests/test_opencode_launcher.py -k 'read_only_shared_pack_file or generic_file_copy_failure or skips_unchanged_legacy_tree_after_marker or replays_active_legacy_session_tail_writes or migrates_existing_session_local_opencode_data'`
- `python3 -m pytest tests/test_opencode_launcher.py` — 95 passed
- `python3 scripts/regression_fresh_user_gate.py --quick` — PASS

Note: fresh-user gate install dry-run logged upstream release lookup `curl 403`, but the gate completed successfully via local-source path.

Local regression report: `.ai/regression-reports/2026-06-16-opencode-shared-state-readonly-copy.md` (local/ignored).
