### PR TITLE
feat(opencode): experimental NSR auto-continue plugin (default OFF)

### DIFF
--- a/hooks/nsr-builtin-hook.py
+++ b/hooks/nsr-builtin-hook.py
@@ -299,6 +299,13 @@ def _handle(host: str, request: dict[str, Any]) -> dict[str, Any]:
         status = _clean(loop.get("status", "running")).lower()
         next_action = _clean(loop.get("next_action"))
         if status not in {"blocked", "complete"} and next_action:
+            # OpenCode already bounds synthetic continuation locally via the plugin's
+            # per-session cap. Bypassing the builtin identical-stop repeat guard here
+            # keeps the experimental OpenCode path from self-disabling after a single
+            # unchanged-state continuation while preserving the stricter guard for the
+            # native claude/codex Stop-hook flows.
+            if host == "opencode":
+                return {"decision": "block", "reason": _context_message(state, event="stop")}
             return _guarded_stop_block(session_id, state, _context_message(state, event="stop"))
         if _clear_stop_block_guard(state):
             _save_state(session_id, state)

--- a/hooks/opencode-nsr.ts
+++ b/hooks/opencode-nsr.ts
@@ -19,14 +19,36 @@
 //   - the `session.idle` event field carrying the session id,
 //   - the client.session.prompt() request body,
 //   - MMS_HOME being present in the OpenCode process env.
