### PR TITLE
feat(flywheel): add domestic tier fallback

### DIFF
--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -449,6 +449,23 @@ def _gateway_route_payload(route, *, gateway_url, gateway_key, server):
     }
 
 
+def _normalized_bridge_protocol(route):
+    protocol = str((route or {}).get("protocol") or "").strip()
+    aliases = {
+        "responses": "openai_responses",
+        "openai": "openai_responses",
+        "openai_responses": "openai_responses",
+        "chat": "openai_chat_completions",
+        "chat_completions": "openai_chat_completions",
+        "openai_chat": "openai_chat_completions",
+        "openai_chat_completions": "openai_chat_completions",
+        "anthropic": "anthropic_messages",
+        "messages": "anthropic_messages",
+        "anthropic_messages": "anthropic_messages",
+    }
+    return aliases.get(protocol, protocol or "anthropic_messages")
+
+
 _OPENAI_MODEL_PREFIXES = ("gpt-", "o1-", "o3-", "o4-", "codex-")
 _DOMESTIC_MODEL_PREFIXES = ("glm", "kimi", "k2.6", "mimo", "qwen", "minimax", "deepseek")
 _DOMESTIC_THINKING_BLOCK_TYPES = {"thinking", "redacted_thinking"}
@@ -5736,6 +5753,134 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
             # fallback 也失败，返回 502
             self._json(502, {"error": {"message": str(exc)}})
 
+    def _do_openai_responses_fallback_route(self, payload, model_name, gateway_url, gateway_key, started_ms, route=None):
+        """Forward one mixed-protocol fallback route through OpenAI Responses."""
+        route = route if isinstance(route, dict) else {}
+        provider_id = route.get("provider_id") or getattr(self.server, "provider_id", "")
+        provider_profile = route.get("provider_profile") or getattr(self.server, "provider_profile", "")
+        reasoning_enabled = bool(getattr(self.server, "reasoning_enabled", True))
+        reasoning_effort = getattr(self.server, "reasoning_effort", "high")
+        route_payload = copy.deepcopy(payload)
+        route_payload["model"] = model_name
+        profile_id = apply_profile_body_patches(
+            route_payload,
+            protocol="responses",
+            provider_id=provider_id,
+            profile_id=provider_profile,
+            base_url=gateway_url,
+            model_name=model_name,
+            thinking_enabled=reasoning_enabled,
+            reasoning_effort=reasoning_effort,
+        )
+        if not profile_id and reasoning_enabled:
+            reasoning_payload = route_payload.get("reasoning")
+            next_reasoning = dict(reasoning_payload) if isinstance(reasoning_payload, dict) else {}
+            next_reasoning["effort"] = reasoning_effort
+            route_payload["reasoning"] = next_reasoning
+        elif not profile_id:
+            route_payload.pop("reasoning", None)
+
+        target_url = _build_gateway_url(gateway_url, "/responses")
+        fwd_headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {gateway_key}",
+        }
+        apply_profile_auth_headers(
+            fwd_headers,
+            protocol="responses",
+            api_key=gateway_key,
+            provider_id=provider_id,
+            profile_id=provider_profile,
+            base_url=gateway_url,
+            model_name=model_name,
+        )
+        fwd_headers.update(_copy_passthrough_headers(self.headers))
+
+        first_byte_ms = None
+        output_tokens = None
+        try:
+            with httpx.stream(
+                "POST",
+                target_url,
+                headers=fwd_headers,
+                json=route_payload,
+                timeout=300,
+                **_route_httpx_kwargs(self.server, route, target_url),
+            ) as response:
+                content_type = response.headers.get("content-type", "application/json")
+                if response.status_code >= 400:
+                    body_text = response.read().decode("utf-8", errors="replace")
+                    return {
+                        "sent": False,
+                        "status": response.status_code,
+                        "body": body_text,
+                        "url": target_url,
+                    }
+
+                if "text/event-stream" in content_type.lower():
+                    self.send_response(response.status_code)
+                    self.send_header("Content-Type", content_type)
+                    self.send_header("Cache-Control", "no-cache")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    for raw_line in response.iter_lines():
+                        if first_byte_ms is None:
+                            first_byte_ms = _now_ms()
+                        stripped = raw_line.strip()
+                        if stripped.startswith("data:"):
+                            data_str = stripped[5:].strip()
+                            if data_str and data_str != "[DONE]":
+                                try:
+                                    event_payload = json.loads(data_str)
+                                except json.JSONDecodeError:
+                                    event_payload = None
+                                extracted = _extract_output_tokens(event_payload)
+                                if extracted is not None:
+                                    output_tokens = extracted
+                        self.wfile.write(raw_line.encode("utf-8") + b"\n")
+                        if raw_line == "":
+                            self.wfile.flush()
+                    self.close_connection = True
+                else:
+                    body_out = response.read()
+                    if not body_out:
+                        return {
+                            "sent": False,
+                            "status": 502,
+                            "body": "empty responses fallback body",
+                            "url": target_url,
+                            "failure_token": "invalid_text",
+                        }
+                    first_byte_ms = _now_ms()
+                    try:
+                        output_tokens = _extract_output_tokens(json.loads(body_out.decode("utf-8")))
+                    except Exception:
+                        output_tokens = None
+                    self.send_response(response.status_code)
+                    self.send_header("Content-Type", content_type)
+                    self.send_header("Content-Length", str(len(body_out)))
+                    self.end_headers()
+                    self.wfile.write(body_out)
+
+                _record_bridge_speed(
+                    model_name,
+                    started_ms=started_ms,
+                    first_byte_ms=first_byte_ms,
+                    output_tokens=output_tokens,
+                    provider_scope=getattr(self.server, "speed_scope", None),
+                    server=self.server,
+                )
+                return {"sent": True, "status": response.status_code, "url": target_url}
+        except Exception as exc:
+            token = _native_fallback_error_token(exc)
+            return {
+                "sent": False,
+                "status": 502,
+                "body": str(exc),
+                "url": target_url,
+                "failure_token": token,
+            }
+
     def _do_anthropic_messages_fallback(self, payload, model_name, gateway_url, gateway_key, started_ms, route=None):
         """Codex Responses hot fallback through Anthropic Messages transport."""
         route = route if isinstance(route, dict) else {}
@@ -5773,6 +5918,49 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                 provider_profile = active_route.get("provider_profile") or getattr(self.server, "provider_profile", "")
                 is_last_route = route_index >= len(forward_routes) - 1
                 retry_statuses, _retry_tokens = _native_fallback_retry_sets(active_route)
+                active_protocol = _normalized_bridge_protocol(active_route)
+
+                if active_protocol == "openai_responses":
+                    result = self._do_openai_responses_fallback_route(
+                        payload,
+                        active_model,
+                        active_gateway_url,
+                        active_gateway_key,
+                        started_ms,
+                        route=active_route,
+                    )
+                    if result.get("sent"):
+                        return
+                    last_status = int(result.get("status") or 502)
+                    last_body = str(result.get("body") or "")
+                    last_target_url = str(result.get("url") or "")
+                    failure_token = str(result.get("failure_token") or "").strip()
+                    can_try_next = (
+                        (last_status in retry_statuses)
+                        or (failure_token and failure_token in _retry_tokens)
+                    )
+                    if not is_last_route and can_try_next:
+                        next_route = forward_routes[route_index + 1]
+                        _log_native_fallback(
+                            from_route=active_route,
+                            to_route=next_route,
+                            model_name=active_model,
+                            reason=failure_token or f"http_{last_status}",
+                            request_url=last_target_url,
+                        )
+                        continue
+                    break
+
+                if active_protocol == "openai_chat_completions":
+                    self._do_chatcompletions_fallback(
+                        payload,
+                        active_model,
+                        active_gateway_url,
+                        active_gateway_key,
+                        started_ms,
+                        route=active_route,
+                    )
+                    return
 
                 anthropic_payload = _responses_payload_to_anthropic_messages_payload(payload, active_model)
                 profile_id = apply_profile_body_patches(

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -5567,7 +5567,7 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
             _bridge_error_logger.error("do_POST responses proxy error: %s", exc, exc_info=True)
             self._json(502, {"error": {"message": str(exc)}})
 
-    def _do_chatcompletions_fallback(self, payload, model_name, gateway_url, gateway_key, started_ms, route=None):
+    def _do_chatcompletions_fallback(self, payload, model_name, gateway_url, gateway_key, started_ms, route=None, return_result=False):
         """Responses API 不可用时，内部翻译为 Chat Completions 请求并转发。"""
         route = route if isinstance(route, dict) else {}
         provider_id = route.get("provider_id") or getattr(self.server, "provider_id", "")
@@ -5652,6 +5652,13 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                                 )
                                 time.sleep(delay)
                                 continue
+                            if return_result:
+                                return {
+                                    "sent": False,
+                                    "status": response.status_code,
+                                    "body": last_body or "chat completions fallback rate limited",
+                                    "url": target_url,
+                                }
                             _record_bridge_blocking_failure(
                                 self.server,
                                 model_name=model_name,
@@ -5709,9 +5716,17 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                             provider_scope=getattr(self.server, "speed_scope", None),
                             server=self.server,
                         )
