### PR TITLE
feat: add flywheel headless runner

### DIFF
--- a/docs/FLYWHEEL_MMS_CONTRACT.md
+++ b/docs/FLYWHEEL_MMS_CONTRACT.md
@@ -22,10 +22,11 @@ Phase 2 adds a headless worker/fixer runner:
 mmf flywheel run --lane worker --priority AI-P3 --cwd <worktree> --artifact-dir <run-dir> exec <prompt>
 ```
 
-`run` resolves the same profile, writes `<run-dir>/resolved-route.json`, then
-launches Codex headlessly through the selected MMS route. The command accepts
-Looper's Codex-shaped tail (`exec [--model <ignored>] <prompt>`). MMS owns the
-actual model/provider choice; Looper's `--model` is ignored.
+`run` resolves the same profile, writes `<run-dir>/resolved-route.json` and
+`<run-dir>/run-result.json`, then launches Codex headlessly through the selected
+MMS route. The command accepts Looper's Codex-shaped tail
+(`exec [--model <ignored>] <prompt>`). MMS owns the actual model/provider
+choice; Looper's `--model` is ignored.
 
 By default `run` prints only raw agent text to stdout. This preserves Looper's
 completion marker contract: if the agent prints
@@ -33,9 +34,35 @@ completion marker contract: if the agent prints
 parse. Use `--json` only for diagnostics, not as the Looper command output.
 
 `resolved-route.json` is safe for issue/PR evidence: it contains sanitized
-model/provider/runtime metadata, but not API keys, endpoint URLs, or proxy
-fields. The raw key and endpoint are used only in-process to launch the selected
-runtime.
+model/provider/runtime metadata and `cache_transport_evidence.v1`, but not API
+keys, endpoint URLs, or proxy fields. The transport evidence records the
+concrete upstream `request_path` (for example `/v1/messages`) while leaving
+`request_url` blank because MMS provider hosts can be private. The raw key and
+endpoint are used only in-process to launch the selected runtime.
+
+The runner also exposes the same evidence in the JSON result and
+`run-result.json`:
+
+```json
+{
+  "cache_transport_evidence": {
+    "schema": "cache_transport_evidence.v1",
+    "model": "qwen3.7-max",
+    "provider_id": "newapi-personal-tokyo",
+    "protocol": "anthropic_messages",
+    "request_url": "",
+    "request_path": "/v1/messages",
+    "fallback_used": false,
+    "fallback_reason": ""
+  }
+}
+```
+
+For non-OpenAI-family CN / dual-protocol / cache-sensitive routes, `run`
+defaults to `anthropic_messages` when `anthropic_base_url` exists. OpenAI-family
+models default to `openai_responses`. `openai_chat_completions` for
+cache-sensitive non-OpenAI routes is only valid as an audited fallback with a
+non-empty `fallback_reason`.
 
 ## Config Shape
 
@@ -61,7 +88,7 @@ default = "flywheel.fixer.default"
 "AI-P4" = "opencode-committee-fast"
 
 [flywheel.profiles."flywheel.worker.p3"]
-runtime = "opencode"
+runtime = "codex"
 model = "qwen3.7-max"
 provider = "direct-qwen"
 reasoning_effort = "high"
@@ -69,9 +96,9 @@ thinking_mode = "disable"
 max_context_tokens = 1000000
 ```
 
-Supported profile fields:
+Supported resolver profile fields:
 
-- `runtime` / `runtime_kind` / `cli`: `codex`, `opencode`, `opencode_profile`, or future runner ids.
+- `runtime` / `runtime_kind` / `cli`: `codex`, `opencode`, `opencode_profile`, or future runner ids. `mmf flywheel run` currently executes only `codex`; other runtimes are resolver-only until their runner adapters land.
 - `model` / `model_id`: MMS model route key or OpenCode profile id.
 - `provider` / `provider_id` / `route_provider` / `model_route_provider` / `channel`: optional provider override.
 - `thinking_mode`: `auto`, `enable`, or `disable`.

--- a/docs/FLYWHEEL_MMS_CONTRACT.md
+++ b/docs/FLYWHEEL_MMS_CONTRACT.md
@@ -4,7 +4,7 @@ MMS Next is the model/source-of-truth for Flywheel and Looper model selection.
 Flywheel keeps GitHub issue/PR/gate flow ownership; MMS owns model, provider,
 fallback, and runtime-control resolution.
 
