### PR TITLE
feat: add debate trigger contract (v1.5 slice 2)

### DIFF
--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -56,6 +56,17 @@ DEBATE_HOST_AUTHORITY_CONTRACT = (
 )
 
 
+DEBATE_TRIGGER_CONTRACT = (
+    "Debate trigger contract: this profile is for a fork or proposition - "
+    "'A vs B', 'should we do X', or an undecided direction before "
+    "implementation (the 'when in doubt, debate it' and issue-direction case). "
+    "If you are handed a pure judge-this-artifact task with no fork (the shape "
+    "the committee profile handles), do not run debate rounds on it: restate it "
+    "as an explicit proposition to debate, or hand it back as 'use the committee "
+    "profile'."
+)
+
+
 def opencode_lite_agent_configs(model_ref):
     """Return session-local OpenCode agents for the MMS lite lane."""
     if not model_ref:
@@ -1292,6 +1303,7 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
         "committee vote files, committee verdict vocabulary, committee decision "
         "artifacts, review-hub request roots, or legacy mms discuss semantics. "
         + DEBATE_HOST_AUTHORITY_CONTRACT + " "
+        + DEBATE_TRIGGER_CONTRACT + " "
         + OPENCODE_REVIEW_MISSION_CONTRACT + " "
         "Use only the selected debate subagents available in this session: "
         f"{member_list_text}. Do not invent missing agents or model aliases. "
@@ -1373,6 +1385,7 @@ def opencode_debate_agent_configs(agent_models, *, roster_config=None, agent_pol
                     "v1 self-check checklist, use host_authored synthesis only, and "
                     "preserve real disagreement instead of claiming fake convergence. "
                     + DEBATE_HOST_AUTHORITY_CONTRACT + " "
+                    + DEBATE_TRIGGER_CONTRACT + " "
                     "Send the unchanged mission block in every debate member packet. "
                     "Repeat the MMS-MISSION block at the top and MMS-MISSION plus "
                     "MMS-TARGET at the bottom."

--- a/mms_opencode_profiles.py
+++ b/mms_opencode_profiles.py
@@ -28,14 +28,14 @@ OPENCODE_PROFILE_OPTIONS = [
         "profile_id": OPENCODE_COMMITTEE_PROFILE_ID,
         "label": "Committee",
         "badge": "委员会",
-        "summary": "通用委员会：GPT-5.4 host 默认派发给所选 subagent，最后汇总共识/分歧；默认只选 GPT-5.4，可加 GPT-5.5、DeepSeek、GLM、MiMo、Kimi、MiniMax。",
+        "summary": "通用委员会：评判已有 artifact（执行后 review / 共识汇总）；遇事不决、要对 fork/命题辩论时改用 Debate。GPT-5.4 host 默认派发给所选 subagent，最后汇总共识/分歧；默认只选 GPT-5.4，可加 GPT-5.5、DeepSeek、GLM、MiMo、Kimi、MiniMax。",
     },
     {
         "id": "debate",
         "profile_id": OPENCODE_DEBATE_PROFILE_ID,
         "label": "Debate",
         "badge": "辩论",
-        "summary": "结构化辩论：独立于 Committee；blind seed -> crossfire -> revision，由 debate-host 写 .ai/debate/<thread-id>/ artifacts 并按 rubric 输出 resolution。",
+        "summary": "结构化辩论：用于 fork / 命题（遇事不决、issue 开发方向），不评判单一 artifact（那走 Committee）；独立于 Committee；blind seed -> crossfire -> revision，由 debate-host 写 .ai/debate/<thread-id>/ artifacts 并按 rubric 输出 resolution。",
     },
     {
         "id": "omo",

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -3306,7 +3306,8 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
     authority_order = (
         "human > deterministic facts > rubric applied to member outputs > host"
     )
-    # Primary and fallback hosts must carry the identical full authority contract.
+    # Primary and fallback hosts must carry the identical full authority contract
+    # and the same debate trigger contract.
     for prompt_text in (host_prompt_lower, host_pro_prompt):
         assert "host authority contract" in prompt_text
         assert "you are not the decision authority" in prompt_text
@@ -3315,6 +3316,9 @@ def test_core_opencode_debate_profile_builds_structured_debate_roster(monkeypatc
         assert "never invent a member's missing position" in prompt_text
         assert "aggregate losslessly" in prompt_text
         assert "the user does not need to" in prompt_text
+        assert "debate trigger contract" in prompt_text
+        assert "fork or proposition" in prompt_text
+        assert "use the committee profile" in prompt_text
     assert "mms-mission" in host_pro_prompt
     assert "mms-target" in host_pro_prompt
     assert "mms-mode" in host_pro_prompt

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -4382,6 +4382,21 @@ def test_opencode_smoke_classifies_thinking_block_roundtrip_as_blocked():
     assert smoke_opencode_profile._health_status(error_class, 0.5) == "blocked"
 
 
+def test_opencode_profile_summaries_state_debate_vs_committee_split():
+    import mms_opencode_profiles as profiles
+
+    by_id = {opt.get("id"): opt for opt in profiles.OPENCODE_PROFILE_OPTIONS}
+    debate_summary = by_id["debate"]["summary"]
+    committee_summary = by_id["committee"]["summary"]
+    # Debate selection surface states the fork/proposition trigger split.
+    assert "fork" in debate_summary
+    assert "命题" in debate_summary
+    assert "Committee" in debate_summary
+    # Committee side is symmetric: judges an artifact, points forks at Debate.
+    assert "artifact" in committee_summary
+    assert "Debate" in committee_summary
+
+
 def test_core_opencode_profile_menu_includes_lite_pro_health_summary(monkeypatch):
     import mms_core
 


### PR DESCRIPTION
## Summary

debate v1.5 第二刀（issue #49，upgrade ③ trigger-contract split）。把 `DEBATE_TRIGGER_CONTRACT` 写进 `debate-host` / `debate-host-pro`：

- 本 profile 用于 **fork / proposition**（"A vs B"、"要不要做 X"、遇事不决 / issue 方向）。
- 收到**纯评判 artifact** 的任务（committee 的形状）时，不跑 debate rounds：reframe 成显式命题，或退回 `use the committee profile`。
- 共享常量 `DEBATE_TRIGGER_CONTRACT`，primary + fallback 复用，**对称测试**（防 fallback drift，沿用 PR #51 的做法）。

## Scope / 边界

- 只动 `mms_opencode_agents.py` 的 debate host prompt + `tests/test_opencode_launcher.py` 断言。
- **不碰** launcher/routing/bridge/committee/runtime；不加 model route；不改 contract/rubric schema。
- base 已含 PR #60 hotfix（committee 常量 `)`）。

## Validation

- `python3 -m py_compile mms_opencode_agents.py` — OK
- `pytest tests/test_opencode_launcher.py::test_core_opencode_debate_profile_builds_structured_debate_roster` — passed（含新断言）
- `pytest tests/test_opencode_launcher.py` — 93 passed, 1 failed
  - 唯一失败 `test_core_opencode_lite_pro_...` 为已知 env-dependent bug（#58，低优先），与本 PR 无关。
- 仅 prompt 字符串 + 测试改动，不触及 core/launcher/installer/session/config/resume/HOME-XDG，故未跑 fresh-user gate。

## 关联

Issue #49（v1.5 spec）。剩余 slice：① assigned sides、② persuasion ledger、④ pivot、⑤ advisory synthesizer。