### PR TITLE
[codex] speed up opencode migration fast path

### DIFF
--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -151,23 +151,11 @@ def _opencode_shared_state_marker_mtime_ns(state_root):
 
 def _opencode_data_checkpoint_mtime_ns(data_dir):
     data_dir = Path(data_dir)
-    candidates = [data_dir, data_dir / "opencode.db", data_dir / "snapshot"]
+    candidates = [data_dir, data_dir / "opencode.db"]
     try:
         candidates.extend(path for path in data_dir.iterdir() if path.is_file())
     except OSError:
         return 0
-    snapshot_dir = data_dir / "snapshot"
-    if snapshot_dir.is_dir():
-        try:
-            for project_dir in snapshot_dir.iterdir():
-                candidates.append(project_dir)
-                if not project_dir.is_dir():
-                    continue
-                for session_dir in project_dir.iterdir():
-                    candidates.append(session_dir)
-                    candidates.append(session_dir / "objects" / "pack")
-        except OSError:
-            return 0
     newest = 0
     for path in candidates:
         try:
@@ -489,6 +477,37 @@ def _sync_opencode_tree(src, dst):
     return changed, failed
 
 
+def _sync_opencode_incremental_state(src, dst):
+    src = Path(src)
+    dst = Path(dst)
+    if not src.is_dir():
+        return False, False
+    changed = False
+    failed = False
+    db_changed, db_failed = _sync_opencode_db(src / "opencode.db", dst / "opencode.db")
+    changed = db_changed or changed
+    failed = db_failed or failed
+    try:
+        children = sorted(src.iterdir())
+    except OSError:
+        return changed, True
+    for path in children:
+        if not path.is_file() or path.name in {"opencode.db", "opencode.db-wal", "opencode.db-shm"}:
+            continue
+        target = dst / path.name
+        if target.exists():
+            try:
+                if path.stat().st_mtime_ns <= target.stat().st_mtime_ns:
+                    continue
+            except OSError:
+                failed = True
+                continue
+        file_changed, file_failed = _copy_opencode_file(path, target)
+        changed = file_changed or changed
+        failed = file_failed or failed
+    return changed, failed
+
+
 def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
     sessions_dir = Path(session_home).parent
     if not sessions_dir.is_dir():
@@ -518,7 +537,10 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
             if marker_mtime_ns and _mtime and _mtime <= marker_mtime_ns:
                 continue
             profile_scanned = True
-            tree_changed, tree_failed = _sync_opencode_tree(data_dir, target_opencode_dir)
+            if marker_mtime_ns:
+                tree_changed, tree_failed = _sync_opencode_incremental_state(data_dir, target_opencode_dir)
+            else:
+                tree_changed, tree_failed = _sync_opencode_tree(data_dir, target_opencode_dir)
             profile_migrated = tree_changed or profile_migrated
             profile_failed = tree_failed or profile_failed
         if profile_scanned or profile_failed or not marker_mtime_ns:

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -134,10 +134,15 @@ def _opencode_profile_state_root(real_user_path, profile_slug):
     return Path(real_user_path(".local", "share", "mms-opencode", "state", profile_slug))
 
 
-def _write_opencode_shared_state_marker(state_root, *, migrated):
+def _write_opencode_shared_state_marker(state_root, *, migrated, covered_mtime_ns=0):
     state_root.mkdir(parents=True, exist_ok=True)
     marker = state_root / _OPENCODE_SHARED_STATE_MIGRATION_MARKER
     marker.write_text("migrated=1\n" if migrated else "migrated=0\n", encoding="utf-8")
+    if migrated and covered_mtime_ns:
+        try:
+            os.utime(marker, ns=(int(covered_mtime_ns), int(covered_mtime_ns)))
+        except OSError:
+            marker.write_text("migrated=0\n", encoding="utf-8")
 
 
 def _opencode_shared_state_marker_mtime_ns(state_root):
@@ -564,11 +569,13 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
         profile_migrated = False
         profile_failed = False
         profile_scanned = False
+        profile_covered_mtime_ns = 0
         marker_mtime_ns = _opencode_shared_state_marker_mtime_ns(state_root)
         for _mtime, data_dir in sorted(candidates, reverse=True):
             if marker_mtime_ns and _mtime and _mtime <= marker_mtime_ns:
                 continue
             profile_scanned = True