-Phase 1 adds a read-only resolver:
+Phase 1 added a read-only resolver:
 
 ```bash
 mmf flywheel resolve --lane worker --priority AI-P3 --json
@@ -15,6 +15,27 @@ The resolver does not launch a model, write user config, or read Runtimia Agent
 state. It reads the active MMS config root plus model route exports and emits a
 sanitized plan that is safe to paste into tracker comments: provider/model ids and
 runtime controls are included; API keys and endpoint/proxy URLs are omitted.
+
+Phase 2 adds a headless worker/fixer runner:
+
+```bash
+mmf flywheel run --lane worker --priority AI-P3 --cwd <worktree> --artifact-dir <run-dir> exec <prompt>
+```
+
+`run` resolves the same profile, writes `<run-dir>/resolved-route.json`, then
+launches Codex headlessly through the selected MMS route. The command accepts
+Looper's Codex-shaped tail (`exec [--model <ignored>] <prompt>`). MMS owns the
+actual model/provider choice; Looper's `--model` is ignored.
+
+By default `run` prints only raw agent text to stdout. This preserves Looper's
+completion marker contract: if the agent prints
+`__LOOPER_RESULT__={...json...}`, the marker lands at line start for Looper to
+parse. Use `--json` only for diagnostics, not as the Looper command output.
+
+`resolved-route.json` is safe for issue/PR evidence: it contains sanitized
+model/provider/runtime metadata, but not API keys, endpoint URLs, or proxy
+fields. The raw key and endpoint are used only in-process to launch the selected
+runtime.
 
 ## Config Shape
 
@@ -65,8 +86,9 @@ If no Flywheel config exists, the resolver preserves current Flywheel behavior:
 - `fixer`: `flywheel.fixer.default` -> `codex`, `gpt-5.5`, `reasoning_effort=medium`.
 - `committee`: `AI-P0 -> heavy`, `AI-P1 -> standard`, `AI-P2 -> light`, `AI-P3/P4 -> fast`.
 
-## Next Phase
+## Remaining Follow-Up
 
-The next contract slice should add a headless runner that consumes this resolver
-output and launches the selected CLI/profile while preserving Looper's completion
-marker contract.
+Flywheel should switch its worker hook from the older Runtimia Codex wrapper to
+`mmf flywheel run` after this MMS runner lands. Committee profile execution can
+remain on the existing OpenCode committee path until it needs the same runner
+interface.

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -5883,7 +5883,7 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
 
 class _ResponsesToChatHandler(_ResponsesProxyHandler):
     """Local bridge: accepts Codex's /v1/responses requests,
-    translates to /v1/chat/completions, forwards to gateway."""
+    translates to the configured upstream transport, and forwards to gateway."""
 
     server_version = "MMSCodexChatBridge/0.1"
 
@@ -5962,6 +5962,25 @@ class _ResponsesToChatHandler(_ResponsesProxyHandler):
         provider_profile = getattr(self.server, "provider_profile", "")
         reasoning_enabled = bool(getattr(self.server, "reasoning_enabled", True))
         reasoning_effort = getattr(self.server, "reasoning_effort", "high")
+        started_ms = _now_ms()
+        primary_protocol = str(getattr(self.server, "primary_protocol", "openai_chat_completions") or "openai_chat_completions")
+
+        if primary_protocol == "anthropic_messages":
+            messages_route = {
+                "provider_id": provider_id,
+                "provider_profile": provider_profile,
+                "protocol": "anthropic_messages",
+                "fallback_reason": "",
+            }
+            self._do_anthropic_messages_fallback(
+                payload,
+                model_name,
+                gateway_url,
+                gateway_key,
+                started_ms,
+                route=messages_route,
+            )
+            return
 
         # Translate Responses → Chat Completions request
         chat_messages = _responses_input_to_messages(
@@ -6010,7 +6029,6 @@ class _ResponsesToChatHandler(_ResponsesProxyHandler):
         fwd_headers.update(_copy_passthrough_headers(self.headers))
 
         translator = _ChatCompletionsToResponsesTranslator(model_name)
-        started_ms = _now_ms()
         first_byte_ms = None
         output_tokens = None
         try:
@@ -6122,14 +6140,16 @@ def codex_chatcompletions_bridge(
     reasoning_effort="high",
     proxy_url="",
     no_proxy="",
+    primary_protocol="openai_chat_completions",
     rescue_fallback_model="",
     rescue_fallback_cli="",
     rescue_hot_fallback_enabled=None,
 ):
-    """Local bridge for Codex: translates /v1/responses → /v1/chat/completions.
+    """Local bridge for Codex: translates /v1/responses to chat or messages.
 
     Use this when the gateway only supports Chat Completions for non-GPT models
-    but Codex requires Responses API.
+    or when a cache-sensitive route must use Anthropic Messages while Codex
+    still requires Responses API.
     """
     _ensure_httpx()
     if httpx is None:
@@ -6151,6 +6171,11 @@ def codex_chatcompletions_bridge(
     server._last_reasoning_content = ""
     server.proxy_url = str(proxy_url or "").strip()
     server.no_proxy = str(no_proxy or "").strip()
+    server.primary_protocol = (
+        "anthropic_messages"
+        if str(primary_protocol or "").strip() == "anthropic_messages"
+        else "openai_chat_completions"
+    )
     _configure_bridge_rescue(server)
     if rescue_fallback_model:
         server.rescue_fallback_model = str(rescue_fallback_model or "").strip()

--- a/mms_core.py
+++ b/mms_core.py
@@ -17220,7 +17220,7 @@ def main():
             f"  {current_command()} fake-upstream ... 开发期 fake upstream 开关与日志\n"
             f"  {current_command()} review-launch ... 非交互 multi-review reviewer launcher 握手\n"
             f"  {current_command()} review-dispatch --root <artifact-root> 生成/启动 OpenCode Review Hub 派发\n"
-            f"  {current_command()} flywheel resolve --lane worker --priority AI-P3 --json  解析 Flywheel/Looper lane\n"
+            f"  {current_command()} flywheel resolve/run --lane worker --priority AI-P3  解析/运行 Flywheel lane\n"
             f"  {current_command()} env <preset>    输出预设对应的 export 环境变量\n"
             f"  {current_command()} activate <preset>  输出可 eval 的 export 语句\n"
             f"  {current_command()} usage ...       查看 usage 统计\n\n"

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -1,14 +1,15 @@
-"""Flywheel/Looper profile resolver for MMS Next.
+"""Flywheel/Looper profile resolver and headless worker runner for MMS Next.
 
-Phase 1 intentionally does not launch models. It resolves which MMS profile/model
-would be used for a Flywheel lane so Looper can later call one stable headless
-runner without duplicating model policy.
+`resolve` reports which MMS profile/model would be used for a Flywheel lane.
+`run` launches the worker/fixer lane through that resolved MMS route while
+preserving Looper's raw completion-marker output contract.
 """
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,9 @@ PRIORITIES = {"AI-P0", "AI-P1", "AI-P2", "AI-P3", "AI-P4"}
 EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 THINKING_MODES = {"auto", "enable", "disable"}
 SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD")
+FAKE_RESPONSE_ENV = "MMS_FLYWHEEL_RUN_FAKE_RESPONSE"
+FAKE_JSONL_ENV = "MMS_FLYWHEEL_RUN_FAKE_JSONL"
+RUN_RESULT_SCHEMA = "mms.flywheel_run_result.v1"
 
 DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
     "lanes": {
@@ -413,6 +417,336 @@ def resolve_flywheel_profile(
     return {key: value for key, value in resolved.items() if value not in (None, "")}
 
 
+def _raw_selected_route(resolved: dict[str, Any]) -> dict[str, Any]:
+    config = resolved.get("config") if isinstance(resolved.get("config"), dict) else {}
+    route_path = Path(str(config.get("route_path") or "")).expanduser()
+    model = str(resolved.get("model") or "").strip()
+    selected = resolved.get("selected_route") if isinstance(resolved.get("selected_route"), dict) else {}
+    selected_slot = str(selected.get("slot") or "").strip()
+    if not route_path or not model or not selected_slot:
+        return {}
+    routes = _routes_from(route_path)
+    entry = routes.get(model)
+    for slot, candidate in _route_candidates(entry):
+        if slot == selected_slot:
+            return dict(candidate)
+    raise FlywheelConfigError(f"selected route slot {selected_slot!r} not found for model {model!r}")
+
+
+def _protocols_for_route(route: dict[str, Any]) -> list[str]:
+    protocols: list[str] = []
+    if str(route.get("anthropic_base_url") or "").strip():
+        protocols.append("anthropic_messages")
+    if str(route.get("openai_base_url") or "").strip():
+        protocols.append("openai_chat_completions")
+    return protocols
+
+
+def _launcher_effort(value: Any) -> str:
+    raw = str(value or "").strip().lower()
+    if raw in {"low", "medium", "high", "xhigh"}:
+        return raw
+    if raw == "max":
+        return "xhigh"
+    if raw in {"none", "minimal"}:
+        return "low"
+    return raw
+
+
+def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict[str, Any]:
+    provider_id = str(route.get("provider_id") or resolved.get("provider_id") or "").strip()
+    api_key = str(route.get("api_key") or route.get("openai_api_key") or "").strip()
+    openai_base_url = str(route.get("openai_base_url") or route.get("base_url") or "").strip()
+    anthropic_base_url = str(route.get("anthropic_base_url") or "").strip()
+    if not provider_id:
+        raise FlywheelConfigError("selected route has no provider_id")
+    if not api_key:
+        raise FlywheelConfigError(f"selected route {provider_id!r} has no api_key")
+    if not openai_base_url and not anthropic_base_url:
+        raise FlywheelConfigError(f"selected route {provider_id!r} has no endpoint URL")
+    runtime = {
+        "id": provider_id,
+        "provider_id": provider_id,
+        "name": provider_id,
+        "auth_mode": "api_key",
+        "runtime_kind": "provider",
+        "api_key": api_key,
+        "openai_api_key": api_key,
+        "openai_base_url": openai_base_url,
+        "anthropic_base_url": anthropic_base_url,
+        "protocols": _protocols_for_route(route),
+        "supported_clis": ["codex", "opencode", "claude"],
+        "role": "auto",
+        "model": str(route.get("model_id") or resolved.get("model") or "").strip(),
+        "thinking_mode": str(resolved.get("thinking_mode") or "auto").strip().lower(),
+        "native_fallback": True,
+    }
+    effort = _launcher_effort(resolved.get("reasoning_effort"))
+    if effort:
+        runtime["reasoning_effort"] = effort
+    for key in ("proxy", "no_proxy", "provider_profile", "profile"):
+        value = route.get(key)
+        if value not in (None, ""):
+            runtime[key] = value
+    return runtime
+
+
+def _sanitize_runtime(runtime: dict[str, Any]) -> dict[str, Any]:
+    safe = {}
+    for key, value in (runtime or {}).items():
+        if _is_secret_key(str(key)):
+            continue
+        if key in {"api_key", "openai_api_key", "openai_base_url", "anthropic_base_url", "base_url", "proxy", "no_proxy"}:
+            continue
+        if value not in (None, ""):
+            safe[key] = value
+    return safe
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(f".{path.name}.tmp")
+    temp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temp.replace(path)
+
+
+def _artifact_dir(cwd: Path, explicit: str = "") -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    stamp = os.environ.get("MMS_FLYWHEEL_RUN_ID") or os.environ.get("LOOPER_TASK_ID") or "latest"
+    safe_stamp = "".join(ch if ch.isalnum() or ch in {"-", "_", "."} else "-" for ch in stamp)
+    return (cwd / ".ai" / "flywheel-runs" / safe_stamp).resolve()
+
+
+def _extract_prompt(remainder: list[str], *, explicit_prompt: str = "", prompt_file: str = "") -> tuple[str, list[str], str]:
+    if explicit_prompt:
+        return explicit_prompt, list(remainder or []), "prompt"
+    if prompt_file:
+        return Path(prompt_file).expanduser().read_text(encoding="utf-8"), list(remainder or []), "prompt_file"
+    args = list(remainder or [])
+    if args and args[0] in {"exec", "run"}:
+        args = args[1:]
+    prompt = ""
+    forwarded: list[str] = []
+    i = 0
+    while i < len(args):
+        item = args[i]
+        if item in {"--model", "-m"} and i + 1 < len(args):
+            i += 2
+            continue
+        if item in {"--dir", "-C", "--cd"} and i + 1 < len(args):
+            forwarded.extend([item, args[i + 1]])
+            i += 2
+            continue
+        if item == "--":
+            i += 1
+            if i < len(args):
+                prompt = " ".join(args[i:]).strip()
+            break
+        if item.startswith("-"):
+            forwarded.append(item)
+        else:
+            prompt = item
+        i += 1
+    if not prompt:
+        raise FlywheelConfigError("flywheel run prompt is empty")
+    return prompt, forwarded, "argv"
+
+
+def _extract_codex_agent_text(jsonl_text: str) -> str:
+    chunks: list[str] = []
+    for line in str(jsonl_text or "").splitlines():
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        item = obj.get("item") if isinstance(obj, dict) else {}
+        if obj.get("type") == "item.completed" and isinstance(item, dict) and item.get("type") == "agent_message":
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                chunks.append(text)
+    return "\n".join(chunks)
+
+
+def _codex_exec_args(*, cwd: Path, prompt: str, sandbox: str) -> list[str]:
+    return [
+        "exec",
+        "--json",
+        "--skip-git-repo-check",
+        "--ignore-user-config",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--dangerously-bypass-hook-trust",
+        "--sandbox",
+        sandbox,
+        "-C",
+        str(cwd),
+        prompt,
+    ]
+
+
+def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd: Path, sandbox: str) -> tuple[int, str, str]:
+    import mms_launchers
+
+    mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
+    mms_launchers.gateway_health_check(runtime)
+    gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
+    api_key = runtime.get("openai_api_key") or runtime.get("api_key", "")
+    provider_id = runtime.get("id", "")
+    provider_profile = str(runtime.get("profile") or runtime.get("provider_profile") or "")
+    speed_scope = mms_launchers.build_provider_speed_scope(runtime)
+    try:
+        advertised_models = list(mms_launchers._probe_models(runtime, emit_output=False).get("models") or [])  # noqa: SLF001
+    except Exception:
+        advertised_models = [model] if model else []
+
+    is_gpt = bool(mms_launchers._is_gpt_model(model))  # noqa: SLF001
+    bridge_factory = mms_launchers.codex_responses_bridge if is_gpt else mms_launchers.codex_chatcompletions_bridge
+    bridge_kwargs = {
+        "model_name": model or "unknown",
+        "advertised_models": advertised_models,
+        "speed_scope": speed_scope,
+        "provider_id": provider_id,
+        "provider_profile": provider_profile,
+        "reasoning_enabled": bool(mms_launchers._runtime_thinking_enabled(runtime)),  # noqa: SLF001
+        "reasoning_effort": mms_launchers._runtime_reasoning_effort(runtime, default="medium"),  # noqa: SLF001
+        "proxy_url": runtime.get("proxy"),
+        "no_proxy": runtime.get("no_proxy"),
+        **mms_launchers._rescue_bridge_kwargs(),  # noqa: SLF001
+    }
+    if is_gpt:
+        bridge_kwargs["native_fallback_routes"] = mms_launchers._resolve_codex_responses_fallback_routes(runtime, model)  # noqa: SLF001
+
+    with bridge_factory(gateway_url, api_key, **bridge_kwargs) as bridge_cfg:
+        bridge_base_url = mms_launchers._codex_provider_base_url(bridge_cfg["base_url"])  # noqa: SLF001
+        env = mms_launchers._codex_gateway_env(runtime, bridge_cfg["base_url"], model_info={"model": model})  # noqa: SLF001
+        env["OPENAI_API_KEY"] = bridge_cfg["api_key"]
+        env["OPENAI_BASE_URL"] = bridge_base_url
+        cmd = ["codex", "-c", 'model_provider="custom"']
+        if is_gpt and mms_launchers._runtime_thinking_enabled(runtime):  # noqa: SLF001
+            effort = mms_launchers._runtime_reasoning_effort(runtime, default="medium")  # noqa: SLF001
+            cmd += ["-c", f'model_reasoning_effort="{effort}"']
+        cmd += [
+            "-c",
+            f'openai_base_url="{bridge_base_url}"',
+            "-c",
+            f'model_providers.custom.base_url="{bridge_base_url}"',
+            "-c",
+            "features.responses_websockets=false",
+            "-c",
+            "features.responses_websockets_v2=false",
+        ]
+        if model:
+            cmd += ["-m", model]
+        cmd += _codex_exec_args(cwd=cwd, prompt=prompt, sandbox=sandbox)
+        cmd, env, exe = mms_launchers.prepare_cli_command(cmd, env)
+        if not exe:
+            raise FlywheelConfigError("codex executable not found")
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
+        return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+def run_flywheel_lane(
+    *,
+    lane: str,
+    priority: str = "",
+    profile: str = "",
+    config_root: str = "",
+    config_path: str = "",
+    route_path: str = "",
+    lineup_path: str = "",
+    cwd: str = "",
+    artifact_dir: str = "",
+    prompt: str = "",
+    prompt_file: str = "",
+    runner_args: list[str] | None = None,
+    sandbox: str = "danger-full-access",
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    workdir = Path(cwd or os.getcwd()).expanduser().resolve()
+    resolved = resolve_flywheel_profile(
+        lane=lane,
+        priority=priority,
+        profile=profile,
+        config_root=config_root,
+        config_path=config_path,
+        route_path=route_path,
+        lineup_path=lineup_path,
+    )
+    runtime_kind = str(resolved.get("runtime_kind") or "").strip()
+    if runtime_kind not in {"codex"}:
+        raise FlywheelConfigError(f"flywheel run currently supports codex runtime only, got {runtime_kind!r}")
+    raw_route = _raw_selected_route(resolved)
+    runtime = _runtime_from_route(resolved, raw_route)
+    prompt_text, forwarded_args, prompt_source = _extract_prompt(
+        runner_args or [],
+        explicit_prompt=prompt,
+        prompt_file=prompt_file,
+    )
+    out_dir = _artifact_dir(workdir, artifact_dir)
+    resolved_artifact = out_dir / "resolved-route.json"
+    artifact_payload = {
+        "schema": "mms.flywheel_resolved_route.v1",
+        "resolved": resolved,
+        "runtime": _sanitize_runtime(runtime),
+        "prompt_source": prompt_source,
+        "forwarded_args": forwarded_args,
+        "cwd": str(workdir),
+        "sandbox": sandbox,
+    }
+    _write_json(resolved_artifact, artifact_payload)
+
+    result: dict[str, Any] = {
+        "schema": RUN_RESULT_SCHEMA,
+        "ok": True,
+        "status": "dry_run" if dry_run else "completed",
+        "lane": resolved.get("lane"),
+        "priority": resolved.get("priority", ""),
+        "profile_id": resolved.get("profile_id"),
+        "runtime_kind": runtime_kind,
+        "model": resolved.get("model"),
+        "provider_id": resolved.get("provider_id"),
+        "artifact_dir": str(out_dir),
+        "resolved_route_path": str(resolved_artifact),
+        "exit_code": 0,
+        "agent_text": "",
+        "stderr": "",
+    }
+    if dry_run:
+        result["command_preview"] = {
+            "cli": "codex",
+            "args": _codex_exec_args(cwd=workdir, prompt="<prompt>", sandbox=sandbox),
+        }
+        return result
+
+    fake_response = str(os.environ.get(FAKE_RESPONSE_ENV) or "")
+    fake_jsonl = str(os.environ.get(FAKE_JSONL_ENV) or "")
+    if fake_response:
+        result["agent_text"] = fake_response
+        result["fake_dispatch"] = True
+        return result
+    if fake_jsonl:
+        result["agent_text"] = _extract_codex_agent_text(fake_jsonl)
+        result["fake_dispatch"] = True
+        return result
+
+    rc, stdout_text, stderr_text = _run_codex_headless(
+        runtime=runtime,
+        model=str(resolved.get("model") or ""),
+        prompt=prompt_text,
+        cwd=workdir,
+        sandbox=sandbox,
+    )
+    agent_text = _extract_codex_agent_text(stdout_text)
+    if not agent_text and stdout_text:
+        agent_text = stdout_text
+    result["exit_code"] = rc
+    result["ok"] = rc == 0
+    result["status"] = "completed" if rc == 0 else "failed"
+    result["agent_text"] = agent_text
+    result["stderr"] = stderr_text
+    return result
+
+
 def _print_human(payload: dict[str, Any]) -> None:
     print(f"lane: {payload.get('lane')} priority: {payload.get('priority') or '<default>'}")
     print(f"profile: {payload.get('profile_id')}")
@@ -442,10 +776,64 @@ def handle_flywheel_command(argv: list[str], *, command_name: str = "mmf flywhee
     resolve.add_argument("--route-path", default="", help="explicit model-routes.json path")
     resolve.add_argument("--lineup-path", default="", help="explicit model-routes.lineup.json path")
     resolve.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    run = sub.add_parser("run", help="run a Flywheel lane headlessly through the resolved MMS runtime")
+    run.add_argument("--lane", required=True, choices=sorted(LANES))
+    run.add_argument("--priority", default="", help="AI-P0..AI-P4, or P0..P4")
+    run.add_argument("--profile", default="", help="override profile id for diagnostics")
+    run.add_argument("--config-root", default="", help="MMS config root; defaults to MMS_CONFIG_ROOT")
+    run.add_argument("--config", default="", help="explicit flywheel TOML config path")
+    run.add_argument("--route-path", default="", help="explicit model-routes.json path")
+    run.add_argument("--lineup-path", default="", help="explicit model-routes.lineup.json path")
+    run.add_argument("--cwd", default="", help="working directory for the headless agent")
+    run.add_argument("--artifact-dir", default="", help="where to write resolved-route.json")
+    run.add_argument("--prompt", default="", help="prompt text; overrides trailing argv prompt")
+    run.add_argument("--prompt-file", default="", help="read prompt from a file")
+    run.add_argument("--sandbox", default="danger-full-access", choices=["read-only", "workspace-write", "danger-full-access"])
+    run.add_argument("--dry-run", action="store_true", help="resolve and write artifacts without launching Codex")
+    run.add_argument("--json", action="store_true", help="emit machine-readable JSON instead of raw agent text")
+    run.add_argument("runner_args", nargs=argparse.REMAINDER, help="Looper-style exec/run args; final positional is the prompt")
     ns = parser.parse_args(argv)
-    if ns.command != "resolve":
+    if ns.command not in {"resolve", "run"}:
         parser.print_help()
         return 2
+    if ns.command == "run":
+        try:
+            result = run_flywheel_lane(
+                lane=ns.lane,
+                priority=ns.priority,
+                profile=ns.profile,
+                config_root=ns.config_root,
+                config_path=ns.config,
+                route_path=ns.route_path,
+                lineup_path=ns.lineup_path,
+                cwd=ns.cwd,
+                artifact_dir=ns.artifact_dir,
+                prompt=ns.prompt,
+                prompt_file=ns.prompt_file,
+                runner_args=ns.runner_args,
+                sandbox=ns.sandbox,
+                dry_run=ns.dry_run,
+            )
+        except Exception as exc:
+            if ns.json:
+                print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False))
+            else:
+                print(f"flywheel run failed: {exc}", file=os.sys.stderr)
+            return 1
+        if ns.json:
+            payload = dict(result)
+            if len(str(payload.get("agent_text") or "")) > 2000:
+                payload["agent_text"] = str(payload["agent_text"])[:2000] + "\n...[truncated]"
+            print(json.dumps({"ok": bool(result.get("ok")), "result": payload}, ensure_ascii=False, indent=2))
+        else:
+            stderr_text = str(result.get("stderr") or "")
+            if stderr_text:
+                print(stderr_text, file=os.sys.stderr, end="" if stderr_text.endswith("\n") else "\n")
+            agent_text = str(result.get("agent_text") or "")
+            if agent_text:
+                print(agent_text, end="" if agent_text.endswith("\n") else "\n")
+        return int(result.get("exit_code") or (0 if result.get("ok") else 1))
+
     try:
         payload = resolve_flywheel_profile(
             lane=ns.lane,

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 try:  # Python 3.11+
     import tomllib
@@ -27,6 +28,11 @@ SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD")
 FAKE_RESPONSE_ENV = "MMS_FLYWHEEL_RUN_FAKE_RESPONSE"
 FAKE_JSONL_ENV = "MMS_FLYWHEEL_RUN_FAKE_JSONL"
 RUN_RESULT_SCHEMA = "mms.flywheel_run_result.v1"
+RUN_RESULT_ARTIFACT_SCHEMA = "mms.flywheel_run_artifact.v1"
+CACHE_TRANSPORT_EVIDENCE_SCHEMA = "cache_transport_evidence.v1"
+TRANSPORT_PROTOCOLS = {"anthropic_messages", "openai_chat_completions", "openai_responses"}
+OPENAI_FAMILY_PREFIXES = ("gpt-", "o1", "o3", "o4", "o5", "codex-")
+DOMESTIC_MODEL_MARKERS = ("qwen", "kimi", "deepseek", "glm", "minimax", "mimo", "moonshot", "doubao")
 
 DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
     "lanes": {
@@ -401,6 +407,7 @@ def resolve_flywheel_profile(
         "route_status": route_status,
         "selected_route": {"slot": selected_name, **_sanitize_route(selected_route)} if selected_route else {},
         "fallback_routes": fallbacks,
+        "selected_transport": _transport_evidence_for_route(selected_route, model) if selected_route else {},
         "thinking_mode": thinking,
         "reasoning_effort": effort,
         "max_context_tokens": context_tokens,
@@ -434,12 +441,142 @@ def _raw_selected_route(resolved: dict[str, Any]) -> dict[str, Any]:
 
 
 def _protocols_for_route(route: dict[str, Any]) -> list[str]:
-    protocols: list[str] = []
+    raw_protocols = route.get("protocols")
+    if isinstance(raw_protocols, str):
+        raw_protocols = [raw_protocols]
+    protocols: list[str] = [
+        str(item).strip()
+        for item in (raw_protocols or [])
+        if str(item).strip() in {"anthropic_messages", "openai_chat_completions"}
+    ]
     if str(route.get("anthropic_base_url") or "").strip():
         protocols.append("anthropic_messages")
     if str(route.get("openai_base_url") or "").strip():
         protocols.append("openai_chat_completions")
-    return protocols
+    return list(dict.fromkeys(protocols))
+
+
+def _is_openai_family_model(model: str) -> bool:
+    normalized = str(model or "").strip().lower()
+    if normalized.startswith(OPENAI_FAMILY_PREFIXES):
+        return True
+    return normalized.startswith(("openai/", "openai."))
+
+
+def _is_domestic_model(model: str) -> bool:
+    normalized = str(model or "").strip().lower()
+    return any(marker in normalized for marker in DOMESTIC_MODEL_MARKERS)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on", "enable", "enabled"}
+
+
+def _route_cache_sensitive(route: dict[str, Any]) -> bool:
+    hints = route.get("protocol_hints") if isinstance(route.get("protocol_hints"), dict) else {}
+    return (
+        _truthy(route.get("cache_sensitive_transport"))
+        or _truthy(route.get("cache_sensitive"))
+        or _truthy(hints.get("cache_sensitive_transport"))
+    )
+
+
+def _join_request_path(base_url: str, endpoint: str) -> str:
+    parts = urlsplit(str(base_url or "").strip())
+    path = parts.path.rstrip("/")
+    if endpoint == "messages":
+        if path.endswith("/v1/messages") or path.endswith("/messages"):
+            return path or "/messages"
+        if path.endswith("/v1"):
+            return f"{path}/messages"
+        return f"{path}/v1/messages" if path else "/v1/messages"
+    if endpoint == "responses":
+        if path.endswith("/v1/responses") or path.endswith("/responses"):
+            return path or "/responses"
+        if path.endswith("/v1"):
+            return f"{path}/responses"
+        return f"{path}/v1/responses" if path else "/v1/responses"
+    if path.endswith("/v1/chat/completions") or path.endswith("/chat/completions"):
+        return path or "/chat/completions"
+    if path.endswith("/v1"):
+        return f"{path}/chat/completions"
+    return f"{path}/v1/chat/completions" if path else "/v1/chat/completions"
+
+
+def _transport_request_path(route: dict[str, Any], protocol: str) -> str:
+    if protocol == "anthropic_messages":
+        base = str(route.get("anthropic_base_url") or route.get("openai_base_url") or route.get("base_url") or "").strip()
+        return _join_request_path(base, "messages")
+    if protocol == "openai_responses":
+        base = str(route.get("openai_base_url") or route.get("base_url") or "").strip()
+        return _join_request_path(base, "responses")
+    base = str(route.get("openai_base_url") or route.get("base_url") or "").strip()
+    return _join_request_path(base, "chat/completions")
+
+
+def _preferred_transport_for_route(route: dict[str, Any], model: str) -> str:
+    explicit = str(route.get("protocol") or route.get("preferred_protocol") or "").strip()
+    if explicit in TRANSPORT_PROTOCOLS:
+        return explicit
+    protocols = set(_protocols_for_route(route))
+    anthropic_url = str(route.get("anthropic_base_url") or "").strip()
+    openai_url = str(route.get("openai_base_url") or route.get("base_url") or "").strip()
+    if _is_openai_family_model(model):
+        if openai_url:
+            return "openai_responses"
+        if anthropic_url:
+            raise FlywheelConfigError(f"OpenAI-family model {model!r} requires an OpenAI-compatible endpoint")
+    if anthropic_url and (
+        "anthropic_messages" in protocols
+        or _route_cache_sensitive(route)
+        or _is_domestic_model(model)
+        or bool(openai_url)
+    ):
+        return "anthropic_messages"
+    if openai_url:
+        return "openai_chat_completions"
+    if anthropic_url:
+        return "anthropic_messages"
+    raise FlywheelConfigError("selected route has no usable transport endpoint")
+
+
+def _zero_cache_usage() -> dict[str, int]:
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cached_tokens": 0,
+    }
+
+
+def _transport_evidence_for_route(
+    route: dict[str, Any],
+    model: str,
+    *,
+    protocol: str | None = None,
+    fallback_used: bool = False,
+    fallback_reason: str = "",
+) -> dict[str, Any]:
+    selected_protocol = protocol or _preferred_transport_for_route(route, model)
+    return {
+        "schema": CACHE_TRANSPORT_EVIDENCE_SCHEMA,
+        "model": str(route.get("model_id") or model or "").strip(),
+        "provider_id": str(route.get("provider_id") or "").strip(),
+        "protocol": selected_protocol,
+        # Keep artifacts paste-safe: request_path is concrete, request_url is
+        # intentionally omitted because MMS provider endpoints can be private.
+        "request_url": "",
+        "request_path": _transport_request_path(route, selected_protocol),
+        "route_source": "mms:model-routes",
+        "provider_profile": str(route.get("provider_profile") or route.get("profile") or "").strip(),
+        "fallback_used": bool(fallback_used),
+        "fallback_reason": str(fallback_reason or ""),
+        "evidence_source": "resolved_route",
+        "usage": _zero_cache_usage(),
+    }
 
 
 def _launcher_effort(value: Any) -> str:
@@ -458,6 +595,12 @@ def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict
     api_key = str(route.get("api_key") or route.get("openai_api_key") or "").strip()
     openai_base_url = str(route.get("openai_base_url") or route.get("base_url") or "").strip()
     anthropic_base_url = str(route.get("anthropic_base_url") or "").strip()
+    model = str(route.get("model_id") or resolved.get("model") or "").strip()
+    preferred_transport = _preferred_transport_for_route(route, model)
+    if preferred_transport in {"openai_responses", "openai_chat_completions"} and not openai_base_url:
+        raise FlywheelConfigError(f"selected route {provider_id!r} has no OpenAI-compatible endpoint")
+    if preferred_transport == "anthropic_messages" and not (anthropic_base_url or openai_base_url):
+        raise FlywheelConfigError(f"selected route {provider_id!r} has no Anthropic-compatible endpoint")
     if not provider_id:
         raise FlywheelConfigError("selected route has no provider_id")
     if not api_key:
@@ -475,9 +618,12 @@ def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict
         "openai_base_url": openai_base_url,
         "anthropic_base_url": anthropic_base_url,
         "protocols": _protocols_for_route(route),
+        "preferred_transport": preferred_transport,
+        "transport_request_path": _transport_request_path(route, preferred_transport),
+        "cache_transport_evidence": _transport_evidence_for_route(route, model, protocol=preferred_transport),
         "supported_clis": ["codex", "opencode", "claude"],
         "role": "auto",
-        "model": str(route.get("model_id") or resolved.get("model") or "").strip(),
+        "model": model,
         "thinking_mode": str(resolved.get("thinking_mode") or "auto").strip().lower(),
         "native_fallback": True,
     }
@@ -508,6 +654,30 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
     temp = path.with_name(f".{path.name}.tmp")
     temp.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     temp.replace(path)
+
+
+def _preview_text(value: Any, *, limit: int = 4000) -> str:
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "\n...[truncated]"
+
+
+def _write_run_result_artifact(path: Path, result: dict[str, Any]) -> None:
+    metadata = {
+        key: value
+        for key, value in result.items()
+        if key not in {"agent_text", "stderr"} and value not in (None, "")
+    }
+    payload = {
+        "schema": RUN_RESULT_ARTIFACT_SCHEMA,
+        "result": metadata,
+        "output": {
+            "agent_text_preview": _preview_text(result.get("agent_text")),
+            "stderr_preview": _preview_text(result.get("stderr")),
+        },
+    }
+    _write_json(path, payload)
 
 
 def _artifact_dir(cwd: Path, explicit: str = "") -> Path:
@@ -589,7 +759,6 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
 
     mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
     mms_launchers.gateway_health_check(runtime)
-    gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
     api_key = runtime.get("openai_api_key") or runtime.get("api_key", "")
     provider_id = runtime.get("id", "")
     provider_profile = str(runtime.get("profile") or runtime.get("provider_profile") or "")
@@ -600,7 +769,9 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
         advertised_models = [model] if model else []
 
     is_gpt = bool(mms_launchers._is_gpt_model(model))  # noqa: SLF001
-    bridge_factory = mms_launchers.codex_responses_bridge if is_gpt else mms_launchers.codex_chatcompletions_bridge
+    preferred_transport = str(runtime.get("preferred_transport") or "").strip()
+    if not preferred_transport:
+        preferred_transport = "openai_responses" if is_gpt else "openai_chat_completions"
     bridge_kwargs = {
         "model_name": model or "unknown",
         "advertised_models": advertised_models,
@@ -613,8 +784,23 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
         "no_proxy": runtime.get("no_proxy"),
         **mms_launchers._rescue_bridge_kwargs(),  # noqa: SLF001
     }
-    if is_gpt:
+    if preferred_transport == "anthropic_messages":
+        gateway_url = mms_launchers._anthropic_base_url(runtime)  # noqa: SLF001
+        if not gateway_url:
+            raise FlywheelConfigError("selected Anthropic transport has no anthropic_base_url")
+        bridge_factory = mms_launchers.codex_chatcompletions_bridge
+        bridge_kwargs["primary_protocol"] = "anthropic_messages"
+    elif is_gpt or preferred_transport == "openai_responses":
+        gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
+        if not gateway_url:
+            raise FlywheelConfigError("selected OpenAI Responses transport has no openai_base_url")
+        bridge_factory = mms_launchers.codex_responses_bridge
         bridge_kwargs["native_fallback_routes"] = mms_launchers._resolve_codex_responses_fallback_routes(runtime, model)  # noqa: SLF001
+    else:
+        gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
+        if not gateway_url:
+            raise FlywheelConfigError("selected OpenAI Chat transport has no openai_base_url")
+        bridge_factory = mms_launchers.codex_chatcompletions_bridge
 
     with bridge_factory(gateway_url, api_key, **bridge_kwargs) as bridge_cfg:
         bridge_base_url = mms_launchers._codex_provider_base_url(bridge_cfg["base_url"])  # noqa: SLF001
@@ -684,10 +870,13 @@ def run_flywheel_lane(
     )
     out_dir = _artifact_dir(workdir, artifact_dir)
     resolved_artifact = out_dir / "resolved-route.json"
+    run_result_artifact = out_dir / "run-result.json"
+    transport_evidence = runtime.get("cache_transport_evidence") if isinstance(runtime.get("cache_transport_evidence"), dict) else {}
     artifact_payload = {
         "schema": "mms.flywheel_resolved_route.v1",
         "resolved": resolved,
         "runtime": _sanitize_runtime(runtime),
+        "cache_transport_evidence": transport_evidence,
         "prompt_source": prompt_source,
         "forwarded_args": forwarded_args,
         "cwd": str(workdir),
@@ -707,6 +896,9 @@ def run_flywheel_lane(
         "provider_id": resolved.get("provider_id"),
         "artifact_dir": str(out_dir),
         "resolved_route_path": str(resolved_artifact),
+        "run_result_path": str(run_result_artifact),
+        "cache_transport_evidence": transport_evidence,
+        "transport_evidence": [transport_evidence] if transport_evidence else [],
         "exit_code": 0,
         "agent_text": "",
         "stderr": "",
@@ -716,6 +908,7 @@ def run_flywheel_lane(
             "cli": "codex",
             "args": _codex_exec_args(cwd=workdir, prompt="<prompt>", sandbox=sandbox),
         }
+        _write_run_result_artifact(run_result_artifact, result)
         return result
 
     fake_response = str(os.environ.get(FAKE_RESPONSE_ENV) or "")
@@ -723,10 +916,12 @@ def run_flywheel_lane(
     if fake_response:
         result["agent_text"] = fake_response
         result["fake_dispatch"] = True
+        _write_run_result_artifact(run_result_artifact, result)
         return result
     if fake_jsonl:
         result["agent_text"] = _extract_codex_agent_text(fake_jsonl)
         result["fake_dispatch"] = True
+        _write_run_result_artifact(run_result_artifact, result)
         return result
 
     rc, stdout_text, stderr_text = _run_codex_headless(
@@ -744,6 +939,7 @@ def run_flywheel_lane(
     result["status"] = "completed" if rc == 0 else "failed"
     result["agent_text"] = agent_text
     result["stderr"] = stderr_text
+    _write_run_result_artifact(run_result_artifact, result)
     return result
 
 

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -67,6 +67,23 @@ def _seed_routes(root):
     _write_json(root / "model-routes.lineup.json", lineup)
 
 
+def _write_qwen_worker_config(root: Path, *, effort: str = "high"):
+    (root / "config.toml").write_text(
+        """
+[flywheel.lanes.worker]
+"AI-P3" = "flywheel.worker.p3"
+
+[flywheel.profiles."flywheel.worker.p3"]
+runtime = "codex"
+model = "qwen3.7-max"
+provider = "direct-qwen"
+reasoning_effort = "{effort}"
+thinking_mode = "enable"
+""".strip().format(effort=effort),
+        encoding="utf-8",
+    )
+
+
 def test_resolve_worker_profile_from_mms_config(tmp_path):
     root = tmp_path / "mms-next"
     root.mkdir()
@@ -174,3 +191,139 @@ def test_mms_core_dispatches_flywheel_command(tmp_path, capsys, monkeypatch):
     out = json.loads(capsys.readouterr().out)
     assert exc.value.code == 0
     assert out["result"]["profile_id"] == "opencode-committee-fast"
+
+
+def test_run_dry_run_writes_sanitized_resolved_route_artifact(tmp_path):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    artifact_dir = tmp_path / "artifacts"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_routes(root)
+    _write_qwen_worker_config(root, effort="max")
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        artifact_dir=str(artifact_dir),
+        runner_args=["exec", "--model", "ignored-by-mms", "do the task"],
+        dry_run=True,
+    )
+
+    artifact = Path(result["resolved_route_path"])
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert result["ok"] is True
+    assert result["status"] == "dry_run"
+    assert result["model"] == "qwen3.7-max"
+    assert result["provider_id"] == "direct-qwen"
+    assert payload["runtime"]["reasoning_effort"] == "xhigh"
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert "secret-qwen" not in serialized
+    assert "https://qwen.example" not in serialized
+    assert "api_key" not in payload["runtime"]
+    assert "openai_base_url" not in payload["runtime"]
+
+
+def test_run_fake_response_emits_raw_looper_marker(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_routes(root)
+    _write_qwen_worker_config(root)
+    monkeypatch.setenv(
+        "MMS_FLYWHEEL_RUN_FAKE_RESPONSE",
+        'done\n__LOOPER_RESULT__={"summary":"ok","git_pr_lifecycle":{"prUrl":"https://github.com/CtriXin/EchoMind/pull/1"}}\n',
+    )
+
+    rc = mms_flywheel.handle_flywheel_command(
+        [
+            "run",
+            "--lane",
+            "worker",
+            "--priority",
+            "AI-P3",
+            "--config-root",
+            str(root),
+            "--cwd",
+            str(workdir),
+            "exec",
+            "--model",
+            "ignored",
+            "ship it",
+        ],
+        command_name="mmf flywheel",
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert 'done\n__LOOPER_RESULT__={"summary":"ok"' in out
+
+
+def test_run_invokes_codex_runner_with_raw_runtime_but_json_output_is_safe(tmp_path, monkeypatch, capsys):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_routes(root)
+    _write_qwen_worker_config(root)
+    captured = {}
+
+    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        captured["prompt"] = prompt
+        captured["cwd"] = cwd
+        captured["sandbox"] = sandbox
+        return (
+            0,
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
+            "",
+        )
+
+    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+
+    rc = mms_flywheel.handle_flywheel_command(
+        [
+            "run",
+            "--lane",
+            "worker",
+            "--priority",
+            "AI-P3",
+            "--config-root",
+            str(root),
+            "--cwd",
+            str(workdir),
+            "--json",
+            "--",
+            "fix this",
+        ],
+        command_name="mmf flywheel",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["result"]["agent_text"] == "agent text"
+    assert captured["runtime"]["api_key"] == "secret-qwen"
+    assert captured["runtime"]["openai_base_url"] == "https://qwen.example/v1"
+    assert captured["model"] == "qwen3.7-max"
+    assert captured["prompt"] == "fix this"
+    serialized = json.dumps(payload, ensure_ascii=False)
+    assert "secret-qwen" not in serialized
+    assert "https://qwen.example" not in serialized
+
+
+def test_run_rejects_committee_profile_for_headless_worker_runner(tmp_path):
+    root = tmp_path / "mms-next"
+    root.mkdir()
+
+    with pytest.raises(mms_flywheel.FlywheelConfigError, match="codex runtime only"):
+        mms_flywheel.run_flywheel_lane(
+            lane="committee",
+            priority="AI-P0",
+            config_root=str(root),
+            prompt="review",
+        )

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -60,6 +62,41 @@ def _seed_routes(root):
                     {"provider_id": "newapi-personal-tokyo", "model_id": "qwen3.7-max", "max_context_tokens": 800000},
                     {"provider_id": "newapi-tencent", "model_id": "qwen3.7-max", "max_context_tokens": 500000},
                 ],
+            }
+        },
+    }
+    _write_json(root / "model-routes.json", router)
+    _write_json(root / "model-routes.lineup.json", lineup)
+
+
+def _seed_dual_protocol_routes(root):
+    router = {
+        "version": 1,
+        "routes": {
+            "qwen3.7-max": {
+                "primary": {
+                    "provider_id": "dual-qwen",
+                    "model_id": "qwen3.7-max",
+                    "openai_base_url": "https://qwen.example/v1",
+                    "anthropic_base_url": "https://qwen.example/v1",
+                    "api_key": "secret-qwen",
+                    "protocols": ["anthropic_messages", "openai_chat_completions"],
+                    "cache_sensitive_transport": True,
+                },
+                "fallbacks": [],
+            }
+        },
+    }
+    lineup = {
+        "version": 1,
+        "routes": {
+            "qwen3.7-max": {
+                "primary": {
+                    "provider_id": "dual-qwen",
+                    "model_id": "qwen3.7-max",
+                    "max_context_tokens": 1000000,
+                },
+                "fallbacks": [],
             }
         },
     }
@@ -226,6 +263,52 @@ def test_run_dry_run_writes_sanitized_resolved_route_artifact(tmp_path):
     assert "openai_base_url" not in payload["runtime"]
 
 
+def test_run_dry_run_emits_cache_transport_evidence_for_dual_protocol_route(tmp_path):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    artifact_dir = tmp_path / "artifacts"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_dual_protocol_routes(root)
+    (root / "config.toml").write_text(
+        """
+[flywheel.lanes.worker]
+"AI-P3" = "flywheel.worker.p3"
+
+[flywheel.profiles."flywheel.worker.p3"]
+runtime = "codex"
+model = "qwen3.7-max"
+provider = "dual-qwen"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        artifact_dir=str(artifact_dir),
+        runner_args=["exec", "do the task"],
+        dry_run=True,
+    )
+
+    artifact = json.loads(Path(result["resolved_route_path"]).read_text(encoding="utf-8"))
+    run_artifact = json.loads(Path(result["run_result_path"]).read_text(encoding="utf-8"))
+    evidence = result["cache_transport_evidence"]
+    assert evidence["schema"] == "cache_transport_evidence.v1"
+    assert evidence["protocol"] == "anthropic_messages"
+    assert evidence["request_path"] == "/v1/messages"
+    assert evidence["request_url"] == ""
+    assert evidence["fallback_used"] is False
+    assert artifact["cache_transport_evidence"] == evidence
+    assert run_artifact["result"]["cache_transport_evidence"] == evidence
+    assert artifact["runtime"]["preferred_transport"] == "anthropic_messages"
+    serialized = json.dumps(artifact, ensure_ascii=False)
+    assert "secret-qwen" not in serialized
+    assert "https://qwen.example" not in serialized
+
+
 def test_run_fake_response_emits_raw_looper_marker(tmp_path, monkeypatch, capsys):
     root = tmp_path / "mms-next"
     workdir = tmp_path / "work"
@@ -314,6 +397,113 @@ def test_run_invokes_codex_runner_with_raw_runtime_but_json_output_is_safe(tmp_p
     serialized = json.dumps(payload, ensure_ascii=False)
     assert "secret-qwen" not in serialized
     assert "https://qwen.example" not in serialized
+
+
+def test_run_invokes_codex_runner_with_anthropic_transport_for_dual_protocol_route(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_dual_protocol_routes(root)
+    (root / "config.toml").write_text(
+        """
+[flywheel.lanes.worker]
+"AI-P3" = "flywheel.worker.p3"
+
+[flywheel.profiles."flywheel.worker.p3"]
+runtime = "codex"
+model = "qwen3.7-max"
+provider = "dual-qwen"
+""".strip(),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        return (
+            0,
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
+            "",
+        )
+
+    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        runner_args=["exec", "fix this"],
+    )
+
+    assert result["ok"] is True
+    assert captured["runtime"]["preferred_transport"] == "anthropic_messages"
+    assert captured["runtime"]["transport_request_path"] == "/v1/messages"
+    assert captured["runtime"]["cache_transport_evidence"]["protocol"] == "anthropic_messages"
+    assert captured["runtime"]["api_key"] == "secret-qwen"
+    assert captured["model"] == "qwen3.7-max"
+
+
+def test_codex_headless_passes_primary_anthropic_protocol_to_bridge(tmp_path, monkeypatch):
+    import mms_launchers
+
+    captured = {}
+    runtime = {
+        "id": "dual-qwen",
+        "api_key": "secret-qwen",
+        "openai_api_key": "secret-qwen",
+        "openai_base_url": "https://qwen.example/v1",
+        "anthropic_base_url": "https://qwen.example/v1",
+        "protocols": ["anthropic_messages", "openai_chat_completions"],
+        "preferred_transport": "anthropic_messages",
+    }
+
+    @contextmanager
+    def fake_bridge(gateway_url, api_key, **kwargs):
+        captured["gateway_url"] = gateway_url
+        captured["api_key"] = api_key
+        captured["kwargs"] = kwargs
+        yield {"base_url": "http://127.0.0.1:9999", "api_key": "bridge-token"}
+
+    monkeypatch.setattr(mms_launchers, "_ensure_bridge_helpers", lambda: None)
+    monkeypatch.setattr(mms_launchers, "gateway_health_check", lambda _runtime: None)
+    monkeypatch.setattr(mms_launchers, "_anthropic_base_url", lambda _runtime: _runtime["anthropic_base_url"])
+    monkeypatch.setattr(mms_launchers, "_openai_base_url", lambda _runtime: _runtime["openai_base_url"])
+    monkeypatch.setattr(mms_launchers, "build_provider_speed_scope", lambda _runtime: {})
+    monkeypatch.setattr(mms_launchers, "_probe_models", lambda _runtime, emit_output=False: {"models": ["qwen3.7-max"]})
+    monkeypatch.setattr(mms_launchers, "_is_gpt_model", lambda _model: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_thinking_enabled", lambda _runtime: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_reasoning_effort", lambda _runtime, default="medium": default)
+    monkeypatch.setattr(mms_launchers, "_rescue_bridge_kwargs", lambda: {})
+    monkeypatch.setattr(mms_launchers, "codex_chatcompletions_bridge", fake_bridge)
+    monkeypatch.setattr(mms_launchers, "_codex_provider_base_url", lambda base_url: f"{base_url}/v1")
+    monkeypatch.setattr(mms_launchers, "_codex_gateway_env", lambda _runtime, _base_url, model_info=None: {})
+    monkeypatch.setattr(mms_launchers, "prepare_cli_command", lambda cmd, env: (cmd, env, "codex"))
+    monkeypatch.setattr(
+        mms_flywheel.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}),
+            stderr="",
+        ),
+    )
+
+    rc, stdout, stderr = mms_flywheel._run_codex_headless(
+        runtime=runtime,
+        model="qwen3.7-max",
+        prompt="do it",
+        cwd=tmp_path,
+        sandbox="danger-full-access",
+    )
+
+    assert rc == 0
+    assert stderr == ""
+    assert "agent_message" in stdout
+    assert captured["gateway_url"] == "https://qwen.example/v1"
+    assert captured["kwargs"]["primary_protocol"] == "anthropic_messages"
 
 
 def test_run_rejects_committee_profile_for_headless_worker_runner(tmp_path):


### PR DESCRIPTION
## 结论

给 Flywheel/Looper 增加 `mmf flywheel run` headless runner，让 worker/fixer lane 通过 MMS route 启动 Codex headless。此 PR 是 stacked PR，依赖 #72 的 `mmf flywheel resolve`。

## 改动

- 新增 `mmf flywheel run`，支持 `worker` / `fixer` lane，接受 Looper/Codex 形态：`exec [--model ignored] <prompt>`。
- 非 `--json` 模式输出 raw agent text，保持 `__LOOPER_RESULT__=` 在行首，避免破坏 Looper completion marker。
- 写入 `<artifact-dir>/resolved-route.json`，但只写 sanitized route/runtime；不落 `api_key`、endpoint URL、proxy。
- 对 unsupported runtime / missing route / missing prompt fail closed。
- 更新 `docs/FLYWHEEL_MMS_CONTRACT.md`，明确当前 `run` 只覆盖 Codex headless；committee 仍走现有 OpenCode committee path。

## 验证

- `python3 -m py_compile mms_flywheel.py mms_core.py`
- `pytest -q tests/test_mms_flywheel.py tests/test_command_smoke.py` -> `12 passed`
- `./mmf flywheel run --lane worker --priority AI-P3 --dry-run --json --prompt 'test prompt'`
- dry-run JSON grep：确认没有 `api_key` / endpoint URL / proxy 泄漏
- `git diff --check`
- `python3 scripts/regression_fresh_user_gate.py --quick` -> `64 passed`

## Review Hub

- Mission: `20260619T062342Z-review-flywheel-mms-headless-runner-and-hook-integration`
- Reviewers: `qwen3.7-max`, `MiniMax-M3`
- Result: PASS / no blockers / `reviewers_complete=2`, `reviewers_incomplete=0`
- Residual low risks: launcher internal helper coupling, no subprocess timeout, diagnostic truncation is intentional
- Evidence grade: G1 public summary; full Review Hub artifacts are local/private under `.agent.local/review-hub/2026-06-19-flywheel-runner-postreview/`

## Merge note

请先处理 #72；本 PR 当前 base 是 `agent/0.1.0-flywheel-resolve`。#72 merge 后可 rebase/retarget 到 `dev` 再合。