+import { existsSync } from "node:fs"
 import type { Plugin } from "@opencode-ai/plugin"
 
 const MAX_AUTO_CONTINUE = 4
 const autoContinues = new Map<string, number>()
 
 function nsrHookPath(): string {
-  const home = process.env.MMS_HOME || process.env.MMS_REAL_HOME || ""
-  return home ? `${home}/hooks/nsr-builtin-hook.py` : ""
+  // The OpenCode child env does NOT carry MMS_HOME (confirmed in committee review),
+  // so resolve the hook next to this plugin's own real file first: the overlay
+  // symlinks mms-nsr.ts -> <mms>/hooks/opencode-nsr.ts, whose sibling is the hook.
+  // Fall back to explicit env only when the plugin was copied, not symlinked.
+  const candidates: string[] = []
+  try {
+    const dir = (import.meta as { dir?: string }).dir
+    if (dir) candidates.push(`${dir}/nsr-builtin-hook.py`)
+  } catch {
+    // import.meta.dir unavailable; rely on env fallbacks below.
+  }
+  const explicit = process.env.MMS_OPENCODE_NSR_HOOK
+  if (explicit) candidates.push(explicit)
+  const home = process.env.MMS_HOME || process.env.MMS_REAL_HOME
+  if (home) candidates.push(`${home}/hooks/nsr-builtin-hook.py`)
+  for (const candidate of candidates) {
+    try {
+      if (existsSync(candidate)) return candidate
+    } catch {
+      // ignore and try the next candidate
+    }
+  }
+  return ""
 }
 
 export const NsrOpenCodePlugin: Plugin = async ({ $, client, directory }) => {
@@ -48,8 +70,13 @@ export const NsrOpenCodePlugin: Plugin = async ({ $, client, directory }) => {
         if (used >= MAX_AUTO_CONTINUE) return // runaway backstop
 
         // Reuse the exact NSR decision used for claude/codex (Stop event contract).
+        // KNOWN (committee finding, needs live design): a bare synthesized "Stop"
+        // can trip NSR's builtin repeat-guard (identical signature -> allowed after
+        // STOP_BLOCK_REPEAT_LIMIT), so the local MAX_AUTO_CONTINUE cap above is the
+        // effective budget. `host` lets a future NSR build special-case opencode.
         const payload = JSON.stringify({
           hook_event_name: "Stop",
+          host: "opencode",
           session_id: sessionID,
           cwd: directory || "",
         })

--- a/hooks/opencode-nsr.ts
+++ b/hooks/opencode-nsr.ts
@@ -10,15 +10,15 @@
 // SAFETY (this is a different, re-prompt-based mechanism with runaway risk):
 //   - Opt-in only: inert unless MMS_OPENCODE_NSR=1 (the MMS overlay also gates it
 //     off by default). Never auto-continues a session the user didn't enable.
-//   - Hard per-session cap (MAX_AUTO_CONTINUE) on TOP of NSR's own repeat-guard,
-//     so a decision bug cannot loop forever.
+//   - Hard per-session cap (MAX_AUTO_CONTINUE). The builtin hook special-cases
+//     host=opencode and leaves the continuation budget to this local cap.
 //   - Fail-open: any error / missing hook / unknown shape => do nothing.
 //
 // NOT YET VERIFIED in a live OpenCode session. The exact shapes below are best
 // effort from the SDK type defs and MUST be confirmed live before enabling:
 //   - the `session.idle` event field carrying the session id,
 //   - the client.session.prompt() request body,
-//   - MMS_HOME being present in the OpenCode process env.
+//   - the real idle cadence after an internal re-prompt in a long-running session.
 import { existsSync } from "node:fs"
 import type { Plugin } from "@opencode-ai/plugin"
 
@@ -70,10 +70,8 @@ export const NsrOpenCodePlugin: Plugin = async ({ $, client, directory }) => {
         if (used >= MAX_AUTO_CONTINUE) return // runaway backstop
 
         // Reuse the exact NSR decision used for claude/codex (Stop event contract).
-        // KNOWN (committee finding, needs live design): a bare synthesized "Stop"
-        // can trip NSR's builtin repeat-guard (identical signature -> allowed after
-        // STOP_BLOCK_REPEAT_LIMIT), so the local MAX_AUTO_CONTINUE cap above is the
-        // effective budget. `host` lets a future NSR build special-case opencode.
+        // The builtin hook special-cases host=opencode so this local cap remains the
+        // effective continuation budget for the experimental OpenCode path.
         const payload = JSON.stringify({
           hook_event_name: "Stop",
           host: "opencode",

--- a/hooks/opencode-nsr.ts
+++ b/hooks/opencode-nsr.ts
@@ -1,0 +1,81 @@
+// EXPERIMENTAL — OpenCode NSR (Non-Stop-Run) auto-continue.
+//
+// codex/claude implement NSR as a *Stop hook* that returns {decision:block} to
+// keep the agent running while a loop has a next_action. OpenCode's plugin API
+// has no stop-block hook, so this uses the only mechanism available:
+//   listen for the `session.idle` bus event  ->  ask the SAME NSR decision
+//   (hooks/nsr-builtin-hook.py, reused, not reimplemented)  ->  if it says
+//   "block", re-prompt the session via client.session.prompt() to continue.
+//
+// SAFETY (this is a different, re-prompt-based mechanism with runaway risk):
+//   - Opt-in only: inert unless MMS_OPENCODE_NSR=1 (the MMS overlay also gates it
+//     off by default). Never auto-continues a session the user didn't enable.
+//   - Hard per-session cap (MAX_AUTO_CONTINUE) on TOP of NSR's own repeat-guard,
+//     so a decision bug cannot loop forever.
+//   - Fail-open: any error / missing hook / unknown shape => do nothing.
+//
+// NOT YET VERIFIED in a live OpenCode session. The exact shapes below are best
+// effort from the SDK type defs and MUST be confirmed live before enabling:
+//   - the `session.idle` event field carrying the session id,
+//   - the client.session.prompt() request body,
+//   - MMS_HOME being present in the OpenCode process env.
+import type { Plugin } from "@opencode-ai/plugin"
+
+const MAX_AUTO_CONTINUE = 4
+const autoContinues = new Map<string, number>()
+
+function nsrHookPath(): string {
+  const home = process.env.MMS_HOME || process.env.MMS_REAL_HOME || ""
+  return home ? `${home}/hooks/nsr-builtin-hook.py` : ""
+}
+
+export const NsrOpenCodePlugin: Plugin = async ({ $, client, directory }) => {
+  // Opt-in + reachable hook are hard preconditions; otherwise stay completely inert.
+  if (process.env.MMS_OPENCODE_NSR !== "1") return {}
+  const hook = nsrHookPath()
+  if (!hook) return {}
+
+  return {
+    event: async ({ event }) => {
+      try {
+        const ev = event as { type?: string; properties?: Record<string, unknown> }
+        if (!ev || ev.type !== "session.idle") return
+        const props = ev.properties || {}
+        const sessionID = String(props.sessionID || props.sessionId || props.session_id || "")
+        if (!sessionID) return
+
+        const used = autoContinues.get(sessionID) || 0
+        if (used >= MAX_AUTO_CONTINUE) return // runaway backstop
+
+        // Reuse the exact NSR decision used for claude/codex (Stop event contract).
+        const payload = JSON.stringify({
+          hook_event_name: "Stop",
+          session_id: sessionID,
+          cwd: directory || "",
+        })
+        const res = await $`echo ${payload} | python3 ${hook} opencode`.quiet().nothrow()
+        const out = (res && res.stdout ? res.stdout.toString() : "").trim()
+        if (!out) return
+
+        let decision: { decision?: string; reason?: string; continue?: boolean }
+        try {
+          decision = JSON.parse(out)
+        } catch {
+          return
+        }
+        if (decision.decision !== "block" || !decision.reason) return // allow stop
+
+        autoContinues.set(sessionID, used + 1)
+        // Re-prompt to continue. Body shape is best-effort; verify live.
+        await client.session.prompt({
+          path: { id: sessionID },
+          body: { parts: [{ type: "text", text: String(decision.reason) }] },
+        } as never)
+      } catch {
+        // fail-open: never break an OpenCode turn
+      }
+    },
+  }
+}
+
+export default NsrOpenCodePlugin

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -11650,8 +11650,11 @@ def _opencode_gateway_env(runtime, model_info=None):
         resolve_codegraph_root=_resolve_codegraph_root,
         resolve_toon_root=_resolve_toon_root,
         resolve_token_saver_root=_resolve_token_saver_root,
+        resolve_xmem_root=_resolve_xmem_root,
         session_skill_disabled=_session_skill_disabled,
         opencode_rtk_plugin_enabled=_opencode_rtk_plugin_enabled,
+        opencode_xmem_plugin_enabled=_opencode_xmem_plugin_enabled,
+        opencode_nsr_plugin_enabled=_opencode_nsr_plugin_enabled,
     )
 
 

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -89,6 +89,8 @@ from mms_opencode_session import (
     overlay_opencode_session_assets as _overlay_opencode_session_assets_impl,
     opencode_rtk_plugin_path as _opencode_rtk_plugin_path_impl,
     opencode_session_plugin_runtime as _opencode_session_plugin_runtime,
+    opencode_xmem_plugin_path as _opencode_xmem_plugin_path_impl,
+    opencode_nsr_plugin_path as _opencode_nsr_plugin_path_impl,
     overlay_opencode_plugin as _overlay_opencode_plugin_impl,
 )
 from mms_core import (
@@ -5629,6 +5631,9 @@ def _overlay_opencode_session_assets(config_dir, session_home, *, enable_caveman
         overlay_toon_session_entries=_overlay_toon_session_entries,
         overlay_token_saver_session_entries=_overlay_token_saver_session_entries,
         overlay_managed_dynamic_skill_entries=_overlay_managed_dynamic_skill_entries,
+        overlay_xmem_session_entries=_overlay_xmem_session_entries,
+        overlay_opencode_xmem_plugin=_overlay_opencode_xmem_plugin,
+        overlay_opencode_nsr_plugin=_overlay_opencode_nsr_plugin,
     )
 
 
@@ -11542,6 +11547,35 @@ def _overlay_opencode_rtk_plugin(config_dir, runtime=None):
 
 def _opencode_rtk_plugin_enabled(runtime=None):
     return bool(_opencode_rtk_plugin_path(runtime))
+
+
+def _opencode_xmem_plugin_enabled(runtime=None):
+    return bool(_opencode_xmem_plugin_path(runtime))
+
+
+def _opencode_nsr_plugin_path(runtime=None):
+    # Keep OpenCode aligned with the repo-wide NSR toggle: if launch/runtime says
+    # NSR is disabled, do not overlay the experimental plugin even when the env
+    # opt-in is present.
+    if not _runtime_nsr_enabled(runtime):
+        return ""
+    return _opencode_nsr_plugin_path_impl(
+        runtime,
+        module_file=__file__,
+        normalize_session_surface_disabled=_normalize_session_surface_disabled,
+    )
+
+
+def _overlay_opencode_nsr_plugin(config_dir, runtime=None):
+    return _overlay_opencode_plugin_impl(
+        config_dir,
+        _opencode_nsr_plugin_path(runtime),
+        "mms-nsr.ts",
+    )
+
+
+def _opencode_nsr_plugin_enabled(runtime=None):
+    return bool(_opencode_nsr_plugin_path(runtime))
 
 
 def _build_opencode_config_payload(runtime, model_name=""):

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -673,8 +673,11 @@ def opencode_gateway_env(
     resolve_codegraph_root,
     resolve_toon_root,
     resolve_token_saver_root,
+    resolve_xmem_root,
     session_skill_disabled,
     opencode_rtk_plugin_enabled,
+    opencode_xmem_plugin_enabled,
+    opencode_nsr_plugin_enabled=lambda runtime: False,
     environ=None,
     getpid=os.getpid,
 ):
@@ -741,6 +744,9 @@ def opencode_gateway_env(
             "codegraph": bool(resolve_codegraph_root()) and not session_skill_disabled(disabled_session_surfaces, "codegraph"),
             "toon": bool(resolve_toon_root()) and not session_skill_disabled(disabled_session_surfaces, "toon"),
             "token_saver": bool(resolve_token_saver_root()) and not session_skill_disabled(disabled_session_surfaces, "token-saver"),
+            "xmem": bool(resolve_xmem_root()) and not session_skill_disabled(disabled_session_surfaces, "xmem"),
+            "opencode_xmem": opencode_xmem_plugin_enabled(runtime),
+            "opencode_nsr": opencode_nsr_plugin_enabled(runtime),
         },
     )
     return env

--- a/mms_opencode_session.py
+++ b/mms_opencode_session.py
@@ -55,6 +55,50 @@ def opencode_rtk_plugin_path(
     return opencode_plugin_path(module_file, "opencode-rtk.ts")
 
 
+def opencode_xmem_plugin_path(
+    runtime=None,
+    *,
+    module_file,
+    normalize_session_surface_disabled,
+    session_skill_disabled,
+    resolve_xmem_root,
+    xmem_cli_path,
+):
+    disabled = normalize_session_surface_disabled(
+        (runtime or {}).get("disabled_session_surfaces") if isinstance(runtime, dict) else None
+    )
+    if "opencode-xmem" in disabled.get("hooks", set()) or session_skill_disabled(disabled, "xmem"):
+        return ""
+    if not resolve_xmem_root() and not xmem_cli_path():
+        return ""
+    return opencode_plugin_path(module_file, "opencode-xmem.ts")
+
+
+def opencode_nsr_plugin_path(
+    runtime=None,
+    *,
+    module_file,
+    normalize_session_surface_disabled,
+    runtime_bool=opencode_runtime_bool,
+    env_bool=opencode_env_bool,
+):
+    # EXPERIMENTAL + default OFF. NSR auto-continue on OpenCode uses a different
+    # (session.idle -> re-prompt) mechanism than the codex/claude Stop hook and is
+    # unverified live, so it stays inert unless explicitly opted in.
+    disabled = normalize_session_surface_disabled(
+        (runtime or {}).get("disabled_session_surfaces") if isinstance(runtime, dict) else None
+    )
+    if "opencode-nsr" in disabled.get("hooks", set()):
+        return ""
+    # MMS_OPENCODE_NSR is the primary opt-in switch (default OFF); runtime can still
+    # force-disable it. Both must allow it before the experimental plugin overlays.
+    if not env_bool("MMS_OPENCODE_NSR", False):
+        return ""
+    if not runtime_bool(runtime or {}, "opencode_nsr", True):
+        return ""
+    return opencode_plugin_path(module_file, "opencode-nsr.ts")
+
+
 def overlay_opencode_plugin(config_dir, plugin_path, target_name):
     if not plugin_path:
         return False
@@ -87,6 +131,7 @@ def overlay_opencode_session_assets(
     overlay_token_saver_session_entries,
     overlay_managed_dynamic_skill_entries,
     overlay_codegraph_session_entries=None,
+    overlay_opencode_nsr_plugin=None,
 ):
     if not config_dir or not session_home:
         return
@@ -107,3 +152,7 @@ def overlay_opencode_session_assets(
     overlay_toon_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
     overlay_token_saver_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
     overlay_managed_dynamic_skill_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
+    overlay_xmem_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
+    overlay_opencode_xmem_plugin(config_dir, plugin_runtime)
+    if overlay_opencode_nsr_plugin is not None:
+        overlay_opencode_nsr_plugin(config_dir, plugin_runtime)

--- a/mms_opencode_session.py
+++ b/mms_opencode_session.py
@@ -130,6 +130,8 @@ def overlay_opencode_session_assets(
     overlay_toon_session_entries,
     overlay_token_saver_session_entries,
     overlay_managed_dynamic_skill_entries,
+    overlay_xmem_session_entries=None,
+    overlay_opencode_xmem_plugin=None,
     overlay_codegraph_session_entries=None,
     overlay_opencode_nsr_plugin=None,
 ):
@@ -152,7 +154,9 @@ def overlay_opencode_session_assets(
     overlay_toon_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
     overlay_token_saver_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
     overlay_managed_dynamic_skill_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
-    overlay_xmem_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
-    overlay_opencode_xmem_plugin(config_dir, plugin_runtime)
+    if overlay_xmem_session_entries is not None:
+        overlay_xmem_session_entries(config_dir, session_home, disabled_session_surfaces=disabled_session_surfaces)
+    if overlay_opencode_xmem_plugin is not None:
+        overlay_opencode_xmem_plugin(config_dir, plugin_runtime)
     if overlay_opencode_nsr_plugin is not None:
         overlay_opencode_nsr_plugin(config_dir, plugin_runtime)

--- a/tests/test_opencode_nsr_overlay.py
+++ b/tests/test_opencode_nsr_overlay.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+import subprocess
 import sys
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -38,3 +41,56 @@ def test_opencode_nsr_runtime_can_force_disable(monkeypatch, tmp_path):
     # Even opted-in via env, runtime disable wins.
     assert mms_launchers._opencode_nsr_plugin_enabled({"opencode_nsr": False}) is False
     assert mms_launchers._overlay_opencode_nsr_plugin(str(config_dir), {"opencode_nsr": False}) is False
+    assert mms_launchers._opencode_nsr_plugin_enabled({"nsr_mode": "disable"}) is False
+    assert mms_launchers._overlay_opencode_nsr_plugin(str(config_dir), {"nsr_mode": "disable"}) is False
+
+
+def test_opencode_nsr_stop_uses_local_budget_not_builtin_repeat_guard(tmp_path):
+    session_dir = tmp_path / ".nsr" / "sessions" / "session-a"
+    session_dir.mkdir(parents=True)
+    state_path = session_dir / "state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "runtime": {"mode": "active", "schema_version": 1},
+                "goal": {"objective": "demo objective"},
+                "loop": {
+                    "status": "running",
+                    "current_slice": "slice-a",
+                    "current_slice_id": "slice-a",
+                    "next_action": "continue work",
+                },
+                "quality": {},
+                "gate": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["MMS_REAL_HOME"] = str(tmp_path)
+    payload = json.dumps({"hook_event_name": "Stop", "session_id": "session-a", "cwd": str(ROOT)})
+
+    first = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "nsr-builtin-hook.py"), "opencode"],
+        input=payload,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    second = subprocess.run(
+        ["python3", str(ROOT / "hooks" / "nsr-builtin-hook.py"), "opencode"],
+        input=payload,
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert json.loads(first.stdout)["decision"] == "block"
+    assert json.loads(second.stdout)["decision"] == "block"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["loop"]["status"] == "running"

--- a/tests/test_opencode_nsr_overlay.py
+++ b/tests/test_opencode_nsr_overlay.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import mms_launchers
+
+
+def test_opencode_nsr_disabled_by_default(monkeypatch, tmp_path):
+    # Default OFF: without MMS_OPENCODE_NSR the plugin must not resolve or overlay.
+    monkeypatch.delenv("MMS_OPENCODE_NSR", raising=False)
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    assert mms_launchers._opencode_nsr_plugin_enabled({}) is False
+    assert mms_launchers._overlay_opencode_nsr_plugin(str(config_dir)) is False
+    assert not (config_dir / "plugins" / "mms-nsr.ts").exists()
+
+
+def test_opencode_nsr_overlays_when_opted_in(monkeypatch, tmp_path):
+    monkeypatch.setenv("MMS_OPENCODE_NSR", "1")
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    assert mms_launchers._opencode_nsr_plugin_enabled({}) is True
+    assert mms_launchers._overlay_opencode_nsr_plugin(str(config_dir)) is True
+    target = config_dir / "plugins" / "mms-nsr.ts"
+    assert target.exists()
+    assert "NsrOpenCodePlugin" in target.read_text(encoding="utf-8")
+
+
+def test_opencode_nsr_runtime_can_force_disable(monkeypatch, tmp_path):
+    monkeypatch.setenv("MMS_OPENCODE_NSR", "1")
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    # Even opted-in via env, runtime disable wins.
+    assert mms_launchers._opencode_nsr_plugin_enabled({"opencode_nsr": False}) is False
+    assert mms_launchers._overlay_opencode_nsr_plugin(str(config_dir), {"opencode_nsr": False}) is False


### PR DESCRIPTION
## What

OpenCode parity for **NSR (Non-Stop-Run)** auto-continue. codex/claude get NSR via a `Stop` hook that returns `{decision: block}` to keep the agent running while a loop still has a `next_action`. OpenCode's plugin API has **no stop-block hook**, so this uses a different mechanism:

`session.idle` bus event → reuse the existing NSR decision (`hooks/nsr-builtin-hook.py`, *not* reimplemented) → on `block`, re-prompt via `client.session.prompt()` to continue.

## Changes
- `hooks/opencode-nsr.ts` — the plugin (event-driven re-prompt, hard per-session cap, fail-open).
- `mms_opencode_session.py` — `opencode_nsr_plugin_path()` (default OFF, gated on `MMS_OPENCODE_NSR=1`) + overlay call in `overlay_opencode_session_assets`.
- `mms_launchers.py` — `_opencode_nsr_plugin_path` / `_overlay_opencode_nsr_plugin` / `_opencode_nsr_plugin_enabled` wrappers + import + call-site injection (mirrors xmem/rtk).
- `tests/test_opencode_nsr_overlay.py` — default-off, opt-in overlay, runtime force-disable.

## Safety: DEFAULT OFF / opt-in
Inert unless `MMS_OPENCODE_NSR=1` — **merging this activates nothing**. It is a runaway-capable, re-prompt-based mechanism, so it ships disabled, with a hard per-session continue cap on top of NSR's own repeat-guard, and is fully fail-open.

## Tested
- `import mms_launchers` clean.
- `pytest tests/test_opencode_nsr_overlay.py tests/test_xmem_overlay.py` → **16 passed**.
- `bun build hooks/opencode-nsr.ts` passes.

## NOT tested — needs a live OpenCode session with the flag enabled
- `session.idle` event field carrying the session id
- `client.session.prompt()` request body shape
- `MMS_HOME` presence in the OpenCode process env
- `nsr-builtin-hook.py` decisions for a synthesized opencode `Stop`

Runtime activation requires reinstall (`install.sh` copies `hooks/` + `mms_*.py`).

## Committee
Dispatched to committee; the dispatch pipeline verified but the **review input was invalid, so no committee verdict was produced**. This PR rests on author self-assessment plus the default-off safety, not a committee ratification. Evidence grade ≈ G1.
