### PR TITLE
feat: add StepFun effort profile

### DIFF
--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -102,6 +102,94 @@
         }
       }
     },
+    "stepfun": {
+      "label": "StepFun",
+      "match": {
+        "provider_id_contains": [
+          "stepfun"
+        ],
+        "base_url_contains": [
+          "api.stepfun.com"
+        ],
+        "model_prefixes": [
+          "step-3.7-flash",
+          "step-router-v1"
+        ],
+        "require_model_prefix": true
+      },
+      "references": [
+        "https://platform.stepfun.com/docs/zh/guides/models/step-3.7-flash",
+        "https://platform.stepfun.com/docs/zh/guides/models/step-3.7-flash-quickstart",
+        "https://platform.stepfun.com/docs/zh/step-plan/integrations/reasoning-api"
+      ],
+      "endpoints": {
+        "openai_base_url": "https://api.stepfun.com/v1",
+        "anthropic_base_url": "https://api.stepfun.com",
+        "step_plan_openai_base_url": "https://api.stepfun.com/step_plan/v1",
+        "step_plan_anthropic_base_url": "https://api.stepfun.com/step_plan"
+      },
+      "auth_headers": {
+        "openai_chat": [
+          "authorization_bearer"
+        ],
+        "anthropic_messages": [
+          "authorization_bearer"
+        ]
+      },
+      "thinking": {
+        "supported": true,
+        "ui": "thinking_and_effort",
+        "default_enabled": true,
+        "roundtrip": "reasoning_effort"
+      },
+      "effort": {
+        "openai_chat": {
+          "path": "reasoning_effort",
+          "default": "medium",
+          "allowed": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "map": {
+            "xhigh": "high"
+          }
+        },
+        "anthropic_messages": {
+          "path": "output_config.effort",
+          "default": "medium",
+          "allowed": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "map": {
+            "xhigh": "high"
+          }
+        }
+      },
+      "context_windows": {
+        "step-3.7-flash": 262144
+      },
+      "api_formats": {
+        "openai_chat": {
+          "base_url": "https://api.stepfun.com/v1",
+          "request_path": "/chat/completions"
+        },
+        "anthropic_messages": {
+          "base_url": "https://api.stepfun.com",
+          "request_path": "/v1/messages"
+        },
+        "step_plan_openai_chat": {
+          "base_url": "https://api.stepfun.com/step_plan/v1",
+          "request_path": "/chat/completions"
+        },
+        "step_plan_anthropic_messages": {
+          "base_url": "https://api.stepfun.com/step_plan",
+          "request_path": "/v1/messages"
+        }
+      }
+    },
     "dashscope-openai": {
       "label": "Alibaba DashScope OpenAI-compatible",
       "match": {

--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -179,14 +179,6 @@
         "anthropic_messages": {
           "base_url": "https://api.stepfun.com",
           "request_path": "/v1/messages"
-        },
-        "step_plan_openai_chat": {
-          "base_url": "https://api.stepfun.com/step_plan/v1",
-          "request_path": "/chat/completions"
-        },
-        "step_plan_anthropic_messages": {
-          "base_url": "https://api.stepfun.com/step_plan",
-          "request_path": "/v1/messages"
         }
       }
     },

--- a/docs/PROVIDER_PROFILES.md
+++ b/docs/PROVIDER_PROFILES.md
@@ -57,6 +57,7 @@ Keep this policy route-scoped. The built-in `cpa-antigravity-gemini` profile car
 | Xiaomi MiMo | `https://api.xiaomimimo.com/v1` + `/chat/completions` | `https://api.xiaomimimo.com/anthropic` + `/v1/messages` | `thinking.type` enabled/disabled; OpenAI format aliases output cap to `max_completion_tokens`; no GPT-style effort tier recorded |
 | MiniMax | `https://api.minimaxi.com/v1` + `/chat/completions` | `https://api.minimaxi.com/anthropic` + `/v1/messages` | OpenAI format can use `reasoning_split`; Anthropic format uses thinking blocks |
 | DeepSeek | `https://api.deepseek.com` + `/chat/completions` | `https://api.deepseek.com/anthropic` + `/v1/messages` | OpenAI `reasoning_effort` and Anthropic `output_config.effort`, currently `high`/`max` |
