### PR TITLE
fix: harden Flywheel headless seams

### DIFF
--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -758,6 +758,7 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
     import mms_launchers
 
     mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
+    mms_launchers._ensure_speed_stats()  # noqa: SLF001 - keep launcher lazy imports initialized.
     mms_launchers.gateway_health_check(runtime)
     api_key = runtime.get("openai_api_key") or runtime.get("api_key", "")
     provider_id = runtime.get("id", "")
@@ -812,6 +813,12 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
             effort = mms_launchers._runtime_reasoning_effort(runtime, default="medium")  # noqa: SLF001
             cmd += ["-c", f'model_reasoning_effort="{effort}"']
         cmd += [
+            "-c",
+            'model_providers.custom.name="custom"',
+            "-c",
+            'model_providers.custom.wire_api="responses"',
+            "-c",
+            "model_providers.custom.requires_openai_auth=true",
             "-c",
             f'openai_base_url="{bridge_base_url}"',
             "-c",

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -3894,6 +3894,11 @@ def _resolve_token_saver_root():
     return ""
 
 
+def _resolve_xmem_root():
+    # xmem is global-only now; MMS should not bundle or inject a session-local copy.
+    return ""
+
+
 def _resolve_auto_github_contributor_root():
     candidates = []
     explicit = str(os.environ.get("MMS_AUTO_GITHUB_CONTRIBUTOR_ROOT") or "").strip()
@@ -5635,6 +5640,14 @@ def _overlay_opencode_session_assets(config_dir, session_home, *, enable_caveman
         overlay_opencode_xmem_plugin=_overlay_opencode_xmem_plugin,
         overlay_opencode_nsr_plugin=_overlay_opencode_nsr_plugin,
     )
+
+
+def _overlay_xmem_session_entries(*_args, **_kwargs):
+    return None
+
+
+def _overlay_opencode_xmem_plugin(*_args, **_kwargs):
+    return None
 
 
 def _configure_ecc_session_env(env_data, *, enable_ecc=False):
@@ -11550,7 +11563,7 @@ def _opencode_rtk_plugin_enabled(runtime=None):
 
 
 def _opencode_xmem_plugin_enabled(runtime=None):
-    return bool(_opencode_xmem_plugin_path(runtime))
+    return False
 
 
 def _opencode_nsr_plugin_path(runtime=None):

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -446,6 +446,73 @@ provider = "dual-qwen"
     assert captured["model"] == "qwen3.7-max"
 
 
+def test_codex_headless_initializes_lazy_speed_stats(tmp_path, monkeypatch):
+    import mms_launchers
+
+    captured = {}
+    runtime = {
+        "id": "direct-qwen",
+        "api_key": "secret-qwen",
+        "openai_api_key": "secret-qwen",
+        "openai_base_url": "https://qwen.example/v1",
+        "protocols": ["openai_chat_completions"],
+        "preferred_transport": "openai_chat_completions",
+    }
+
+    @contextmanager
+    def fake_bridge(gateway_url, api_key, **kwargs):
+        captured["speed_scope"] = kwargs.get("speed_scope")
+        yield {"base_url": "http://127.0.0.1:9999", "api_key": "bridge-token"}
+
+    def fake_ensure_speed_stats():
+        mms_launchers.build_provider_speed_scope = lambda _runtime: {"provider": "direct-qwen"}
+
+    monkeypatch.setattr(mms_launchers, "_ensure_bridge_helpers", lambda: None)
+    monkeypatch.setattr(mms_launchers, "build_provider_speed_scope", None)
+    monkeypatch.setattr(mms_launchers, "_ensure_speed_stats", fake_ensure_speed_stats)
+    monkeypatch.setattr(mms_launchers, "gateway_health_check", lambda _runtime: None)
+    monkeypatch.setattr(mms_launchers, "_openai_base_url", lambda _runtime: _runtime["openai_base_url"])
+    monkeypatch.setattr(mms_launchers, "_probe_models", lambda _runtime, emit_output=False: {"models": ["qwen3.7-max"]})
+    monkeypatch.setattr(mms_launchers, "_is_gpt_model", lambda _model: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_thinking_enabled", lambda _runtime: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_reasoning_effort", lambda _runtime, default="medium": default)
+    monkeypatch.setattr(mms_launchers, "_rescue_bridge_kwargs", lambda: {})
+    monkeypatch.setattr(mms_launchers, "codex_chatcompletions_bridge", fake_bridge)
+    monkeypatch.setattr(mms_launchers, "_codex_provider_base_url", lambda base_url: f"{base_url}/v1")
+    monkeypatch.setattr(mms_launchers, "_codex_gateway_env", lambda _runtime, _base_url, model_info=None: {})
+
+    def fake_prepare_cli_command(cmd, env):
+        captured["cmd"] = cmd
+        return cmd, env, "codex"
+
+    monkeypatch.setattr(mms_launchers, "prepare_cli_command", fake_prepare_cli_command)
+    monkeypatch.setattr(
+        mms_flywheel.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "ok"}}),
+            stderr="",
+        ),
+    )
+
+    rc, _stdout, stderr = mms_flywheel._run_codex_headless(
+        runtime=runtime,
+        model="qwen3.7-max",
+        prompt="do it",
+        cwd=tmp_path,
+        sandbox="danger-full-access",
+    )
+
+    assert rc == 0
+    assert stderr == ""
+    assert captured["speed_scope"] == {"provider": "direct-qwen"}
+    assert "--ignore-user-config" in captured["cmd"]
+    assert 'model_providers.custom.name="custom"' in captured["cmd"]
+    assert 'model_providers.custom.wire_api="responses"' in captured["cmd"]
+    assert "model_providers.custom.requires_openai_auth=true" in captured["cmd"]
+
+
 def test_codex_headless_passes_primary_anthropic_protocol_to_bridge(tmp_path, monkeypatch):
     import mms_launchers
 


### PR DESCRIPTION
## Summary
- initialize lazy launcher speed helpers before Flywheel headless Codex bridge setup
- pass complete custom Codex provider metadata under --ignore-user-config
- keep xmem global-only for OpenCode committee sessions, avoiding session-local injection failures

## Evidence
- EchoMind full E2E PR20 hit worker and committee seams before this fix
- PR20 rerun passed after local MMS_REPO_ROOT pointed to the fixed worktree

## Validation
- python3 -m py_compile mms_flywheel.py mms_launchers.py mms_opencode_env.py mms_opencode_session.py
- pytest -q tests/test_mms_flywheel.py tests/test_native_fallback.py tests/test_gateway_bridge_model_override.py — 44 passed
- python3 scripts/regression_fresh_user_gate.py --quick — 64 passed, gate PASS
- runtimia-mms-agent run --format json --model opencode-committee-fast '请只输出一句：OK' — returned OK

## Trace
- EchoMind PR20: https://github.com/CtriXin/EchoMind/pull/20
- Supersedes the post-merge branch-only commit pushed after PR73 was already merged; this PR is based on current origin/dev.