+            profile_covered_mtime_ns = max(profile_covered_mtime_ns, int(_mtime or 0))
             if marker_mtime_ns:
                 tree_changed, tree_failed = _sync_opencode_incremental_state(data_dir, target_opencode_dir)
             else:
@@ -576,7 +583,11 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
             profile_migrated = tree_changed or profile_migrated
             profile_failed = tree_failed or profile_failed
         if profile_scanned or profile_failed or not marker_mtime_ns:
-            _write_opencode_shared_state_marker(state_root, migrated=bool(candidates) and not profile_failed)
+            _write_opencode_shared_state_marker(
+                state_root,
+                migrated=bool(candidates) and not profile_failed,
+                covered_mtime_ns=profile_covered_mtime_ns,
+            )
         copied = profile_migrated or copied
         failed = profile_failed or failed
     return copied, failed

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -22,6 +22,7 @@ def opencode_write_config(path, runtime, model, *, build_config_content, atomic_
 _OPENCODE_SHARED_STATE_MIGRATION_MARKER = ".mms-shared-state-migration-v1"
 _OPENCODE_PROFILE_MARKER = ".mms/opencode-profile"
 _OPENCODE_ISOLATE_DATA_MARKER = ".mms/opencode-isolate-data"
+_OPENCODE_INCREMENTAL_SKIP_DIRS = {"log"}
 
 
 def _write_opencode_profile_marker(session_home, profile_slug):
@@ -151,18 +152,36 @@ def _opencode_shared_state_marker_mtime_ns(state_root):
 
 def _opencode_data_checkpoint_mtime_ns(data_dir):
     data_dir = Path(data_dir)
-    candidates = [data_dir, data_dir / "opencode.db"]
-    try:
-        candidates.extend(path for path in data_dir.iterdir() if path.is_file())
-    except OSError:
-        return 0
     newest = 0
-    for path in candidates:
+    stack = [data_dir]
+    while stack:
+        current = stack.pop()
         try:
-            newest = max(newest, path.stat().st_mtime_ns)
+            newest = max(newest, current.stat().st_mtime_ns)
         except OSError:
             continue
+        try:
+            children = sorted(current.iterdir())
+        except OSError:
+            return 0
+        for path in children:
+            if _opencode_incremental_path_skipped(data_dir, path):
+                continue
+            try:
+                newest = max(newest, path.stat().st_mtime_ns)
+            except OSError:
+                continue
+            if path.is_dir():
+                stack.append(path)
     return newest
+
+
+def _opencode_incremental_path_skipped(root, path):
+    try:
+        rel = Path(path).relative_to(root)
+    except ValueError:
+        return False
+    return bool(rel.parts and rel.parts[0] in _OPENCODE_INCREMENTAL_SKIP_DIRS)
 
 
 def _is_sqlite_db(path):
@@ -484,27 +503,40 @@ def _sync_opencode_incremental_state(src, dst):
         return False, False
     changed = False
     failed = False
-    db_changed, db_failed = _sync_opencode_db(src / "opencode.db", dst / "opencode.db")
-    changed = db_changed or changed
-    failed = db_failed or failed
-    try:
-        children = sorted(src.iterdir())
-    except OSError:
-        return changed, True
-    for path in children:
-        if not path.is_file() or path.name in {"opencode.db", "opencode.db-wal", "opencode.db-shm"}:
+    stack = [src]
+    while stack:
+        current = stack.pop()
+        try:
+            children = sorted(current.iterdir())
+        except OSError:
+            failed = True
             continue
-        target = dst / path.name
-        if target.exists():
-            try:
-                if path.stat().st_mtime_ns <= target.stat().st_mtime_ns:
-                    continue
-            except OSError:
-                failed = True
+        for path in children:
+            if _opencode_incremental_path_skipped(src, path):
                 continue
-        file_changed, file_failed = _copy_opencode_file(path, target)
-        changed = file_changed or changed
-        failed = file_failed or failed
+            rel = path.relative_to(src)
+            target = dst / rel
+            if path.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                stack.append(path)
+                continue
+            if path.name in {"opencode.db-wal", "opencode.db-shm"}:
+                continue
+            if rel == Path("opencode.db"):
+                db_changed, db_failed = _sync_opencode_db(path, target)
+                changed = db_changed or changed
+                failed = db_failed or failed
+                continue
+            if target.exists():
+                try:
+                    if path.stat().st_mtime_ns <= target.stat().st_mtime_ns:
+                        continue
+                except OSError:
+                    failed = True
+                    continue
+            file_changed, file_failed = _copy_opencode_file(path, target)
+            changed = file_changed or changed
+            failed = file_failed or failed
     return changed, failed
 
 

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 from pathlib import Path
 
 from mms_opencode_config import opencode_config_slug
@@ -152,6 +153,13 @@ def _opencode_shared_state_marker_mtime_ns(state_root):
             return 0
         return marker.stat().st_mtime_ns
     except OSError:
+        return 0
+
+
+def _opencode_migration_cutoff_mtime_ns():
+    try:
+        return time.time_ns()
+    except Exception:
         return 0
 
 
@@ -550,6 +558,7 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
     if not sessions_dir.is_dir():
         return False, False
 
+    migration_cutoff_mtime_ns = _opencode_migration_cutoff_mtime_ns()
     candidates_by_profile = {}
     for session_dir in sessions_dir.iterdir():
         profile_slug = _opencode_legacy_profile_slug_from_session(session_dir)
@@ -569,13 +578,11 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
         profile_migrated = False
         profile_failed = False
         profile_scanned = False
-        profile_covered_mtime_ns = 0
         marker_mtime_ns = _opencode_shared_state_marker_mtime_ns(state_root)
         for _mtime, data_dir in sorted(candidates, reverse=True):
             if marker_mtime_ns and _mtime and _mtime <= marker_mtime_ns:
                 continue
             profile_scanned = True
-            profile_covered_mtime_ns = max(profile_covered_mtime_ns, int(_mtime or 0))
             if marker_mtime_ns:
                 tree_changed, tree_failed = _sync_opencode_incremental_state(data_dir, target_opencode_dir)
             else:
@@ -586,7 +593,7 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
             _write_opencode_shared_state_marker(
                 state_root,
                 migrated=bool(candidates) and not profile_failed,
-                covered_mtime_ns=profile_covered_mtime_ns,
+                covered_mtime_ns=migration_cutoff_mtime_ns,
             )
         copied = profile_migrated or copied
         failed = profile_failed or failed

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -139,6 +139,44 @@ def _write_opencode_shared_state_marker(state_root, *, migrated):
     marker.write_text("migrated=1\n" if migrated else "migrated=0\n", encoding="utf-8")
 
 
+def _opencode_shared_state_marker_mtime_ns(state_root):
+    marker = Path(state_root) / _OPENCODE_SHARED_STATE_MIGRATION_MARKER
+    try:
+        if marker.read_text(encoding="utf-8").strip() != "migrated=1":
+            return 0
+        return marker.stat().st_mtime_ns
+    except OSError:
+        return 0
+
+
+def _opencode_data_checkpoint_mtime_ns(data_dir):
+    data_dir = Path(data_dir)
+    candidates = [data_dir, data_dir / "opencode.db", data_dir / "snapshot"]
+    try:
+        candidates.extend(path for path in data_dir.iterdir() if path.is_file())
+    except OSError:
+        return 0
+    snapshot_dir = data_dir / "snapshot"
+    if snapshot_dir.is_dir():
+        try:
+            for project_dir in snapshot_dir.iterdir():
+                candidates.append(project_dir)
+                if not project_dir.is_dir():
+                    continue
+                for session_dir in project_dir.iterdir():
+                    candidates.append(session_dir)
+                    candidates.append(session_dir / "objects" / "pack")
+        except OSError:
+            return 0
+    newest = 0
+    for path in candidates:
+        try:
+            newest = max(newest, path.stat().st_mtime_ns)
+        except OSError:
+            continue
+    return newest
+
+
 def _is_sqlite_db(path):
     try:
         with Path(path).open("rb") as handle:
@@ -464,10 +502,7 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
         data_dir = session_dir / ".local" / "share" / "opencode"
         if not data_dir.is_dir():
             continue
-        try:
-            mtime = data_dir.stat().st_mtime
-        except OSError:
-            mtime = 0
+        mtime = _opencode_data_checkpoint_mtime_ns(data_dir)
         candidates_by_profile.setdefault(profile_slug, []).append((mtime, data_dir))
 
     copied = False
@@ -477,11 +512,17 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
         target_opencode_dir = state_root / "opencode"
         profile_migrated = False
         profile_failed = False
+        profile_scanned = False
+        marker_mtime_ns = _opencode_shared_state_marker_mtime_ns(state_root)
         for _mtime, data_dir in sorted(candidates, reverse=True):
+            if marker_mtime_ns and _mtime and _mtime <= marker_mtime_ns:
+                continue
+            profile_scanned = True
             tree_changed, tree_failed = _sync_opencode_tree(data_dir, target_opencode_dir)
             profile_migrated = tree_changed or profile_migrated
             profile_failed = tree_failed or profile_failed
-        _write_opencode_shared_state_marker(state_root, migrated=bool(candidates) and not profile_failed)
+        if profile_scanned or profile_failed or not marker_mtime_ns:
+            _write_opencode_shared_state_marker(state_root, migrated=bool(candidates) and not profile_failed)
         copied = profile_migrated or copied
         failed = profile_failed or failed
     return copied, failed

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1101,6 +1101,54 @@ def test_opencode_set_soft_home_marks_generic_file_copy_failure_without_crashing
     assert env["MMS_OPENCODE_MIGRATION_FAILED"] == "1"
 
 
+def test_opencode_set_soft_home_skips_unchanged_legacy_tree_after_marker(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_state = old_session / ".local" / "share" / "opencode" / "metadata.json"
+    old_state.parent.mkdir(parents=True)
+    old_state.write_text('{"status":"first"}\n', encoding="utf-8")
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_state = Path(env["XDG_DATA_HOME"]) / "opencode" / "metadata.json"
+    assert shared_state.read_text(encoding="utf-8") == '{"status":"first"}\n'
+
+    monkeypatch.setattr(
+        mms_opencode_env,
+        "_sync_opencode_tree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unchanged legacy tree was scanned")),
+    )
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert shared_state.read_text(encoding="utf-8") == '{"status":"first"}\n'
+
+
 def test_opencode_set_soft_home_replays_active_legacy_session_tail_writes(tmp_path):
     import mms_opencode_env
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1149,6 +1149,81 @@ def test_opencode_set_soft_home_skips_unchanged_legacy_tree_after_marker(monkeyp
     assert shared_state.read_text(encoding="utf-8") == '{"status":"first"}\n'
 
 
+def test_opencode_set_soft_home_replays_db_after_marker_without_full_tree_scan(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_db = old_session / ".local" / "share" / "opencode" / "opencode.db"
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "first",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 1,
+                "model": {"id": "gpt-5.4"},
+            }
+        ],
+    )
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_db = Path(env["XDG_DATA_HOME"]) / "opencode" / "opencode.db"
+    marker = Path(env["XDG_DATA_HOME"]) / ".mms-shared-state-migration-v1"
+
+    _write_opencode_session_db(
+        old_db,
+        sessions=[
+            {
+                "id": "session-1",
+                "title": "second",
+                "directory": "/tmp/project-a",
+                "time_created": 1,
+                "time_updated": 2,
+                "model": {"id": "gpt-5.5"},
+            }
+        ],
+    )
+    newer = marker.stat().st_mtime + 1
+    os.utime(old_db, (newer, newer))
+    monkeypatch.setattr(
+        mms_opencode_env,
+        "_sync_opencode_tree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("incremental replay used full tree scan")),
+    )
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    rows = _read_opencode_session_db(shared_db)
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert rows["sessions"]["session-1"]["title"] == "second"
+
+
 def test_opencode_set_soft_home_replays_active_legacy_session_tail_writes(tmp_path):
     import mms_opencode_env
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1224,6 +1224,110 @@ def test_opencode_set_soft_home_replays_db_after_marker_without_full_tree_scan(m
     assert rows["sessions"]["session-1"]["title"] == "second"
 
 
+def test_opencode_set_soft_home_replays_nested_state_after_marker_without_full_tree_scan(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_nested = old_session / ".local" / "share" / "opencode" / "storage" / "nested.txt"
+    old_nested.parent.mkdir(parents=True)
+    old_nested.write_text("first\n", encoding="utf-8")
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_nested = Path(env["XDG_DATA_HOME"]) / "opencode" / "storage" / "nested.txt"
+    marker = Path(env["XDG_DATA_HOME"]) / ".mms-shared-state-migration-v1"
+    assert shared_nested.read_text(encoding="utf-8") == "first\n"
+
+    old_nested.write_text("second\n", encoding="utf-8")
+    newer = marker.stat().st_mtime + 1
+    os.utime(old_nested, (newer, newer))
+    monkeypatch.setattr(
+        mms_opencode_env,
+        "_sync_opencode_tree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("incremental nested replay used full tree scan")),
+    )
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert shared_nested.read_text(encoding="utf-8") == "second\n"
+
+
+def test_opencode_set_soft_home_ignores_log_churn_after_marker(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_log = old_session / ".local" / "share" / "opencode" / "log" / "current.log"
+    old_log.parent.mkdir(parents=True)
+    old_log.write_text("first\n", encoding="utf-8")
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_log = Path(env["XDG_DATA_HOME"]) / "opencode" / "log" / "current.log"
+    marker = Path(env["XDG_DATA_HOME"]) / ".mms-shared-state-migration-v1"
+    assert shared_log.read_text(encoding="utf-8") == "first\n"
+
+    old_log.write_text("second\n", encoding="utf-8")
+    newer = marker.stat().st_mtime + 1
+    os.utime(old_log, (newer, newer))
+    monkeypatch.setattr(
+        mms_opencode_env,
+        "_sync_opencode_incremental_state",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("log churn triggered incremental replay")),
+    )
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert shared_log.read_text(encoding="utf-8") == "first\n"
+
+
 def test_opencode_set_soft_home_replays_active_legacy_session_tail_writes(tmp_path):
     import mms_opencode_env
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1291,6 +1291,9 @@ def test_opencode_set_soft_home_replays_write_after_incremental_scan_before_mark
     old_nested = old_data_dir / "storage" / "nested.txt"
     old_nested.parent.mkdir(parents=True)
     old_nested.write_text("first\n", encoding="utf-8")
+    os.utime(old_nested, ns=(100, 100))
+    cutoff_values = iter([100, 300, 500])
+    monkeypatch.setattr(mms_opencode_env, "_opencode_migration_cutoff_mtime_ns", lambda: next(cutoff_values))
 
     def _real_user_path(*parts):
         return str(real_home.joinpath(*parts))
@@ -1308,14 +1311,13 @@ def test_opencode_set_soft_home_replays_write_after_incremental_scan_before_mark
     assert shared_nested.read_text(encoding="utf-8") == "first\n"
 
     old_nested.write_text("second\n", encoding="utf-8")
-    checkpoint_before_scan = mms_opencode_env._opencode_data_checkpoint_mtime_ns(old_data_dir)
+    os.utime(old_nested, ns=(200, 200))
     original_incremental = mms_opencode_env._sync_opencode_incremental_state
 
     def racing_incremental(src, dst):
         result = original_incremental(src, dst)
         old_nested.write_text("third\n", encoding="utf-8")
-        race_mtime = checkpoint_before_scan + 1
-        os.utime(old_nested, ns=(race_mtime, race_mtime))
+        os.utime(old_nested, ns=(400, 400))
         return result
 
     monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", racing_incremental)
@@ -1331,7 +1333,7 @@ def test_opencode_set_soft_home_replays_write_after_incremental_scan_before_mark
 
     assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
     assert shared_nested.read_text(encoding="utf-8") == "second\n"
-    assert marker.stat().st_mtime_ns <= checkpoint_before_scan
+    assert marker.stat().st_mtime_ns <= 300
 
     monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", original_incremental)
     env3 = {}
@@ -1345,6 +1347,99 @@ def test_opencode_set_soft_home_replays_write_after_incremental_scan_before_mark
 
     assert "MMS_OPENCODE_MIGRATION_FAILED" not in env3
     assert shared_nested.read_text(encoding="utf-8") == "third\n"
+
+
+def test_opencode_set_soft_home_replays_skipped_candidate_write_during_other_candidate_replay(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    sessions_dir = real_home / ".config" / "mms" / "opencode-gateway" / "s"
+    session_a = sessions_dir / "123"
+    session_b = sessions_dir / "124"
+
+    def write_legacy_session(session_dir, nested_rel, text):
+        config_dir = session_dir / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        (config_dir / "opencode.json").write_text(
+            json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+            encoding="utf-8",
+        )
+        nested = session_dir / ".local" / "share" / "opencode" / nested_rel
+        nested.parent.mkdir(parents=True)
+        nested.write_text(text, encoding="utf-8")
+        return nested
+
+    def set_tree_mtime(root, ns):
+        paths = sorted(Path(root).rglob("*"), key=lambda path: len(path.parts), reverse=True)
+        for path in paths:
+            os.utime(path, ns=(ns, ns))
+        os.utime(root, ns=(ns, ns))
+
+    nested_a = write_legacy_session(session_a, Path("storage") / "a" / "nested.txt", "A-first\n")
+    nested_b = write_legacy_session(session_b, Path("storage") / "b" / "nested.txt", "B-first\n")
+    data_a = session_a / ".local" / "share" / "opencode"
+    data_b = session_b / ".local" / "share" / "opencode"
+    set_tree_mtime(data_a, 80)
+    set_tree_mtime(data_b, 80)
+
+    cutoff_values = iter([100, 150, 250])
+    monkeypatch.setattr(mms_opencode_env, "_opencode_migration_cutoff_mtime_ns", lambda: next(cutoff_values))
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(sessions_dir / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_a = Path(env["XDG_DATA_HOME"]) / "opencode" / "storage" / "a" / "nested.txt"
+    shared_b = Path(env["XDG_DATA_HOME"]) / "opencode" / "storage" / "b" / "nested.txt"
+    marker = Path(env["XDG_DATA_HOME"]) / ".mms-shared-state-migration-v1"
+    assert shared_a.read_text(encoding="utf-8") == "A-first\n"
+    assert shared_b.read_text(encoding="utf-8") == "B-first\n"
+    assert marker.stat().st_mtime_ns <= 100
+
+    nested_b.write_text("B-second\n", encoding="utf-8")
+    os.utime(nested_b, ns=(140, 140))
+    original_incremental = mms_opencode_env._sync_opencode_incremental_state
+
+    def racing_incremental(src, dst):
+        result = original_incremental(src, dst)
+        if Path(src) == data_b:
+            nested_a.write_text("A-race\n", encoding="utf-8")
+            os.utime(nested_a, ns=(160, 160))
+        return result
+
+    monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", racing_incremental)
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(sessions_dir / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert shared_a.read_text(encoding="utf-8") == "A-first\n"
+    assert shared_b.read_text(encoding="utf-8") == "B-second\n"
+    assert marker.stat().st_mtime_ns <= 150
+
+    monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", original_incremental)
+    env3 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env3,
+        str(sessions_dir / "202"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env3
+    assert shared_a.read_text(encoding="utf-8") == "A-race\n"
 
 
 def test_opencode_set_soft_home_ignores_log_churn_after_marker(monkeypatch, tmp_path):

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -1276,6 +1276,77 @@ def test_opencode_set_soft_home_replays_nested_state_after_marker_without_full_t
     assert shared_nested.read_text(encoding="utf-8") == "second\n"
 
 
+def test_opencode_set_soft_home_replays_write_after_incremental_scan_before_marker(monkeypatch, tmp_path):
+    import mms_opencode_env
+
+    real_home = tmp_path / "real-home"
+    old_session = real_home / ".config" / "mms" / "opencode-gateway" / "s" / "123"
+    old_config_dir = old_session / ".config" / "opencode"
+    old_config_dir.mkdir(parents=True)
+    (old_config_dir / "opencode.json").write_text(
+        json.dumps({"default_agent": "mobius-builder-pro"}) + "\n",
+        encoding="utf-8",
+    )
+    old_data_dir = old_session / ".local" / "share" / "opencode"
+    old_nested = old_data_dir / "storage" / "nested.txt"
+    old_nested.parent.mkdir(parents=True)
+    old_nested.write_text("first\n", encoding="utf-8")
+
+    def _real_user_path(*parts):
+        return str(real_home.joinpath(*parts))
+
+    env = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "200"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+    shared_nested = Path(env["XDG_DATA_HOME"]) / "opencode" / "storage" / "nested.txt"
+    marker = Path(env["XDG_DATA_HOME"]) / ".mms-shared-state-migration-v1"
+    assert shared_nested.read_text(encoding="utf-8") == "first\n"
+
+    old_nested.write_text("second\n", encoding="utf-8")
+    checkpoint_before_scan = mms_opencode_env._opencode_data_checkpoint_mtime_ns(old_data_dir)
+    original_incremental = mms_opencode_env._sync_opencode_incremental_state
+
+    def racing_incremental(src, dst):
+        result = original_incremental(src, dst)
+        old_nested.write_text("third\n", encoding="utf-8")
+        race_mtime = checkpoint_before_scan + 1
+        os.utime(old_nested, ns=(race_mtime, race_mtime))
+        return result
+
+    monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", racing_incremental)
+
+    env2 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env2,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "201"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env2
+    assert shared_nested.read_text(encoding="utf-8") == "second\n"
+    assert marker.stat().st_mtime_ns <= checkpoint_before_scan
+
+    monkeypatch.setattr(mms_opencode_env, "_sync_opencode_incremental_state", original_incremental)
+    env3 = {}
+    mms_opencode_env.opencode_set_soft_home(
+        env3,
+        str(real_home / ".config" / "mms" / "opencode-gateway" / "s" / "202"),
+        real_user_path=_real_user_path,
+        set_session_home_hint=lambda e, s: e.update({"MMS_SESSION_HOME": s}),
+        profile_id="lite_pro_orchestrated",
+    )
+
+    assert "MMS_OPENCODE_MIGRATION_FAILED" not in env3
+    assert shared_nested.read_text(encoding="utf-8") == "third\n"
+
+
 def test_opencode_set_soft_home_ignores_log_churn_after_marker(monkeypatch, tmp_path):
     import mms_opencode_env
 


### PR DESCRIPTION
## Summary

- Speeds up `mmf` OpenCode profile startup after shared-state migration has already completed.
- Uses `.mms-shared-state-migration-v1` as a marker to skip unchanged legacy session data.
- After the marker exists, avoids initial full-tree migration while still incrementally replaying durable state updates.
- Preserves nested non-log subtree replay for `storage/`, `snapshot/`, `repos/`, `tool-output/`, etc.
- Treats `log/` as volatile after the marker, so log append churn does not force launch-time replay.
- Records marker mtime as a profile-level migration-start cutoff, so writes during the replay/marker window are replayed next launch even across multiple same-profile candidates.

## Root Cause

PR #55 fixed the read-only copy crash, but it did not fix slow startup. The slow path was separate: OpenCode shared-state migration still walked legacy session trees on launch. On the inspected machine, `~/.local/share/mms-opencode` was about 950M and `~/.config/mms/opencode-gateway` was about 727M with multiple active OpenCode sessions, so repeated migration scans made profile startup slow.

Earlier versions of this PR had three review-blocking edge cases:

1. Marker-after replay copied only SQLite/top-level files and dropped nested state updates. The current version recursively replays non-log nested state.
2. Marker mtime used marker write time. A legacy write landing after replay but before marker write could be skipped forever. The current version bounds marker mtime to the migration-start cutoff.
3. With multiple same-profile legacy candidates, a skipped candidate could receive a write while another candidate replayed and then be crossed by the scanned candidate's higher checkpoint. The current version uses a profile-level migration-start cutoff rather than max scanned candidate checkpoint.

## What Changed

- Added a marker mtime check for successful shared-state migration.
- Added a recursive non-log checkpoint for marker-after state.
- Skips replay when marker-current legacy data is unchanged.
- Uses incremental replay after marker instead of initial full-tree migration:
  - SQLite state is still handled by `_sync_opencode_db()`;
  - nested non-log state is replayed recursively;
  - `log/` is intentionally ignored after marker.
- Marker write now uses the profile-level migration-start cutoff as marker mtime.
- Added regression coverage for:
  - skipping unchanged legacy data after marker;
  - replaying DB updates after marker without initial full-tree migration;
  - replaying nested `storage/` updates after marker;
  - ignoring `log/` churn after marker;
  - replaying writes that land after incremental replay but before marker write;
  - replaying writes to a skipped same-profile candidate during another candidate's replay.

## Validation

- `python3 -m py_compile mms_opencode_env.py`
- real-state dry check: current `committee` session dirs evaluated as bounded `incremental` or `skip`, not initial full-tree migration
- `python3 -m pytest tests/test_opencode_launcher.py -k 'write_after_incremental_scan_before_marker or skipped_candidate_write_during_other_candidate_replay or replays_nested_state_after_marker_without_full_tree_scan or ignores_log_churn_after_marker or skips_unchanged_legacy_tree_after_marker or replays_db_after_marker_without_full_tree_scan'` — 6 passed
- `python3 -m pytest tests/test_opencode_launcher.py` — 100 passed
- `python3 scripts/regression_fresh_user_gate.py --quick` — PASS