-                        return
+                        return {"sent": True, "status": 200, "url": target_url}
                     break
             if _chatcompletions_error_requests_messages(last_body) and gateway_url and gateway_key:
+                if return_result:
+                    return {
+                        "sent": False,
+                        "status": last_status,
+                        "body": last_body or "",
+                        "url": target_url if "target_url" in locals() else "",
+                        "failure_token": "invalid_text",
+                    }
                 messages_route = dict(route)
                 messages_route["protocol"] = "anthropic_messages"
                 messages_route["fallback_reason"] = "cache_sensitive_messages_retry"
@@ -5738,6 +5753,13 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                     route=messages_route,
                 )
                 return
+            if return_result:
+                return {
+                    "sent": False,
+                    "status": last_status,
+                    "body": last_body or "chat completions fallback failed",
+                    "url": target_url if "target_url" in locals() else "",
+                }
             _record_bridge_blocking_failure(
                 self.server,
                 model_name=model_name,
@@ -5750,6 +5772,14 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
             self._json(last_status, {"error": {"message": last_body or "chat completions fallback failed"}})
         except Exception as exc:
             _bridge_error_logger.error("fallback chatcompletions error: %s", exc, exc_info=True)
+            if return_result:
+                return {
+                    "sent": False,
+                    "status": 502,
+                    "body": str(exc),
+                    "url": target_url if "target_url" in locals() else "",
+                    "failure_token": _native_fallback_error_token(exc),
+                }
             # fallback 也失败，返回 502
             self._json(502, {"error": {"message": str(exc)}})
 
@@ -5952,15 +5982,36 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                     break
 
                 if active_protocol == "openai_chat_completions":
-                    self._do_chatcompletions_fallback(
+                    result = self._do_chatcompletions_fallback(
                         payload,
                         active_model,
                         active_gateway_url,
                         active_gateway_key,
                         started_ms,
                         route=active_route,
+                        return_result=True,
                     )
-                    return
+                    if result and result.get("sent"):
+                        return
+                    last_status = int((result or {}).get("status") or 502)
+                    last_body = str((result or {}).get("body") or "")
+                    last_target_url = str((result or {}).get("url") or "")
+                    failure_token = str((result or {}).get("failure_token") or "").strip()
+                    can_try_next = (
+                        (last_status in retry_statuses)
+                        or (failure_token and failure_token in _retry_tokens)
+                    )
+                    if not is_last_route and can_try_next:
+                        next_route = forward_routes[route_index + 1]
+                        _log_native_fallback(
+                            from_route=active_route,
+                            to_route=next_route,
+                            model_name=active_model,
+                            reason=failure_token or f"http_{last_status}",
+                            request_url=last_target_url,
+                        )
+                        continue
+                    break
 
                 anthropic_payload = _responses_payload_to_anthropic_messages_payload(payload, active_model)
                 profile_id = apply_profile_body_patches(

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -441,6 +441,9 @@ def _gateway_route_payload(route, *, gateway_url, gateway_key, server):
         "openai_url": str(route.get("openai_url") or getattr(server, "openai_url", "") or "").strip(),
         "proxy_url": str(route.get("proxy_url") or getattr(server, "proxy_url", "") or "").strip(),
         "no_proxy": str(route.get("no_proxy") or getattr(server, "no_proxy", "") or "").strip(),
+        "model": str(route.get("model") or "").strip(),
+        "allow_model_switch": bool(route.get("allow_model_switch")),
+        "protocol": str(route.get("protocol") or "").strip(),
         "fallback_reason": str(route.get("fallback_reason") or "primary"),
         "try_next_on": list(route.get("try_next_on") or []),
     }
@@ -5736,143 +5739,198 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
     def _do_anthropic_messages_fallback(self, payload, model_name, gateway_url, gateway_key, started_ms, route=None):
         """Codex Responses hot fallback through Anthropic Messages transport."""
         route = route if isinstance(route, dict) else {}
-        provider_id = route.get("provider_id") or getattr(self.server, "provider_id", "")
-        provider_profile = route.get("provider_profile") or getattr(self.server, "provider_profile", "")
         reasoning_enabled = bool(getattr(self.server, "reasoning_enabled", True))
         reasoning_effort = getattr(self.server, "reasoning_effort", "high")
-        anthropic_payload = _responses_payload_to_anthropic_messages_payload(payload, model_name)
-        profile_id = apply_profile_body_patches(
-            anthropic_payload,
-            protocol="anthropic_messages",
-            provider_id=provider_id,
-            profile_id=provider_profile,
-            base_url=gateway_url,
-            model_name=model_name,
-            thinking_enabled=reasoning_enabled,
-            reasoning_effort=reasoning_effort,
-        )
-        if profile_id:
-            _canonicalize_domestic_anthropic_history(anthropic_payload, model_name)
-        if not profile_id and _is_domestic_model(model_name):
-            _apply_domestic_reasoning_controls(
-                anthropic_payload,
-                model_name,
-                thinking_enabled=reasoning_enabled,
-                reasoning_effort=reasoning_effort,
-            )
-        if not _normalize_model_name(model_name).startswith("claude-") and not _model_supports_anthropic_cache_control(model_name):
-            _strip_cache_control(anthropic_payload)
 
-        fwd_headers = {
-            "Content-Type": "application/json",
-            "x-api-key": gateway_key,
-            "anthropic-version": "2023-06-01",
-        }
-        apply_profile_auth_headers(
-            fwd_headers,
-            protocol="anthropic_messages",
-            api_key=gateway_key,
-            provider_id=provider_id,
-            profile_id=provider_profile,
-            base_url=gateway_url,
-            model_name=model_name,
-        )
-        claude_passthrough, claude_passthrough_prefixes = _claude_passthrough_rules(self.server, model_name)
-        fwd_headers.update(
-            _copy_passthrough_headers(
-                self.headers,
-                names=claude_passthrough,
-                prefixes=claude_passthrough_prefixes,
-            )
-        )
+        def _forward_routes():
+            primary = _gateway_route_payload(route, gateway_url=gateway_url, gateway_key=gateway_key, server=self.server)
+            routes = [primary]
+            if route.get("include_native_fallbacks"):
+                requested_model = _normalize_model_name(model_name)
+                for item in getattr(self.server, "native_fallback_routes", []) or []:
+                    if not isinstance(item, dict):
+                        continue
+                    item_model = str(item.get("model") or "").strip()
+                    allow_model_switch = bool(item.get("allow_model_switch"))
+                    if item_model and not allow_model_switch and _normalize_model_name(item_model) != requested_model:
+                        continue
+                    next_route = _gateway_route_payload(item, gateway_url="", gateway_key="", server=self.server)
+                    if not next_route.get("gateway_url") or not next_route.get("gateway_key"):
+                        continue
+                    routes.append(next_route)
+            return routes
 
-        translator = _AnthropicMessagesToResponsesTranslator(model_name)
-        first_byte_ms = None
-        output_tokens = None
+        forward_routes = _forward_routes()
+        last_body = None
+        last_status = 404
+        last_target_url = ""
         try:
-            last_body = None
-            last_status = 404
-            for target_url in _build_gateway_candidate_urls(gateway_url, "/messages"):
-                _bridge_error_logger.info(
-                    "FALLBACK to anthropic messages: model=%s url=%s", model_name, target_url
+            for route_index, active_route in enumerate(forward_routes):
+                active_model = str(active_route.get("model") or model_name or "").strip()
+                active_gateway_url = active_route.get("gateway_url") or gateway_url
+                active_gateway_key = active_route.get("gateway_key") or gateway_key
+                provider_id = active_route.get("provider_id") or getattr(self.server, "provider_id", "")
+                provider_profile = active_route.get("provider_profile") or getattr(self.server, "provider_profile", "")
+                is_last_route = route_index >= len(forward_routes) - 1
+                retry_statuses, _retry_tokens = _native_fallback_retry_sets(active_route)
+
+                anthropic_payload = _responses_payload_to_anthropic_messages_payload(payload, active_model)
+                profile_id = apply_profile_body_patches(
+                    anthropic_payload,
+                    protocol="anthropic_messages",
+                    provider_id=provider_id,
+                    profile_id=provider_profile,
+                    base_url=active_gateway_url,
+                    model_name=active_model,
+                    thinking_enabled=reasoning_enabled,
+                    reasoning_effort=reasoning_effort,
                 )
-                retry_remaining = 1
-                while True:
-                    with httpx.stream(
-                        "POST",
-                        target_url,
-                        headers=fwd_headers,
-                        json=anthropic_payload,
-                        timeout=300,
-                        **_route_httpx_kwargs(self.server, route, target_url),
-                    ) as response:
-                        if response.status_code == 429:
-                            last_status = response.status_code
-                            last_body = response.read().decode("utf-8", errors="replace")
-                            retry_after = response.headers.get("Retry-After")
-                            delay = _retry_after_delay_seconds(retry_after)
-                            if retry_remaining > 0 and delay > 0:
-                                retry_remaining -= 1
-                                _bridge_error_logger.warning(
-                                    "anthropic messages fallback rate limited: model=%s url=%s retry_after=%s",
-                                    model_name,
-                                    target_url,
-                                    retry_after,
+                if profile_id:
+                    _canonicalize_domestic_anthropic_history(anthropic_payload, active_model)
+                if not profile_id and _is_domestic_model(active_model):
+                    _apply_domestic_reasoning_controls(
+                        anthropic_payload,
+                        active_model,
+                        thinking_enabled=reasoning_enabled,
+                        reasoning_effort=reasoning_effort,
+                    )
+                if not _normalize_model_name(active_model).startswith("claude-") and not _model_supports_anthropic_cache_control(active_model):
+                    _strip_cache_control(anthropic_payload)
+
+                fwd_headers = {
+                    "Content-Type": "application/json",
+                    "x-api-key": active_gateway_key,
+                    "anthropic-version": "2023-06-01",
+                }
+                apply_profile_auth_headers(
+                    fwd_headers,
+                    protocol="anthropic_messages",
+                    api_key=active_gateway_key,
+                    provider_id=provider_id,
+                    profile_id=provider_profile,
+                    base_url=active_gateway_url,
+                    model_name=active_model,
+                )
+                claude_passthrough, claude_passthrough_prefixes = _claude_passthrough_rules(self.server, active_model)
+                fwd_headers.update(
+                    _copy_passthrough_headers(
+                        self.headers,
+                        names=claude_passthrough,
+                        prefixes=claude_passthrough_prefixes,
+                    )
+                )
+
+                translator = _AnthropicMessagesToResponsesTranslator(active_model)
+                first_byte_ms = None
+                output_tokens = None
+                route_exhausted = False
+                for target_url in _build_gateway_candidate_urls(active_gateway_url, "/messages"):
+                    last_target_url = target_url
+                    _bridge_error_logger.info(
+                        "FALLBACK to anthropic messages: model=%s url=%s", active_model, target_url
+                    )
+                    retry_remaining = 1
+                    while True:
+                        with httpx.stream(
+                            "POST",
+                            target_url,
+                            headers=fwd_headers,
+                            json=anthropic_payload,
+                            timeout=300,
+                            **_route_httpx_kwargs(self.server, active_route, target_url),
+                        ) as response:
+                            if response.status_code == 429:
+                                last_status = response.status_code
+                                last_body = response.read().decode("utf-8", errors="replace")
+                                retry_after = response.headers.get("Retry-After")
+                                delay = _retry_after_delay_seconds(retry_after)
+                                if retry_remaining > 0 and delay > 0:
+                                    retry_remaining -= 1
+                                    _bridge_error_logger.warning(
+                                        "anthropic messages fallback rate limited: model=%s url=%s retry_after=%s",
+                                        active_model,
+                                        target_url,
+                                        retry_after,
+                                    )
+                                    time.sleep(delay)
+                                    continue
+                                if not is_last_route and response.status_code in retry_statuses:
+                                    next_route = forward_routes[route_index + 1]
+                                    _log_native_fallback(
+                                        from_route=active_route,
+                                        to_route=next_route,
+                                        model_name=active_model,
+                                        reason="http_429",
+                                        request_url=target_url,
+                                    )
+                                    route_exhausted = True
+                                    break
+                                _record_bridge_blocking_failure(
+                                    self.server,
+                                    model_name=active_model,
+                                    provider_id=provider_id,
+                                    status_code=response.status_code,
+                                    body_text=last_body,
+                                    request_url=target_url,
+                                    bridge_surface="codex_anthropic_messages_fallback",
                                 )
-                                time.sleep(delay)
-                                continue
-                            _record_bridge_blocking_failure(
-                                self.server,
-                                model_name=model_name,
-                                provider_id=provider_id,
-                                status_code=response.status_code,
-                                body_text=last_body,
-                                request_url=target_url,
-                                bridge_surface="codex_anthropic_messages_fallback",
-                            )
-                            self._json_with_headers(
-                                429,
-                                {"error": {"message": last_body or "anthropic messages fallback rate limited"}},
-                                extra_headers={"Retry-After": retry_after} if retry_after else None,
+                                self._json_with_headers(
+                                    429,
+                                    {"error": {"message": last_body or "anthropic messages fallback rate limited"}},
+                                    extra_headers={"Retry-After": retry_after} if retry_after else None,
+                                )
+                                return
+                            if response.status_code >= 400:
+                                last_status = response.status_code
+                                last_body = response.read().decode("utf-8", errors="replace")
+                                if not is_last_route and response.status_code in retry_statuses:
+                                    next_route = forward_routes[route_index + 1]
+                                    _log_native_fallback(
+                                        from_route=active_route,
+                                        to_route=next_route,
+                                        model_name=active_model,
+                                        reason=f"http_{response.status_code}",
+                                        request_url=target_url,
+                                    )
+                                    route_exhausted = True
+                                break
+
+                            self.send_response(200)
+                            self.send_header("Content-Type", "text/event-stream")
+                            self.send_header("Cache-Control", "no-cache")
+                            self.send_header("Connection", "close")
+                            self.end_headers()
+
+                            for event_type, event_payload in _iter_sse_lines(response):
+                                if first_byte_ms is None:
+                                    first_byte_ms = _now_ms()
+                                for event_name, response_payload in translator.process(event_type, event_payload):
+                                    extracted = _extract_output_tokens(response_payload)
+                                    if extracted is not None:
+                                        output_tokens = extracted
+                                    self._sse(event_name, response_payload)
+                            self.close_connection = True
+                            _record_bridge_speed(
+                                active_model,
+                                started_ms=started_ms,
+                                first_byte_ms=first_byte_ms,
+                                output_tokens=output_tokens,
+                                provider_scope=getattr(self.server, "speed_scope", None),
+                                server=self.server,
                             )
                             return
-                        if response.status_code >= 400:
-                            last_status = response.status_code
-                            last_body = response.read().decode("utf-8", errors="replace")
-                            break
-
-                        self.send_response(200)
-                        self.send_header("Content-Type", "text/event-stream")
-                        self.send_header("Cache-Control", "no-cache")
-                        self.send_header("Connection", "close")
-                        self.end_headers()
-
-                        for event_type, event_payload in _iter_sse_lines(response):
-                            if first_byte_ms is None:
-                                first_byte_ms = _now_ms()
-                            for event_name, response_payload in translator.process(event_type, event_payload):
-                                extracted = _extract_output_tokens(response_payload)
-                                if extracted is not None:
-                                    output_tokens = extracted
-                                self._sse(event_name, response_payload)
-                        self.close_connection = True
-                        _record_bridge_speed(
-                            model_name,
-                            started_ms=started_ms,
-                            first_byte_ms=first_byte_ms,
-                            output_tokens=output_tokens,
-                            provider_scope=getattr(self.server, "speed_scope", None),
-                            server=self.server,
-                        )
-                        return
-                    break
+                    if route_exhausted:
+                        break
+                if route_exhausted:
+                    continue
+                break
             _record_bridge_blocking_failure(
                 self.server,
                 model_name=model_name,
-                provider_id=provider_id,
+                provider_id=str((forward_routes[-1] if forward_routes else route).get("provider_id") or getattr(self.server, "provider_id", "")),
                 status_code=last_status,
                 body_text=last_body or "",
-                request_url=target_url if "target_url" in locals() else "",
+                request_url=last_target_url,
                 bridge_surface="codex_anthropic_messages_fallback",
             )
             self._json(last_status, {"error": {"message": last_body or "anthropic messages fallback failed"}})
@@ -5971,6 +6029,7 @@ class _ResponsesToChatHandler(_ResponsesProxyHandler):
                 "provider_profile": provider_profile,
                 "protocol": "anthropic_messages",
                 "fallback_reason": "",
+                "include_native_fallbacks": True,
             }
             self._do_anthropic_messages_fallback(
                 payload,
@@ -6141,6 +6200,7 @@ def codex_chatcompletions_bridge(
     proxy_url="",
     no_proxy="",
     primary_protocol="openai_chat_completions",
+    native_fallback_routes=None,
     rescue_fallback_model="",
     rescue_fallback_cli="",
     rescue_hot_fallback_enabled=None,
@@ -6176,6 +6236,7 @@ def codex_chatcompletions_bridge(
         if str(primary_protocol or "").strip() == "anthropic_messages"
         else "openai_chat_completions"
     )
+    server.native_fallback_routes = list(native_fallback_routes or [])
     _configure_bridge_rescue(server)
     if rescue_fallback_model:
         server.rescue_fallback_model = str(rescue_fallback_model or "").strip()

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -5982,6 +5982,16 @@ class _ResponsesProxyHandler(BaseHTTPRequestHandler):
                     break
 
                 if active_protocol == "openai_chat_completions":
+                    if is_last_route:
+                        self._do_chatcompletions_fallback(
+                            payload,
+                            active_model,
+                            active_gateway_url,
+                            active_gateway_key,
+                            started_ms,
+                            route=active_route,
+                        )
+                        return
                     result = self._do_chatcompletions_fallback(
                         payload,
                         active_model,

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -629,6 +629,15 @@ def resolve_flywheel_profile(
         or selected_route.get("context_length")
     )
 
+    config_meta: dict[str, Any] = {
+        "root": str(root),
+        "sources": sources,
+        "route_path": str(route_file),
+        "lineup_path": str(lineup_file),
+    }
+    if config_path:
+        config_meta["config_path"] = str(Path(config_path).expanduser().resolve())
+
     resolved: dict[str, Any] = {
         "version": VERSION,
         "lane": lane,
@@ -644,12 +653,7 @@ def resolve_flywheel_profile(
         "thinking_mode": thinking,
         "reasoning_effort": effort,
         "max_context_tokens": context_tokens,
-        "config": {
-            "root": str(root),
-            "sources": sources,
-            "route_path": str(route_file),
-            "lineup_path": str(lineup_file),
-        },
+        "config": config_meta,
     }
     if profile_cfg.get("opencode_profile"):
         resolved["opencode_profile"] = str(profile_cfg["opencode_profile"])
@@ -662,6 +666,7 @@ def _native_fallback_routes_for_resolved(resolved: dict[str, Any]) -> list[dict[
     root = Path(str(config_meta.get("root") or "")).expanduser()
     route_path = Path(str(config_meta.get("route_path") or "")).expanduser()
     lineup_path = Path(str(config_meta.get("lineup_path") or "")).expanduser()
+    config_path = str(config_meta.get("config_path") or "").strip()
     profile_id = str(resolved.get("profile_id") or "").strip()
     model = str(resolved.get("model") or "").strip()
     selected_provider = str(resolved.get("provider_id") or "").strip()
@@ -670,7 +675,7 @@ def _native_fallback_routes_for_resolved(resolved: dict[str, Any]) -> list[dict[
     try:
         routes = _routes_from(route_path)
         lineup_routes = _routes_from(lineup_path)
-        config, _sources = _load_flywheel_config(root)
+        config, _sources = _load_flywheel_config(root, config_path)
         profile_cfg = _profile_config(config, profile_id, routes)
         _sanitized, raw_routes = _resolve_profile_fallbacks(
             root=root,

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -411,7 +411,11 @@ def _bridge_fallback_route(candidate: dict[str, Any], *, model: str, allow_model
     api_key = str(candidate.get("api_key") or candidate.get("openai_api_key") or "").strip()
     anthropic_url = str(candidate.get("anthropic_base_url") or "").strip()
     openai_url = str(candidate.get("openai_base_url") or candidate.get("base_url") or "").strip()
-    gateway_url = anthropic_url or openai_url
+    protocol = _preferred_transport_for_route(candidate, model)
+    if protocol in {"openai_responses", "openai_chat_completions"}:
+        gateway_url = openai_url
+    else:
+        gateway_url = anthropic_url or openai_url
     if not provider_id or not api_key or not gateway_url:
         return {}
     route = {
@@ -423,7 +427,7 @@ def _bridge_fallback_route(candidate: dict[str, Any], *, model: str, allow_model
         "proxy_url": str(candidate.get("proxy") or "").strip(),
         "no_proxy": str(candidate.get("no_proxy") or "").strip(),
         "model": str(model or candidate.get("model_id") or candidate.get("model") or "").strip(),
-        "protocol": _preferred_transport_for_route(candidate, model),
+        "protocol": protocol,
         "fallback_reason": "flywheel_ordered_fallback",
         "try_next_on": [401, 403, 408, 409, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, "connect_error", "timeout", "invalid_json", "invalid_text"],
     }

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -40,11 +40,18 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "default": "flywheel.worker.default",
             "AI-P0": "flywheel.worker.default",
             "AI-P1": "flywheel.worker.default",
-            "AI-P2": "flywheel.worker.default",
-            "AI-P3": "flywheel.worker.default",
-            "AI-P4": "flywheel.worker.default",
+            "AI-P2": "flywheel.worker.cn-glm",
+            "AI-P3": "flywheel.worker.cn-qwen",
+            "AI-P4": "flywheel.worker.cn-qwen",
         },
-        "fixer": {"default": "flywheel.fixer.default"},
+        "fixer": {
+            "default": "flywheel.fixer.default",
+            "AI-P0": "flywheel.fixer.default",
+            "AI-P1": "flywheel.fixer.default",
+            "AI-P2": "flywheel.fixer.cn-glm",
+            "AI-P3": "flywheel.fixer.cn-qwen",
+            "AI-P4": "flywheel.fixer.cn-qwen",
+        },
         "committee": {
             "default": "opencode-committee",
             "AI-P0": "opencode-committee-heavy",
@@ -59,11 +66,57 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "runtime": "codex",
             "model": "gpt-5.5",
             "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+        },
+        "flywheel.worker.cn-glm": {
+            "runtime": "codex",
+            "model": "glm-5.2",
+            "provider": "direct-zai",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.worker.cn-qwen": {
+            "runtime": "codex",
+            "model": "qwen3.7-max",
+            "provider": "direct-qwen",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
         },
         "flywheel.fixer.default": {
             "runtime": "codex",
             "model": "gpt-5.5",
             "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+        },
+        "flywheel.fixer.cn-glm": {
+            "runtime": "codex",
+            "model": "glm-5.2",
+            "provider": "direct-zai",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.fixer.cn-qwen": {
+            "runtime": "codex",
+            "model": "qwen3.7-max",
+            "provider": "direct-qwen",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
         },
     },
 }
@@ -232,6 +285,8 @@ def _sanitize_route(candidate: dict[str, Any]) -> dict[str, Any]:
         "thinking",
         "reasoning_effort",
         "effort",
+        "fallback_reason",
+        "allow_model_switch",
         # Intentionally omit endpoint URLs/proxy fields from the resolver output.
         # The resolver is safe to paste into tracker/PR comments and never emits keys.
     }
@@ -241,6 +296,180 @@ def _sanitize_route(candidate: dict[str, Any]) -> dict[str, Any]:
         if key in allowed and value not in (None, ""):
             safe[key] = value
     return safe
+
+
+def _merged_route_candidates(
+    routes: dict[str, Any],
+    lineup_routes: dict[str, Any],
+    model: str,
+) -> list[tuple[str, dict[str, Any]]]:
+    entry = routes.get(model)
+    if not isinstance(entry, dict):
+        return []
+    meta_by_provider = _metadata_by_provider(lineup_routes.get(model))
+    candidates: list[tuple[str, dict[str, Any]]] = []
+    for name, candidate in _route_candidates(entry):
+        candidate_provider = str(candidate.get("provider_id") or "").strip()
+        merged = {**meta_by_provider.get(candidate_provider, {}), **candidate}
+        candidates.append((name, merged))
+    return candidates
+
+
+def _find_route_candidate(
+    routes: dict[str, Any],
+    lineup_routes: dict[str, Any],
+    *,
+    model: str,
+    provider: str,
+) -> tuple[str, dict[str, Any]] | None:
+    provider = str(provider or "").strip()
+    if not provider:
+        return None
+    for name, candidate in _merged_route_candidates(routes, lineup_routes, model):
+        if str(candidate.get("provider_id") or "").strip() == provider:
+            return name, candidate
+    return None
+
+
+def _normalize_model_id(value: Any) -> str:
+    return str(value or "").strip().lower().replace("[1m]", "")
+
+
+def _provider_declares_model(provider: dict[str, Any], model: str) -> bool:
+    wanted = _normalize_model_id(model)
+    if not wanted:
+        return False
+    for key in ("models", "fallback_models", "extra_models"):
+        raw = provider.get(key)
+        if isinstance(raw, str):
+            raw = [raw]
+        for item in raw or []:
+            if _normalize_model_id(item) == wanted:
+                return True
+    return False
+
+
+def _provider_route_candidate_from_config(root: Path, *, model: str, provider_id: str) -> dict[str, Any] | None:
+    data = _load_toml(root / "config.toml")
+    providers = data.get("providers") if isinstance(data.get("providers"), list) else []
+    for provider in providers:
+        if not isinstance(provider, dict) or not provider.get("enabled", True):
+            continue
+        if str(provider.get("id") or "").strip() != provider_id:
+            continue
+        if not _provider_declares_model(provider, model):
+            return None
+        openai_base_url = str(
+            provider.get("openai_base_url")
+            or provider.get("default_openai_base_url")
+            or provider.get("base_url")
+            or ""
+        ).strip()
+        anthropic_base_url = str(
+            provider.get("anthropic_base_url")
+            or provider.get("default_anthropic_base_url")
+            or ""
+        ).strip()
+        api_key = str(provider.get("api_key") or provider.get("openai_api_key") or "").strip()
+        if not api_key or not (openai_base_url or anthropic_base_url):
+            return None
+        return {
+            "provider_id": provider_id,
+            "model_id": model,
+            "api_key": api_key,
+            "openai_base_url": openai_base_url,
+            "anthropic_base_url": anthropic_base_url,
+            "protocols": provider.get("protocols") or [],
+            "provider_profile": provider.get("provider_profile") or provider.get("profile") or "",
+            "proxy": provider.get("proxy") or "",
+            "no_proxy": provider.get("no_proxy") or "",
+        }
+    return None
+
+
+def _profile_fallback_providers(profile: dict[str, Any]) -> list[str]:
+    raw = profile.get("fallback_providers") or profile.get("fallback_order") or []
+    if isinstance(raw, str):
+        raw = [item.strip() for item in raw.replace(",", " ").split()]
+    providers: list[str] = []
+    for item in raw or []:
+        provider = str(item or "").strip()
+        if provider and provider not in providers:
+            providers.append(provider)
+    return providers
+
+
+def _profile_fallback_model_map(profile: dict[str, Any]) -> dict[str, str]:
+    raw = profile.get("fallback_model_by_provider") or profile.get("fallback_models_by_provider") or {}
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key).strip(): str(value).strip() for key, value in raw.items() if str(key).strip() and str(value).strip()}
+
+
+def _bridge_fallback_route(candidate: dict[str, Any], *, model: str, allow_model_switch: bool = False) -> dict[str, Any]:
+    provider_id = str(candidate.get("provider_id") or "").strip()
+    api_key = str(candidate.get("api_key") or candidate.get("openai_api_key") or "").strip()
+    anthropic_url = str(candidate.get("anthropic_base_url") or "").strip()
+    openai_url = str(candidate.get("openai_base_url") or candidate.get("base_url") or "").strip()
+    gateway_url = anthropic_url or openai_url
+    if not provider_id or not api_key or not gateway_url:
+        return {}
+    route = {
+        "provider_id": provider_id,
+        "provider_profile": str(candidate.get("provider_profile") or candidate.get("profile") or "").strip(),
+        "gateway_url": gateway_url.rstrip("/"),
+        "gateway_key": api_key,
+        "openai_url": openai_url.rstrip("/"),
+        "proxy_url": str(candidate.get("proxy") or "").strip(),
+        "no_proxy": str(candidate.get("no_proxy") or "").strip(),
+        "model": str(model or candidate.get("model_id") or candidate.get("model") or "").strip(),
+        "protocol": _preferred_transport_for_route(candidate, model),
+        "fallback_reason": "flywheel_ordered_fallback",
+        "try_next_on": [401, 403, 408, 409, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524, "connect_error", "timeout", "invalid_json", "invalid_text"],
+    }
+    if allow_model_switch:
+        route["allow_model_switch"] = True
+    return {key: value for key, value in route.items() if value not in (None, "", [])}
+
+
+def _resolve_profile_fallbacks(
+    *,
+    root: Path,
+    routes: dict[str, Any],
+    lineup_routes: dict[str, Any],
+    profile_cfg: dict[str, Any],
+    model: str,
+    selected_provider: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    providers = _profile_fallback_providers(profile_cfg)
+    model_by_provider = _profile_fallback_model_map(profile_cfg)
+    if not providers:
+        return [], []
+
+    sanitized: list[dict[str, Any]] = []
+    raw_routes: list[dict[str, Any]] = []
+    for provider in providers:
+        fallback_model = model_by_provider.get(provider, model)
+        match = _find_route_candidate(routes, lineup_routes, model=fallback_model, provider=provider)
+        if match is not None:
+            _slot, candidate = match
+        else:
+            candidate = _provider_route_candidate_from_config(root, model=fallback_model, provider_id=provider)
+            if candidate is None:
+                continue
+        candidate_provider = str(candidate.get("provider_id") or "").strip()
+        if candidate_provider == selected_provider and fallback_model == model:
+            continue
+        allow_model_switch = fallback_model != model
+        display_candidate = dict(candidate)
+        display_candidate["fallback_reason"] = "flywheel_ordered_fallback"
+        if allow_model_switch:
+            display_candidate["allow_model_switch"] = True
+        sanitized.append({"slot": f"fallback-{len(sanitized) + 1}", **_sanitize_route(display_candidate)})
+        bridge_route = _bridge_fallback_route(candidate, model=fallback_model, allow_model_switch=allow_model_switch)
+        if bridge_route:
+            raw_routes.append(bridge_route)
+    return sanitized, raw_routes
 
 
 def _profile_value(profile: dict[str, Any], *keys: str) -> Any:
@@ -348,16 +577,12 @@ def resolve_flywheel_profile(
     selected_name = ""
     selected_route: dict[str, Any] = {}
     fallbacks: list[dict[str, Any]] = []
+    native_fallback_routes: list[dict[str, Any]] = []
     route_status = "not_applicable" if runtime == "opencode_profile" else "missing"
 
     if isinstance(entry, dict):
         route_status = "resolved"
-        meta_by_provider = _metadata_by_provider(meta_entry)
-        candidates = []
-        for name, candidate in _route_candidates(entry):
-            candidate_provider = str(candidate.get("provider_id") or "").strip()
-            merged = {**meta_by_provider.get(candidate_provider, {}), **candidate}
-            candidates.append((name, merged))
+        candidates = _merged_route_candidates(routes, lineup_routes, model)
         if not candidates:
             raise FlywheelConfigError(f"model route {model!r} has no usable candidates")
         selected_index = 0
@@ -371,7 +596,15 @@ def resolve_flywheel_profile(
                 raise FlywheelConfigError(f"model route {model!r} has no provider {provider!r}")
             selected_index = matches[0]
         selected_name, selected_route = candidates[selected_index]
-        fallbacks = [
+        ordered_fallbacks, native_fallback_routes = _resolve_profile_fallbacks(
+            root=root,
+            routes=routes,
+            lineup_routes=lineup_routes,
+            profile_cfg=profile_cfg,
+            model=model,
+            selected_provider=str(selected_route.get("provider_id") or provider or "").strip(),
+        )
+        fallbacks = ordered_fallbacks or [
             {"slot": name, **_sanitize_route(item)}
             for index, (name, item) in enumerate(candidates)
             if index != selected_index
@@ -422,6 +655,34 @@ def resolve_flywheel_profile(
         resolved["opencode_profile"] = str(profile_cfg["opencode_profile"])
     # Drop null-ish values while keeping explicit empty provider route objects out.
     return {key: value for key, value in resolved.items() if value not in (None, "")}
+
+
+def _native_fallback_routes_for_resolved(resolved: dict[str, Any]) -> list[dict[str, Any]]:
+    config_meta = resolved.get("config") if isinstance(resolved.get("config"), dict) else {}
+    root = Path(str(config_meta.get("root") or "")).expanduser()
+    route_path = Path(str(config_meta.get("route_path") or "")).expanduser()
+    lineup_path = Path(str(config_meta.get("lineup_path") or "")).expanduser()
+    profile_id = str(resolved.get("profile_id") or "").strip()
+    model = str(resolved.get("model") or "").strip()
+    selected_provider = str(resolved.get("provider_id") or "").strip()
+    if not root or not route_path or not profile_id or not model:
+        return []
+    try:
+        routes = _routes_from(route_path)
+        lineup_routes = _routes_from(lineup_path)
+        config, _sources = _load_flywheel_config(root)
+        profile_cfg = _profile_config(config, profile_id, routes)
+        _sanitized, raw_routes = _resolve_profile_fallbacks(
+            root=root,
+            routes=routes,
+            lineup_routes=lineup_routes,
+            profile_cfg=profile_cfg,
+            model=model,
+            selected_provider=selected_provider,
+        )
+        return raw_routes
+    except Exception:
+        return []
 
 
 def _raw_selected_route(resolved: dict[str, Any]) -> dict[str, Any]:
@@ -627,6 +888,10 @@ def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict
         "thinking_mode": str(resolved.get("thinking_mode") or "auto").strip().lower(),
         "native_fallback": True,
     }
+    native_fallback_routes = _native_fallback_routes_for_resolved(resolved)
+    if native_fallback_routes:
+        runtime["native_fallback_routes"] = native_fallback_routes
+        runtime["native_fallback_max"] = len(native_fallback_routes)
     effort = _launcher_effort(resolved.get("reasoning_effort"))
     if effort:
         runtime["reasoning_effort"] = effort
@@ -642,7 +907,16 @@ def _sanitize_runtime(runtime: dict[str, Any]) -> dict[str, Any]:
     for key, value in (runtime or {}).items():
         if _is_secret_key(str(key)):
             continue
-        if key in {"api_key", "openai_api_key", "openai_base_url", "anthropic_base_url", "base_url", "proxy", "no_proxy"}:
+        if key in {
+            "api_key",
+            "openai_api_key",
+            "openai_base_url",
+            "anthropic_base_url",
+            "base_url",
+            "proxy",
+            "no_proxy",
+            "native_fallback_routes",
+        }:
             continue
         if value not in (None, ""):
             safe[key] = value
@@ -785,23 +1059,28 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
         "no_proxy": runtime.get("no_proxy"),
         **mms_launchers._rescue_bridge_kwargs(),  # noqa: SLF001
     }
+    native_fallback_routes = list(runtime.get("native_fallback_routes") or [])
     if preferred_transport == "anthropic_messages":
         gateway_url = mms_launchers._anthropic_base_url(runtime)  # noqa: SLF001
         if not gateway_url:
             raise FlywheelConfigError("selected Anthropic transport has no anthropic_base_url")
         bridge_factory = mms_launchers.codex_chatcompletions_bridge
         bridge_kwargs["primary_protocol"] = "anthropic_messages"
+        if native_fallback_routes:
+            bridge_kwargs["native_fallback_routes"] = native_fallback_routes
     elif is_gpt or preferred_transport == "openai_responses":
         gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
         if not gateway_url:
             raise FlywheelConfigError("selected OpenAI Responses transport has no openai_base_url")
         bridge_factory = mms_launchers.codex_responses_bridge
-        bridge_kwargs["native_fallback_routes"] = mms_launchers._resolve_codex_responses_fallback_routes(runtime, model)  # noqa: SLF001
+        bridge_kwargs["native_fallback_routes"] = native_fallback_routes or mms_launchers._resolve_codex_responses_fallback_routes(runtime, model)  # noqa: SLF001
     else:
         gateway_url = mms_launchers._openai_base_url(runtime)  # noqa: SLF001
         if not gateway_url:
             raise FlywheelConfigError("selected OpenAI Chat transport has no openai_base_url")
         bridge_factory = mms_launchers.codex_chatcompletions_bridge
+        if native_fallback_routes:
+            bridge_kwargs["native_fallback_routes"] = native_fallback_routes
 
     with bridge_factory(gateway_url, api_key, **bridge_kwargs) as bridge_cfg:
         bridge_base_url = mms_launchers._codex_provider_base_url(bridge_cfg["base_url"])  # noqa: SLF001

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -318,6 +318,65 @@ def test_flywheel_runtime_passes_ordered_native_fallback_routes_without_artifact
     assert "native_fallback_routes" not in serialized
 
 
+def test_flywheel_run_preserves_explicit_config_for_native_fallback_routes(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    artifact_dir = tmp_path / "artifacts"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+    explicit_config = tmp_path / "custom-flywheel.toml"
+    explicit_config.write_text(
+        """
+[lanes.worker]
+"AI-P3" = "flywheel.worker.custom"
+
+[profiles."flywheel.worker.custom"]
+runtime = "codex"
+model = "qwen3.7-max"
+provider = "direct-qwen"
+fallback_providers = ["us-cpa-local-codex"]
+
+[profiles."flywheel.worker.custom".fallback_model_by_provider]
+us-cpa-local-codex = "gpt-5.5"
+""".strip(),
+        encoding="utf-8",
+    )
+    captured = {}
+
+    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        return (
+            0,
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
+            "",
+        )
+
+    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        config_path=str(explicit_config),
+        cwd=str(workdir),
+        artifact_dir=str(artifact_dir),
+        runner_args=["exec", "ship it"],
+    )
+
+    assert result["ok"] is True
+    assert captured["model"] == "qwen3.7-max"
+    assert [item["provider_id"] for item in captured["runtime"]["native_fallback_routes"]] == [
+        "us-cpa-local-codex",
+    ]
+    assert captured["runtime"]["native_fallback_routes"][0]["model"] == "gpt-5.5"
+    artifact = json.loads(Path(result["resolved_route_path"]).read_text(encoding="utf-8"))
+    assert artifact["resolved"]["profile_id"] == "flywheel.worker.custom"
+    assert artifact["resolved"]["config"]["config_path"] == str(explicit_config.resolve())
+    assert "native_fallback_routes" not in json.dumps(artifact, ensure_ascii=False)
+
+
 def test_resolve_worker_profile_from_mms_config(tmp_path):
     root = tmp_path / "mms-next"
     root.mkdir()

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -170,12 +170,14 @@ def _seed_flywheel_tier_routes(root):
                         "provider_id": "us-cpa-local-codex",
                         "model_id": "gpt-5.5",
                         "openai_base_url": "https://cpa.example/v1",
+                        "anthropic_base_url": "https://cpa-anthropic.example/v1",
                         "api_key": "secret-cpa",
                     },
                     {
                         "provider_id": "newapi-company",
                         "model_id": "gpt-5.5",
                         "openai_base_url": "https://company.example/v1",
+                        "anthropic_base_url": "https://company-anthropic.example/v1",
                         "api_key": "secret-company",
                     },
                     {
@@ -310,6 +312,8 @@ def test_flywheel_runtime_passes_ordered_native_fallback_routes_without_artifact
         "gpt-5.5",
         "gpt-5.5",
     ]
+    assert captured["runtime"]["native_fallback_routes"][2]["gateway_url"] == "https://cpa.example/v1"
+    assert captured["runtime"]["native_fallback_routes"][3]["gateway_url"] == "https://company.example/v1"
     assert captured["runtime"]["native_fallback_routes"][2]["allow_model_switch"] is True
     artifact = json.loads(Path(result["resolved_route_path"]).read_text(encoding="utf-8"))
     serialized = json.dumps(artifact, ensure_ascii=False)

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -104,6 +104,109 @@ def _seed_dual_protocol_routes(root):
     _write_json(root / "model-routes.lineup.json", lineup)
 
 
+def _seed_flywheel_tier_routes(root):
+    router = {
+        "version": 1,
+        "routes": {
+            "qwen3.7-max": {
+                "primary": {
+                    "provider_id": "direct-qwen",
+                    "model_id": "qwen3.7-max",
+                    "anthropic_base_url": "https://qwen.example/v1",
+                    "openai_base_url": "https://qwen.example/v1",
+                    "api_key": "secret-qwen",
+                },
+                "fallbacks": [
+                    {
+                        "provider_id": "newapi-personal-tokyo",
+                        "model_id": "qwen3.7-max",
+                        "anthropic_base_url": "https://tokyo.example/v1",
+                        "openai_base_url": "https://tokyo.example/v1",
+                        "api_key": "secret-tokyo",
+                    },
+                    {
+                        "provider_id": "newapi-tencent",
+                        "model_id": "qwen3.7-max",
+                        "anthropic_base_url": "https://tencent.example/v1",
+                        "openai_base_url": "https://tencent.example/v1",
+                        "api_key": "secret-tencent",
+                    },
+                ],
+            },
+            "glm-5.2": {
+                "primary": {
+                    "provider_id": "direct-zai",
+                    "model_id": "glm-5.2",
+                    "anthropic_base_url": "https://glm.example/v1",
+                    "openai_base_url": "https://glm.example/v1",
+                    "api_key": "secret-glm",
+                },
+                "fallbacks": [
+                    {
+                        "provider_id": "newapi-personal-tokyo",
+                        "model_id": "glm-5.2",
+                        "anthropic_base_url": "https://tokyo.example/v1",
+                        "openai_base_url": "https://tokyo.example/v1",
+                        "api_key": "secret-tokyo",
+                    },
+                    {
+                        "provider_id": "newapi-tencent",
+                        "model_id": "glm-5.2",
+                        "anthropic_base_url": "https://tencent.example/v1",
+                        "openai_base_url": "https://tencent.example/v1",
+                        "api_key": "secret-tencent",
+                    },
+                ],
+            },
+            "gpt-5.5": {
+                "primary": {
+                    "provider_id": "uscrsopenai",
+                    "model_id": "gpt-5.5",
+                    "openai_base_url": "https://openai.example/v1",
+                    "api_key": "secret-openai",
+                },
+                "fallbacks": [
+                    {
+                        "provider_id": "us-cpa-local-codex",
+                        "model_id": "gpt-5.5",
+                        "openai_base_url": "https://cpa.example/v1",
+                        "api_key": "secret-cpa",
+                    },
+                    {
+                        "provider_id": "newapi-company",
+                        "model_id": "gpt-5.5",
+                        "openai_base_url": "https://company.example/v1",
+                        "api_key": "secret-company",
+                    },
+                    {
+                        "provider_id": "newapi-tencent",
+                        "model_id": "gpt-5.5",
+                        "openai_base_url": "https://tencent.example/v1",
+                        "api_key": "secret-tencent",
+                    },
+                ],
+            },
+        },
+    }
+    lineup = {"version": 1, "routes": router["routes"]}
+    _write_json(root / "model-routes.json", router)
+    _write_json(root / "model-routes.lineup.json", lineup)
+    (root / "config.toml").write_text(
+        """
+[[providers]]
+id = "newapi-personal-tokyo"
+enabled = true
+api_key = "secret-tokyo"
+openai_base_url = "https://tokyo.example/v1"
+anthropic_base_url = "https://tokyo.example/v1"
+protocols = ["anthropic_messages", "openai_chat_completions"]
+fallback_models = ["gpt-5.5", "qwen3.7-max", "glm-5.2"]
+supported_clis = ["codex"]
+""".strip(),
+        encoding="utf-8",
+    )
+
+
 def _write_qwen_worker_config(root: Path, *, effort: str = "high"):
     (root / "config.toml").write_text(
         """
@@ -119,6 +222,100 @@ thinking_mode = "enable"
 """.strip().format(effort=effort),
         encoding="utf-8",
     )
+
+
+def test_default_worker_and_fixer_tiers_use_domestic_models_and_ordered_fallbacks(tmp_path):
+    root = tmp_path / "mms-next"
+    root.mkdir()
+    _seed_flywheel_tier_routes(root)
+
+    worker_p3 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P3", config_root=str(root))
+    worker_p4 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P4", config_root=str(root))
+    fixer_p4 = mms_flywheel.resolve_flywheel_profile(lane="fixer", priority="AI-P4", config_root=str(root))
+    worker_p2 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P2", config_root=str(root))
+    worker_p0 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P0", config_root=str(root))
+
+    assert worker_p3["profile_id"] == "flywheel.worker.cn-qwen"
+    assert worker_p3["model"] == "qwen3.7-max"
+    assert worker_p3["provider_id"] == "direct-qwen"
+    assert worker_p4["model"] == "qwen3.7-max"
+    assert fixer_p4["profile_id"] == "flywheel.fixer.cn-qwen"
+    assert fixer_p4["model"] == "qwen3.7-max"
+    assert worker_p2["profile_id"] == "flywheel.worker.cn-glm"
+    assert worker_p2["model"] == "glm-5.2"
+    assert [item["provider_id"] for item in worker_p3["fallback_routes"]] == [
+        "newapi-personal-tokyo",
+        "newapi-tencent",
+        "us-cpa-local-codex",
+        "newapi-company",
+    ]
+    assert [item["provider_id"] for item in worker_p0["fallback_routes"]] == [
+        "newapi-personal-tokyo",
+        "newapi-tencent",
+        "us-cpa-local-codex",
+        "newapi-company",
+    ]
+    assert [item["model_id"] for item in worker_p3["fallback_routes"]] == [
+        "qwen3.7-max",
+        "qwen3.7-max",
+        "gpt-5.5",
+        "gpt-5.5",
+    ]
+    assert worker_p3["fallback_routes"][2]["allow_model_switch"] is True
+    serialized = json.dumps(worker_p3, ensure_ascii=False)
+    assert "secret-" not in serialized
+    assert "https://" not in serialized
+
+
+def test_flywheel_runtime_passes_ordered_native_fallback_routes_without_artifact_leak(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    artifact_dir = tmp_path / "artifacts"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+    captured = {}
+
+    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        return (
+            0,
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
+            "",
+        )
+
+    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        artifact_dir=str(artifact_dir),
+        runner_args=["exec", "ship it"],
+    )
+
+    assert result["ok"] is True
+    assert captured["model"] == "qwen3.7-max"
+    assert [item["provider_id"] for item in captured["runtime"]["native_fallback_routes"]] == [
+        "newapi-personal-tokyo",
+        "newapi-tencent",
+        "us-cpa-local-codex",
+        "newapi-company",
+    ]
+    assert [item["model"] for item in captured["runtime"]["native_fallback_routes"]] == [
+        "qwen3.7-max",
+        "qwen3.7-max",
+        "gpt-5.5",
+        "gpt-5.5",
+    ]
+    assert captured["runtime"]["native_fallback_routes"][2]["allow_model_switch"] is True
+    artifact = json.loads(Path(result["resolved_route_path"]).read_text(encoding="utf-8"))
+    serialized = json.dumps(artifact, ensure_ascii=False)
+    assert "secret-" not in serialized
+    assert "gateway_key" not in serialized
+    assert "native_fallback_routes" not in serialized
 
 
 def test_resolve_worker_profile_from_mms_config(tmp_path):
@@ -525,6 +722,9 @@ def test_codex_headless_passes_primary_anthropic_protocol_to_bridge(tmp_path, mo
         "anthropic_base_url": "https://qwen.example/v1",
         "protocols": ["anthropic_messages", "openai_chat_completions"],
         "preferred_transport": "anthropic_messages",
+        "native_fallback_routes": [
+            {"provider_id": "newapi-personal-tokyo", "gateway_url": "https://tokyo.example/v1", "gateway_key": "secret-tokyo"}
+        ],
     }
 
     @contextmanager
@@ -571,6 +771,7 @@ def test_codex_headless_passes_primary_anthropic_protocol_to_bridge(tmp_path, mo
     assert "agent_message" in stdout
     assert captured["gateway_url"] == "https://qwen.example/v1"
     assert captured["kwargs"]["primary_protocol"] == "anthropic_messages"
+    assert captured["kwargs"]["native_fallback_routes"] == runtime["native_fallback_routes"]
 
 
 def test_run_rejects_committee_profile_for_headless_worker_runner(tmp_path):

--- a/tests/test_native_fallback.py
+++ b/tests/test_native_fallback.py
@@ -456,6 +456,117 @@ def test_anthropic_bridge_mixed_protocol_fallback_uses_openai_responses(monkeypa
     assert b"response.created" in handler.wfile.getvalue()
 
 
+def test_anthropic_bridge_chat_fallback_honors_try_next_on(monkeypatch):
+    import mms_bridge
+
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, status_code, body=b"", headers=None, lines=None):
+            self.status_code = status_code
+            self._body = body
+            self.headers = headers or {"content-type": "application/json"}
+            self._lines = lines or []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return self._body
+
+        def iter_lines(self):
+            return iter(self._lines)
+
+    def fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        if len(calls) == 1:
+            return FakeResponse(403, b'{"error":{"message":"primary blocked"}}')
+        if len(calls) == 2:
+            return FakeResponse(503, b'{"error":{"message":"chat unavailable"}}')
+        return FakeResponse(
+            200,
+            headers={"content-type": "text/event-stream"},
+            lines=[
+                'event: response.created',
+                'data: {"type":"response.created","response":{"id":"resp_after_chat"}}',
+                "",
+            ],
+        )
+
+    monkeypatch.setattr(mms_bridge, "httpx", types.SimpleNamespace(stream=fake_stream))
+    monkeypatch.setattr(mms_bridge, "_record_bridge_speed", lambda *args, **kwargs: None)
+
+    handler = mms_bridge._ResponsesProxyHandler.__new__(mms_bridge._ResponsesProxyHandler)
+    handler.headers = {}
+    handler.wfile = io.BytesIO()
+    handler.server = types.SimpleNamespace(
+        provider_id="direct-qwen",
+        provider_profile="",
+        gateway_key="qwen-key",
+        gateway_url="https://qwen.example/v1",
+        speed_scope={},
+        proxy_url="",
+        no_proxy="",
+        reasoning_enabled=True,
+        reasoning_effort="medium",
+        native_fallback_routes=[
+            {
+                "provider_id": "newapi-chat",
+                "provider_profile": "",
+                "gateway_url": "https://chat.example/v1",
+                "gateway_key": "chat-key",
+                "model": "gpt-5.5",
+                "protocol": "openai_chat_completions",
+                "allow_model_switch": True,
+                "try_next_on": [503],
+            },
+            {
+                "provider_id": "us-cpa-local-codex",
+                "provider_profile": "openai",
+                "gateway_url": "https://responses.example/v1",
+                "gateway_key": "responses-key",
+                "model": "gpt-5.5",
+                "protocol": "openai_responses",
+                "allow_model_switch": True,
+                "try_next_on": [503],
+            },
+        ],
+    )
+    captured = {"statuses": []}
+    handler.send_response = lambda code: captured["statuses"].append(code)
+    handler.send_header = lambda *args, **kwargs: None
+    handler.end_headers = lambda: None
+
+    handler._do_anthropic_messages_fallback(
+        {"model": "qwen3.7-max", "input": "hi", "stream": True},
+        "qwen3.7-max",
+        "https://qwen.example/v1",
+        "qwen-key",
+        0,
+        route={
+            "provider_id": "direct-qwen",
+            "provider_profile": "",
+            "protocol": "anthropic_messages",
+            "include_native_fallbacks": True,
+            "try_next_on": [403],
+        },
+    )
+
+    assert captured["statuses"] == [200]
+    assert [item[1] for item in calls] == [
+        "https://qwen.example/v1/messages",
+        "https://chat.example/v1/chat/completions",
+        "https://responses.example/v1/responses",
+    ]
+    assert calls[1][2]["json"]["model"] == "gpt-5.5"
+    assert calls[1][2]["headers"]["Authorization"] == "Bearer chat-key"
+    assert calls[2][2]["headers"]["Authorization"] == "Bearer responses-key"
+    assert b"resp_after_chat" in handler.wfile.getvalue()
+
+
 def test_responses_proxy_converts_terminal_403_to_fail_closed(monkeypatch):
     import mms_bridge
 

--- a/tests/test_native_fallback.py
+++ b/tests/test_native_fallback.py
@@ -1,6 +1,12 @@
 import io
 import json
+import sys
 import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
 
 
 def test_resolve_native_fallback_routes_finds_same_vendor_direct():
@@ -565,6 +571,119 @@ def test_anthropic_bridge_chat_fallback_honors_try_next_on(monkeypatch):
     assert calls[1][2]["headers"]["Authorization"] == "Bearer chat-key"
     assert calls[2][2]["headers"]["Authorization"] == "Bearer responses-key"
     assert b"resp_after_chat" in handler.wfile.getvalue()
+
+
+def test_anthropic_bridge_terminal_chat_fallback_retries_messages(monkeypatch):
+    import mms_bridge
+
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, status_code, body=b"", headers=None, lines=None):
+            self.status_code = status_code
+            self._body = body
+            self.headers = headers or {"content-type": "application/json"}
+            self._lines = lines or []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return self._body
+
+        def iter_lines(self):
+            return iter(self._lines)
+
+    def fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        if len(calls) == 1:
+            return FakeResponse(403, b'{"error":{"message":"primary blocked"}}')
+        if len(calls) == 2:
+            return FakeResponse(
+                400,
+                b'{"error":{"message":"prompt-cache sensitive route requires /v1/messages instead of /v1/chat/completions"}}',
+            )
+        return FakeResponse(
+            200,
+            headers={"content-type": "text/event-stream"},
+            lines=[
+                "event: message_start",
+                'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"gpt-5.5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}',
+                "",
+                "event: content_block_start",
+                'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+                "",
+                "event: content_block_delta",
+                'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"resp_messages_retry"}}',
+                "",
+                "event: content_block_stop",
+                'data: {"type":"content_block_stop","index":0}',
+                "",
+                "event: message_stop",
+                'data: {"type":"message_stop"}',
+                "",
+            ],
+        )
+
+    monkeypatch.setattr(mms_bridge, "httpx", types.SimpleNamespace(stream=fake_stream))
+    monkeypatch.setattr(mms_bridge, "_record_bridge_speed", lambda *args, **kwargs: None)
+
+    handler = mms_bridge._ResponsesProxyHandler.__new__(mms_bridge._ResponsesProxyHandler)
+    handler.headers = {}
+    handler.wfile = io.BytesIO()
+    handler.server = types.SimpleNamespace(
+        provider_id="direct-qwen",
+        provider_profile="",
+        gateway_key="qwen-key",
+        gateway_url="https://qwen.example/v1",
+        speed_scope={},
+        proxy_url="",
+        no_proxy="",
+        reasoning_enabled=True,
+        reasoning_effort="medium",
+        native_fallback_routes=[{
+            "provider_id": "newapi-chat",
+            "provider_profile": "",
+            "gateway_url": "https://chat.example/v1",
+            "gateway_key": "chat-key",
+            "model": "gpt-5.5",
+            "protocol": "openai_chat_completions",
+            "allow_model_switch": True,
+            "try_next_on": [503],
+        }],
+    )
+    captured = {"statuses": []}
+    handler.send_response = lambda code: captured["statuses"].append(code)
+    handler.send_header = lambda *args, **kwargs: None
+    handler.end_headers = lambda: None
+
+    handler._do_anthropic_messages_fallback(
+        {"model": "qwen3.7-max", "input": "hi", "stream": True},
+        "qwen3.7-max",
+        "https://qwen.example/v1",
+        "qwen-key",
+        0,
+        route={
+            "provider_id": "direct-qwen",
+            "provider_profile": "",
+            "protocol": "anthropic_messages",
+            "include_native_fallbacks": True,
+            "try_next_on": [403],
+        },
+    )
+
+    assert captured["statuses"] == [200]
+    assert [item[1] for item in calls] == [
+        "https://qwen.example/v1/messages",
+        "https://chat.example/v1/chat/completions",
+        "https://chat.example/v1/messages",
+    ]
+    assert calls[1][2]["headers"]["Authorization"] == "Bearer chat-key"
+    assert calls[2][2]["headers"]["x-api-key"] == "chat-key"
+    assert b"resp_messages_retry" in handler.wfile.getvalue()
 
 
 def test_responses_proxy_converts_terminal_403_to_fail_closed(monkeypatch):

--- a/tests/test_native_fallback.py
+++ b/tests/test_native_fallback.py
@@ -361,6 +361,101 @@ def test_responses_proxy_retries_native_fallback_on_cloudflare_524(monkeypatch):
     assert b"response.created" in handler.wfile.getvalue()
 
 
+def test_anthropic_bridge_mixed_protocol_fallback_uses_openai_responses(monkeypatch):
+    import mms_bridge
+
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, status_code, body=b"", headers=None, lines=None):
+            self.status_code = status_code
+            self._body = body
+            self.headers = headers or {"content-type": "application/json"}
+            self._lines = lines or []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return self._body
+
+        def iter_lines(self):
+            return iter(self._lines)
+
+    def fake_stream(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        if len(calls) == 1:
+            return FakeResponse(403, b'{"error":{"message":"blocked"}}')
+        return FakeResponse(
+            200,
+            headers={"content-type": "text/event-stream"},
+            lines=[
+                'event: response.created',
+                'data: {"type":"response.created","response":{"id":"resp_gpt"}}',
+                "",
+            ],
+        )
+
+    monkeypatch.setattr(mms_bridge, "httpx", types.SimpleNamespace(stream=fake_stream))
+    monkeypatch.setattr(mms_bridge, "_record_bridge_speed", lambda *args, **kwargs: None)
+
+    handler = mms_bridge._ResponsesProxyHandler.__new__(mms_bridge._ResponsesProxyHandler)
+    handler.headers = {}
+    handler.wfile = io.BytesIO()
+    handler.server = types.SimpleNamespace(
+        provider_id="direct-qwen",
+        provider_profile="",
+        gateway_key="qwen-key",
+        gateway_url="https://qwen.example/v1",
+        speed_scope={},
+        proxy_url="",
+        no_proxy="",
+        reasoning_enabled=True,
+        reasoning_effort="medium",
+        native_fallback_routes=[{
+            "provider_id": "us-cpa-local-codex",
+            "provider_profile": "openai",
+            "gateway_url": "https://cpa.example/v1",
+            "gateway_key": "gpt-key",
+            "model": "gpt-5.5",
+            "protocol": "openai_responses",
+            "allow_model_switch": True,
+            "try_next_on": [403],
+        }],
+    )
+    captured = {"statuses": []}
+    handler.send_response = lambda code: captured["statuses"].append(code)
+    handler.send_header = lambda *args, **kwargs: None
+    handler.end_headers = lambda: None
+
+    handler._do_anthropic_messages_fallback(
+        {"model": "qwen3.7-max", "input": "hi", "stream": True},
+        "qwen3.7-max",
+        "https://qwen.example/v1",
+        "qwen-key",
+        0,
+        route={
+            "provider_id": "direct-qwen",
+            "provider_profile": "",
+            "protocol": "anthropic_messages",
+            "include_native_fallbacks": True,
+            "try_next_on": [403],
+        },
+    )
+
+    assert captured["statuses"] == [200]
+    assert [item[1] for item in calls] == [
+        "https://qwen.example/v1/messages",
+        "https://cpa.example/v1/responses",
+    ]
+    assert calls[1][2]["json"]["model"] == "gpt-5.5"
+    assert calls[1][2]["headers"]["Authorization"] == "Bearer gpt-key"
+    assert b"response.created" in handler.wfile.getvalue()
+
+
 def test_responses_proxy_converts_terminal_403_to_fail_closed(monkeypatch):
     import mms_bridge
 


### PR DESCRIPTION
## 变更

- 将 Flywheel worker/fixer 默认 tier lane 对齐到：
  - `AI-P0` / `AI-P1` -> `gpt-5.5`
  - `AI-P2` -> `glm-5.2` direct
  - `AI-P3` / `AI-P4` -> `qwen3.7-max` direct
- 固定 GPT fallback 顺序为 `newapi-personal-tokyo -> newapi-tencent -> us-cpa-local-codex -> newapi-company`。
- 为 GLM/Qwen lane 增加 ordered native fallback：先同模型 `tokyo/tencent`，再允许切到 `gpt-5.5` 的 `cpa/company`。
- 将 MMS resolver 产出的 native fallback routes 传入 Codex bridge，让实际执行和 `mmf flywheel resolve` 展示一致。
- 保持公开 artifacts sanitized：不写 `api_key`、endpoint URL、`gateway_key` 或 raw native routes。

## 边界

- 触及 protected surface：`mms_bridge.py`、`mms_flywheel.py`。
- 不改变 TUI/provider/account 默认选择流程。
- 不引入 global OAuth fallback；fallback routes 只来自 MMS route/config 解析并在 runtime 内存中使用。
- 不自行 merge；等待 committee/human gate。

## 验证

- `python3 -m py_compile mms_flywheel.py mms_bridge.py mms_launchers.py`
- `pytest -q tests/test_mms_flywheel.py tests/test_native_fallback.py tests/test_gateway_bridge_model_override.py` -> 46 passed
- `python3 scripts/regression_fresh_user_gate.py --quick` -> 64 passed, PASS
- `git diff --check`
- Real `mmf flywheel resolve` matrix against `~/.config/mms-next` routes verified P0-P4 worker/fixer model and fallback ordering.
- `mmf flywheel run --lane worker --priority AI-P4 --dry-run --json` verified Qwen direct route and sanitized artifacts.

Refs CtriXin/flywheel#17