+| StepFun | `https://api.stepfun.com/v1` + `/chat/completions`; Step Plan uses `https://api.stepfun.com/step_plan/v1` | `https://api.stepfun.com` + `/v1/messages`; Step Plan uses `https://api.stepfun.com/step_plan` | OpenAI `reasoning_effort` and Anthropic `output_config.effort`, currently `low`/`medium`/`high` |
 | Kimi Code | `https://api.kimi.com/coding/v1` + `/chat/completions` | `https://api.kimi.com/coding/` + `/v1/messages` | `thinking.type` enabled/disabled; split assistant `tool_use` history must preserve both thinking blocks and `reasoning_content`; preserve normal client headers |
 | GLM / Z.ai | `https://api.z.ai/api/paas/v4/` + `/chat/completions` | `https://api.z.ai/api/anthropic` + `/v1/messages` | `thinking.type` enabled/disabled |
 
@@ -95,6 +96,9 @@ documented 1048576 context / 131072 output limits for `mimo-v2.5-pro` and
 - DeepSeek pricing / context lengths: https://api-docs.deepseek.com/quick_start/pricing/
 - DeepSeek Claude Code integration: https://api-docs.deepseek.com/quick_start/agent_integrations/claude_code
 - DeepSeek Anthropic API: https://api-docs.deepseek.com/guides/anthropic_api
+- StepFun Step 3.7 Flash: https://platform.stepfun.com/docs/zh/guides/models/step-3.7-flash
+- StepFun Step 3.7 Flash quickstart: https://platform.stepfun.com/docs/zh/guides/models/step-3.7-flash-quickstart
+- StepFun Step Plan reasoning API: https://platform.stepfun.com/docs/zh/step-plan/integrations/reasoning-api
 - Kimi Code docs: https://www.kimi.com/code/docs/en/
 - Kimi Code third-party agents: https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html
 - Kimi K2.7 Code quickstart: https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart

