### PR TITLE
P0 fix: dev SyntaxError — restore COMMITTEE_HOST_AUTHORITY_CONTRACT closing paren

### DIFF
--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -36,6 +36,9 @@ COMMITTEE_HOST_AUTHORITY_CONTRACT = (
     "by the profile; the user does not need to restate 'dispatch, do not "
     "modify, only summarize'. The only host writes allowed are the bounded "
     "opt-in execution actions explicitly granted by the user."
+)
+
+
 DEBATE_HOST_AUTHORITY_CONTRACT = (
     "Host authority contract: you are a neutral dispatcher, a faithful "
     "summarizer, and a rubric referee; you are not the decision authority and "


### PR DESCRIPTION
## P0 — dev 当前无法 import

Closes #59。`#51 + #53` 合并事故：两个 PR 都在 `OPENCODE_REVIEW_MISSION_CONTRACT` 后同一位置新增模块常量，git auto-merge 丢掉了 `COMMITTEE_HOST_AUTHORITY_CONTRACT` 的闭合 `)`，导致 `mms_opencode_agents.py` 在 dev 上 `SyntaxError: '(' was never closed`，整个 opencode launcher 模块无法 import。

单独 PR #51/#53 各自有效（re-review 92 passed 是各自分支），仅合并后损坏。

## Fix

补回 committee 常量的闭合 `)`（+ 两空行，与 debate 常量对齐）。

## Validation

- `python3 -m py_compile mms_opencode_agents.py` — OK
- `pytest tests/test_opencode_launcher.py` — **93 passed, 1 failed**
  - 修复前：模块 import 失败、大面积 65 failed。
  - 修复后唯一失败 `test_core_opencode_lite_pro_...` 是已知 env-dependent bug（#58，低优先），与本 hotfix 无关。

## 后续

可考虑把两个 host authority 常量放不同位置，降低同位置 merge 冲突概率（#59 备注）。