--- a/mms_capability_resolver.py
+++ b/mms_capability_resolver.py
@@ -211,6 +211,7 @@ def resolve_model_capabilities(
     provider_id: str = "",
     base_url: str = "",
     profile_id: str = "",
+    protocol: str = "",
     manual_override: Mapping[str, Any] | None = None,
     approved_facts: Mapping[str, Any] | None = None,
     approved_facts_path: str | Path | None = None,
@@ -239,6 +240,7 @@ def resolve_model_capabilities(
         provider_id=provider_id,
         base_url=base_url,
         profile_id=profile_id,
+        protocol=protocol,
         provider_profiles=provider_profiles,
     )
     _apply_source(result, profile_caps, "provider_profile")
@@ -636,7 +638,8 @@ def _provider_profile_capabilities(
     provider_id: str,
     base_url: str,
     profile_id: str,
-    provider_profiles: Mapping[str, Any] | None,
+    protocol: str = "",
+    provider_profiles: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     resolved_profile_id, profile = _resolve_profile(
         model_name=model_name,
@@ -644,6 +647,7 @@ def _provider_profile_capabilities(
         provider_id=provider_id,
         base_url=base_url,
         profile_id=profile_id,
+        protocol=protocol,
         provider_profiles=provider_profiles,
     )
     if not profile:
@@ -663,7 +667,7 @@ def _provider_profile_capabilities(
     if isinstance(thinking.get("supported"), bool):
         caps["supports_thinking"] = bool(thinking["supported"])
 
-    control = _thinking_control_from_profile(profile, model_name)
+    control = _thinking_control_from_profile(profile, model_name, protocol=protocol)
     if control:
         caps["thinking_control"] = control
 
@@ -695,7 +699,8 @@ def _resolve_profile(
     provider_id: str,
     base_url: str,
     profile_id: str,
-    provider_profiles: Mapping[str, Any] | None,
+    protocol: str = "",
+    provider_profiles: Mapping[str, Any] | None = None,
 ) -> tuple[str, dict[str, Any]]:
     if provider_profiles is None:
         return resolve_provider_profile(
@@ -704,6 +709,7 @@ def _resolve_profile(
             base_url=base_url,
             model_name=model_name,
             profile_id=profile_id,
+            protocol=protocol,
         )
     payload = dict(provider_profiles)
     profiles = payload.get("profiles") if isinstance(payload.get("profiles"), Mapping) else payload
@@ -816,7 +822,22 @@ def _longest_prefix_int(values: Mapping[str, Any], model_name: str) -> int | Non
     return best_value
 
 
-def _thinking_control_from_profile(profile: Mapping[str, Any], model_name: str) -> dict[str, Any]:
+def _profile_protocol_configs(section: Mapping[str, Any], protocol: str) -> list[Mapping[str, Any]]:
+    if not isinstance(section, Mapping):
+        return []
+    requested = _normalize_protocol_token(protocol)
+    if requested:
+        matches = [
+            config
+            for key, config in section.items()
+            if _normalize_protocol_token(key) == requested and isinstance(config, Mapping)
+        ]
+        if matches:
+            return matches
+    return [config for config in section.values() if isinstance(config, Mapping)]
+
+
+def _thinking_control_from_profile(profile: Mapping[str, Any], model_name: str, *, protocol: str = "") -> dict[str, Any]:
     thinking = _effective_section(profile, "thinking", model_name)
     if thinking.get("supported") is False:
         return {"supported": False, "control_type": "none", "path": ""}
@@ -824,9 +845,7 @@ def _thinking_control_from_profile(profile: Mapping[str, Any], model_name: str) 
     configs_by_path: dict[str, dict[str, Any]] = {}
     for section_name in ("effort", "budget"):
         section = _effective_section(profile, section_name, model_name)
-        for config in section.values():
-            if not isinstance(config, Mapping):
-                continue
+        for config in _profile_protocol_configs(section, protocol):
             path = _clean(config.get("path"))
             if path:
                 configs_by_path.setdefault(path, dict(config))
@@ -882,6 +901,7 @@ def _select_thinking_path(paths: list[str]) -> str:
         "thinkingConfig.thinkingBudget",
         "thinking.type",
         "reasoning.effort",
+        "reasoning_effort",
         "output_config.effort",
         "thinking_budget",
     )

--- a/mms_opencode_config.py
+++ b/mms_opencode_config.py
@@ -388,7 +388,7 @@ def _opencode_model_key(model_name):
     return normalized
 
 
-def opencode_model_capabilities(runtime, model_name):
+def opencode_model_capabilities(runtime, model_name, *, protocol=""):
     runtime = runtime if isinstance(runtime, dict) else {}
     caps_map = runtime.get("model_capabilities")
     target = _opencode_model_key(model_name)
@@ -410,6 +410,7 @@ def opencode_model_capabilities(runtime, model_name):
                 or ""
             ),
             profile_id=str(runtime.get("profile") or runtime.get("provider_profile") or ""),
+            protocol=_opencode_profile_protocol(protocol) if protocol else "",
         )
     except (ImportError, KeyError, TypeError, ValueError):
         return {}
@@ -596,8 +597,8 @@ def _opencode_control_path_is_request_option(path):
     }
 
 
-def _opencode_options_from_capabilities(runtime, model_name, *, thinking_enabled=None, effort=""):
-    caps = opencode_model_capabilities(runtime, model_name)
+def _opencode_options_from_capabilities(runtime, model_name, *, protocol="", thinking_enabled=None, effort=""):
+    caps = opencode_model_capabilities(runtime, model_name, protocol=protocol)
     if not _opencode_capability_source_allowed(caps, "thinking_control"):
         return {}
     control = caps.get("thinking_control") if isinstance(caps.get("thinking_control"), dict) else {}
@@ -626,7 +627,7 @@ def opencode_model_request_options(
 ):
     """Build OpenCode model options from MMS capability/provider-profile data."""
     runtime = runtime if isinstance(runtime, dict) else {}
-    caps = opencode_model_capabilities(runtime, model_name)
+    caps = opencode_model_capabilities(runtime, model_name, protocol=protocol)
     if thinking_enabled is None:
         thinking_enabled = _opencode_runtime_thinking_enabled(runtime)
     effort = str(reasoning_effort or _opencode_runtime_effort(runtime, model_name, caps)).strip().lower()
@@ -656,6 +657,7 @@ def opencode_model_request_options(
     capability_options = _opencode_options_from_capabilities(
         runtime,
         model_name,
+        protocol=protocol,
         thinking_enabled=thinking_enabled,
         effort=effort,
     )
@@ -670,7 +672,7 @@ def _opencode_effort_variant_values(runtime, model_name, *, provider_id="", base
         if raw and raw != "auto" and raw not in values:
             values.append(raw)
 
-    caps = opencode_model_capabilities(runtime, model_name)
+    caps = opencode_model_capabilities(runtime, model_name, protocol=protocol)
     control = caps.get("thinking_control") if isinstance(caps.get("thinking_control"), dict) else {}
     path = str(control.get("path") or "").strip()
     if _opencode_capability_source_allowed(caps, "thinking_control") and _opencode_control_path_is_request_option(path):

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -4818,6 +4818,50 @@ def test_config_web_mmf_official_overrides_use_provider_profiles(tmp_path):
     assert minimax["thinking_control"]["path"] == "thinking.type"
 
 
+def test_config_web_mmf_official_overrides_support_stepfun_effort(tmp_path):
+    payload = {
+        "provider": {
+            "id": "stepfun",
+            "openai_base_url": "https://api.stepfun.com/v1",
+            "models": [
+                {"id": "step-3.7-flash", "visible": True},
+                {"id": "step-router-v1", "visible": True},
+            ],
+        },
+        "fields": [
+            "context_window_tokens",
+            "reasoning",
+            "thinking",
+            "thinking_control",
+            "reasoning_effort",
+        ],
+        "refresh_sources": False,
+        "mmf_official_overrides": True,
+    }
+
+    result = mms_config_web.refresh_model_capability_truth(
+        {"providers": []},
+        payload,
+        config_path=str(tmp_path / "config.toml"),
+    )
+
+    assert result["ok"] is True
+    assert result["matched_model_count"] == 2
+    step_flash = result["model_capabilities"]["step-3.7-flash"]
+    assert step_flash["context_window_tokens"] == 262_144
+    assert step_flash["reasoning"] is True
+    assert step_flash["thinking"] is True
+    assert step_flash["thinking_control"]["path"] == "output_config.effort"
+    assert step_flash["thinking_control"]["allowed"] == ["low", "medium", "high"]
+    assert step_flash["reasoning_effort"] == "medium"
+
+    step_router = result["model_capabilities"]["step-router-v1"]
+    assert "context_window_tokens" not in step_router
+    assert step_router["reasoning"] is True
+    assert step_router["thinking"] is True
+    assert step_router["reasoning_effort"] == "medium"
+
+
 def test_config_web_mmf_official_overrides_refreshes_provider_profile_cache(monkeypatch, tmp_path):
     import mms_provider_profiles
 

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -4851,7 +4851,7 @@ def test_config_web_mmf_official_overrides_support_stepfun_effort(tmp_path):
     assert step_flash["context_window_tokens"] == 262_144
     assert step_flash["reasoning"] is True
     assert step_flash["thinking"] is True
-    assert step_flash["thinking_control"]["path"] == "output_config.effort"
+    assert step_flash["thinking_control"]["path"] == "reasoning_effort"
     assert step_flash["thinking_control"]["allowed"] == ["low", "medium", "high"]
     assert step_flash["reasoning_effort"] == "medium"
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -356,6 +356,33 @@ def test_opencode_model_config_maps_profile_thinking_and_effort(monkeypatch):
     assert model_config["variants"]["xhigh"]["reasoningEffort"] == "max"
 
 
+def test_opencode_stepfun_openai_effort_does_not_emit_output_config():
+    import mms_launchers
+
+    payload = mms_launchers._build_opencode_config_payload(
+        _runtime(
+            id="stepfun",
+            name="StepFun",
+            openai_base_url="https://api.stepfun.com/v1",
+            models=["step-3.7-flash"],
+            reasoning_effort="xhigh",
+            thinking_mode="enable",
+            opencode_lite_agents=False,
+        ),
+        "step-3.7-flash",
+    )
+    model_config = payload["provider"]["mms"]["models"]["step-3.7-flash"]
+
+    assert model_config["options"] == {"reasoningEffort": "high"}
+    assert "output_config" not in model_config["options"]
+    assert model_config["variants"]["low"] == {"reasoningEffort": "low"}
+    assert model_config["variants"]["medium"] == {"reasoningEffort": "medium"}
+    assert model_config["variants"]["high"] == {"reasoningEffort": "high"}
+    assert model_config["variants"]["xhigh"] == {"reasoningEffort": "high"}
+    for options in model_config["variants"].values():
+        assert "output_config" not in options
+
+
 def test_opencode_model_config_does_not_turn_non_request_effort_into_variant(monkeypatch):
     import mms_provider_profiles
     import mms_launchers

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -177,6 +177,84 @@ def test_deepseek_effort_maps_xhigh_to_max_and_disables_cleanly(monkeypatch, tmp
     assert payload["output_config"] == {"format": "markdown"}
 
 
+def test_stepfun_effort_profile_patches_openai_and_messages(monkeypatch, tmp_path):
+    profiles = _profiles(monkeypatch, tmp_path)
+    chat_payload = {"model": "step-3.7-flash", "messages": []}
+
+    profile_id = profiles.apply_profile_body_patches(
+        chat_payload,
+        protocol="openai_chat",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/v1",
+        model_name="step-3.7-flash",
+        thinking_enabled=True,
+        reasoning_effort="xhigh",
+    )
+
+    assert profile_id == "stepfun"
+    assert chat_payload["reasoning_effort"] == "high"
+
+    messages_payload = {
+        "model": "step-router-v1",
+        "messages": [],
+        "output_config": {"format": "markdown"},
+    }
+    profile_id = profiles.apply_profile_body_patches(
+        messages_payload,
+        protocol="anthropic_messages",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/step_plan",
+        model_name="step-router-v1",
+        thinking_enabled=True,
+        reasoning_effort="medium",
+    )
+
+    assert profile_id == "stepfun"
+    assert messages_payload["output_config"] == {
+        "format": "markdown",
+        "effort": "medium",
+    }
+
+    profiles.apply_profile_body_patches(
+        messages_payload,
+        protocol="anthropic_messages",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/step_plan",
+        model_name="step-router-v1",
+        thinking_enabled=False,
+        reasoning_effort="high",
+    )
+    assert messages_payload["output_config"] == {"format": "markdown"}
+
+    caps = profiles.profile_thinking_capabilities(
+        "step-3.7-flash",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/v1",
+    )
+    assert caps["profile"] == "stepfun"
+    assert caps["thinking_supported"] is True
+    assert caps["effort_supported"] is True
+    assert set(caps["effort_allowed"]) == {"low", "medium", "high"}
+    assert caps["effort_default"] == "medium"
+    assert caps["effort_map"]["xhigh"] == "high"
+    assert profiles.profile_context_window(
+        "step-3.7-flash",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/v1",
+    ) == 262_144
+
+    headers = {"Content-Type": "application/json"}
+    profiles.apply_profile_auth_headers(
+        headers,
+        protocol="anthropic_messages",
+        api_key="sk-step",
+        provider_id="stepfun",
+        base_url="https://api.stepfun.com/step_plan",
+        model_name="step-router-v1",
+    )
+    assert headers["Authorization"] == "Bearer sk-step"
+
+
 def test_profile_context_window_and_references(monkeypatch, tmp_path):
     profiles = _profiles(monkeypatch, tmp_path)
 


### PR DESCRIPTION
## Summary

- Add a built-in StepFun provider profile for `step-3.7-flash` and `step-router-v1` effort controls.
- Wire protocol-sensitive capability resolution so OpenCode OpenAI routes emit `reasoningEffort` only, while Anthropic Messages routes keep `output_config.effort`.
- Add WebUI official-overrides and OpenCode request-options regressions.

## Trace

- MMS-MISSION: `MMS-20260620-stepfun-effort-769e9631-7c31e4af`
- Review status: local fixed and verified complete
- Review Hub rereview: `3/3 APPROVE`, `reviewers_incomplete=0`
- Request root: `.mission/review-dispatch/opencode/20260620T013932Z-rereview-stepfun-effort-openai-leak-fix`

## Validation

- `python3 -m py_compile mms_capability_resolver.py mms_opencode_config.py`
- `python3 -m json.tool config/provider-profiles.json >/tmp/stepfun-provider-profiles.json`
- `PYTHONPATH=. pytest -q tests/test_opencode_launcher.py::test_opencode_stepfun_openai_effort_does_not_emit_output_config tests/test_config_web.py::test_config_web_mmf_official_overrides_support_stepfun_effort tests/test_provider_profiles.py::test_stepfun_effort_profile_patches_openai_and_messages tests/test_capability_resolver.py tests/test_tui_model_capability_policy.py`

## Notes

- No real `~/.config/mms/**` writes.
- No launcher/default route priority changes.
- After merge, WebUI preview users still need the normal "应用 MMF 官方覆盖" -> "生成保存预览" -> "写入预览 DB + 发布" flow for latest-approved bundle consumption.
