### PR TITLE
fix(opencode): reduce committee startup blank delay

### DIFF
--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -27,6 +27,11 @@ _OPENCODE_INCREMENTAL_SKIP_DIRS = {"log"}
 _BOOL_TRUE_VALUES = {"1", "true", "yes", "on", "enable", "enabled"}
 _BOOL_FALSE_VALUES = {"0", "false", "no", "off", "disable", "disabled"}
 _OPENCODE_SHARED_CACHE_ENV = "MMS_OPENCODE_SHARED_CACHE"
+_OPENCODE_SHARED_CACHE_BYPASS_ENV_KEYS = (
+    "npm_config_cache",
+    "NPM_CONFIG_CACHE",
+    "BUN_INSTALL_CACHE_DIR",
+)
 
 
 def _write_opencode_profile_marker(session_home, profile_slug):
@@ -238,6 +243,7 @@ def _materialize_opencode_shared_cache(env, session_home, cache_root, *, use_rea
 
     npm_cache = cache_root / "npm"
     bun_cache = cache_root / "bun-install-cache"
+    # Profile-scoped MMS cache, not real ~/Library/Caches; used by macOS Bun/OpenTUI lookups.
     darwin_cache = cache_root / "darwin-caches"
     home_cache_shared = [
         _opencode_link_shared_cache_dir(session_home, ".npm", npm_cache),
@@ -250,8 +256,17 @@ def _materialize_opencode_shared_cache(env, session_home, cache_root, *, use_rea
         ("NPM_CONFIG_CACHE", str(npm_cache)),
         ("BUN_INSTALL_CACHE_DIR", str(bun_cache)),
     ):
-        if not str(env.get(key) or "").strip():
-            env[key] = value
+        env[key] = value
+    return env
+
+
+def _disable_opencode_shared_cache(env):
+    env["MMS_OPENCODE_SHARED_CACHE"] = "0"
+    env.pop("MMS_OPENCODE_CACHE_ROOT", None)
+    env.pop("MMS_OPENCODE_XDG_CACHE_SHARED", None)
+    env.pop("MMS_OPENCODE_HOME_CACHE_SHARED", None)
+    for key in _OPENCODE_SHARED_CACHE_BYPASS_ENV_KEYS:
+        env.pop(key, None)
     return env
 
 
@@ -734,10 +749,7 @@ def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_hom
     if _opencode_shared_cache_enabled({}, env):
         _materialize_opencode_shared_cache(env, session_home, cache_root, use_real_home=use_real_home)
     else:
-        env["MMS_OPENCODE_SHARED_CACHE"] = "0"
-        env.pop("MMS_OPENCODE_CACHE_ROOT", None)
-        env.pop("MMS_OPENCODE_XDG_CACHE_SHARED", None)
-        env.pop("MMS_OPENCODE_HOME_CACHE_SHARED", None)
+        _disable_opencode_shared_cache(env)
     if _opencode_isolate_data_enabled(env):
         _write_opencode_isolate_data_marker(session_home)
         env["XDG_DATA_HOME"] = os.path.join(session_home, ".local", "share")

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -239,6 +239,7 @@ def _materialize_opencode_shared_cache(env, session_home, cache_root, *, use_rea
     # With isolated HOME, OpenCode/Bun/npm otherwise rebuild per-session caches.
     if use_real_home:
         env["MMS_OPENCODE_HOME_CACHE_SHARED"] = "0"
+        _clear_opencode_shared_cache_bypass_env(env)
         return env
 
     npm_cache = cache_root / "npm"
@@ -260,14 +261,18 @@ def _materialize_opencode_shared_cache(env, session_home, cache_root, *, use_rea
     return env
 
 
+def _clear_opencode_shared_cache_bypass_env(env):
+    for key in _OPENCODE_SHARED_CACHE_BYPASS_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
+
 def _disable_opencode_shared_cache(env):
     env["MMS_OPENCODE_SHARED_CACHE"] = "0"
     env.pop("MMS_OPENCODE_CACHE_ROOT", None)
     env.pop("MMS_OPENCODE_XDG_CACHE_SHARED", None)
     env.pop("MMS_OPENCODE_HOME_CACHE_SHARED", None)
-    for key in _OPENCODE_SHARED_CACHE_BYPASS_ENV_KEYS:
-        env.pop(key, None)
-    return env
+    return _clear_opencode_shared_cache_bypass_env(env)
 
 
 def _write_opencode_shared_state_marker(state_root, *, migrated, covered_mtime_ns=0):

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -24,6 +24,9 @@ _OPENCODE_SHARED_STATE_MIGRATION_MARKER = ".mms-shared-state-migration-v1"
 _OPENCODE_PROFILE_MARKER = ".mms/opencode-profile"
 _OPENCODE_ISOLATE_DATA_MARKER = ".mms/opencode-isolate-data"
 _OPENCODE_INCREMENTAL_SKIP_DIRS = {"log"}
+_BOOL_TRUE_VALUES = {"1", "true", "yes", "on", "enable", "enabled"}
+_BOOL_FALSE_VALUES = {"0", "false", "no", "off", "disable", "disabled"}
+_OPENCODE_SHARED_CACHE_ENV = "MMS_OPENCODE_SHARED_CACHE"
 
 
 def _write_opencode_profile_marker(session_home, profile_slug):
@@ -51,6 +54,57 @@ def opencode_profile_state_slug(profile_id):
 def _opencode_isolate_data_enabled(env):
     raw = str(env.get("MMS_OPENCODE_ISOLATE_DATA") or os.environ.get("MMS_OPENCODE_ISOLATE_DATA") or "").strip().lower()
     return raw in {"1", "true", "yes", "on"}
+
+
+def _boolish(value, default=False):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    raw = str(value).strip().lower()
+    if raw in _BOOL_TRUE_VALUES:
+        return True
+    if raw in _BOOL_FALSE_VALUES:
+        return False
+    return default
+
+
+def _opencode_external_skills_enabled(runtime, env):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    if "opencode_external_skills" in runtime:
+        return _boolish(runtime.get("opencode_external_skills"), default=False)
+    return _boolish(env.get("MMS_OPENCODE_EXTERNAL_SKILLS"), default=False)
+
+
+def _opencode_real_home_enabled(runtime, env):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    if "opencode_real_home" in runtime:
+        return _boolish(runtime.get("opencode_real_home"), default=False)
+    return _boolish(env.get("MMS_OPENCODE_REAL_HOME"), default=False)
+
+
+def _opencode_shared_cache_enabled(runtime, env):
+    runtime = runtime if isinstance(runtime, dict) else {}
+    if "opencode_shared_cache" in runtime:
+        return _boolish(runtime.get("opencode_shared_cache"), default=True)
+    if _OPENCODE_SHARED_CACHE_ENV in env:
+        return _boolish(env.get(_OPENCODE_SHARED_CACHE_ENV), default=True)
+    if _OPENCODE_SHARED_CACHE_ENV in os.environ:
+        return _boolish(os.environ.get(_OPENCODE_SHARED_CACHE_ENV), default=True)
+    return True
+
+
+def opencode_apply_external_skill_policy(env, runtime):
+    """Keep MMS-managed OpenCode from scanning global Claude/agent skills by default."""
+    if _opencode_external_skills_enabled(runtime, env):
+        env.pop("OPENCODE_DISABLE_EXTERNAL_SKILLS", None)
+        env.pop("OPENCODE_DISABLE_CLAUDE_CODE_SKILLS", None)
+        env["MMS_OPENCODE_EXTERNAL_SKILLS"] = "1"
+        return env
+    env["OPENCODE_DISABLE_EXTERNAL_SKILLS"] = "1"
+    env["OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"] = "1"
+    env["MMS_OPENCODE_EXTERNAL_SKILLS"] = "0"
+    return env
 
 
 def _copy_missing_tree(src, dst):
@@ -133,6 +187,72 @@ def _opencode_legacy_profile_slug_from_session(session_dir):
 
 def _opencode_profile_state_root(real_user_path, profile_slug):
     return Path(real_user_path(".local", "share", "mms-opencode", "state", profile_slug))
+
+
+def _opencode_profile_cache_root(real_user_path, profile_slug):
+    return Path(real_user_path(".local", "share", "mms-opencode", "cache", profile_slug))
+
+
+def _opencode_link_shared_cache_dir(session_home, relative_path, target_dir):
+    link_path = Path(session_home, *Path(relative_path).parts)
+    target_dir = Path(target_dir)
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        if link_path.is_symlink():
+            if link_path.resolve() == target_dir.resolve():
+                return True
+            link_path.unlink()
+        elif link_path.exists():
+            if link_path.is_dir():
+                try:
+                    next(link_path.iterdir())
+                    return False
+                except StopIteration:
+                    link_path.rmdir()
+            else:
+                return False
+        link_path.parent.mkdir(parents=True, exist_ok=True)
+        link_path.symlink_to(target_dir, target_is_directory=True)
+        return True
+    except OSError:
+        return False
+
+
+def _materialize_opencode_shared_cache(env, session_home, cache_root, *, use_real_home):
+    """Share cold-start caches without exposing the real HOME tree."""
+    cache_root = Path(cache_root)
+    cache_root.mkdir(parents=True, exist_ok=True)
+    env[_OPENCODE_SHARED_CACHE_ENV] = "1"
+    env["MMS_OPENCODE_CACHE_ROOT"] = str(cache_root)
+
+    xdg_opencode_cache = cache_root / "xdg-cache" / "opencode"
+    if _opencode_link_shared_cache_dir(session_home, ".cache/opencode", xdg_opencode_cache):
+        env["MMS_OPENCODE_XDG_CACHE_SHARED"] = "1"
+    else:
+        env["MMS_OPENCODE_XDG_CACHE_SHARED"] = "0"
+
+    # With isolated HOME, OpenCode/Bun/npm otherwise rebuild per-session caches.
+    if use_real_home:
+        env["MMS_OPENCODE_HOME_CACHE_SHARED"] = "0"
+        return env
+
+    npm_cache = cache_root / "npm"
+    bun_cache = cache_root / "bun-install-cache"
+    darwin_cache = cache_root / "darwin-caches"
+    home_cache_shared = [
+        _opencode_link_shared_cache_dir(session_home, ".npm", npm_cache),
+        _opencode_link_shared_cache_dir(session_home, ".bun/install/cache", bun_cache),
+        _opencode_link_shared_cache_dir(session_home, "Library/Caches", darwin_cache),
+    ]
+    env["MMS_OPENCODE_HOME_CACHE_SHARED"] = "1" if all(home_cache_shared) else "0"
+    for key, value in (
+        ("npm_config_cache", str(npm_cache)),
+        ("NPM_CONFIG_CACHE", str(npm_cache)),
+        ("BUN_INSTALL_CACHE_DIR", str(bun_cache)),
+    ):
+        if not str(env.get(key) or "").strip():
+            env[key] = value
+    return env
 
 
 def _write_opencode_shared_state_marker(state_root, *, migrated, covered_mtime_ns=0):
@@ -601,14 +721,23 @@ def _migrate_opencode_data_to_shared_state(session_home, *, real_user_path):
 
 
 def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_home_hint, profile_id):
-    """Keep real HOME/config soft; share OpenCode data/state by profile."""
+    """Isolate OpenCode config/home by default while sharing profile data/state."""
     profile_slug = opencode_profile_state_slug(profile_id)
     real_home = real_user_path()
+    use_real_home = _boolish(env.get("MMS_OPENCODE_REAL_HOME"), default=False)
     state_root = _opencode_profile_state_root(real_user_path, profile_slug)
+    cache_root = _opencode_profile_cache_root(real_user_path, profile_slug)
     _write_opencode_profile_marker(session_home, profile_slug)
-    env["HOME"] = real_home
+    env["HOME"] = real_home if use_real_home else session_home
     env["XDG_CONFIG_HOME"] = os.path.join(session_home, ".config")
     env["XDG_CACHE_HOME"] = os.path.join(session_home, ".cache")
+    if _opencode_shared_cache_enabled({}, env):
+        _materialize_opencode_shared_cache(env, session_home, cache_root, use_real_home=use_real_home)
+    else:
+        env["MMS_OPENCODE_SHARED_CACHE"] = "0"
+        env.pop("MMS_OPENCODE_CACHE_ROOT", None)
+        env.pop("MMS_OPENCODE_XDG_CACHE_SHARED", None)
+        env.pop("MMS_OPENCODE_HOME_CACHE_SHARED", None)
     if _opencode_isolate_data_enabled(env):
         _write_opencode_isolate_data_marker(session_home)
         env["XDG_DATA_HOME"] = os.path.join(session_home, ".local", "share")
@@ -627,6 +756,8 @@ def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_hom
     env["MMS_HOME_ISOLATION_MODE"] = "soft"
     env["MMS_SOFT_HOME"] = "1"
     env["MMS_OPENCODE_SOFT_HOME"] = "1"
+    env["MMS_OPENCODE_HOME_ISOLATED"] = "0" if use_real_home else "1"
+    env["MMS_OPENCODE_REAL_HOME"] = "1" if use_real_home else "0"
     env["MMS_OPENCODE_PROFILE"] = profile_slug
     set_session_home_hint(env, session_home)
     return env
@@ -703,7 +834,14 @@ def opencode_gateway_env(
     clear_opencode_config_env(env)
     inject_real_home_hints(env)
     inject_selected_model_name(env, model, model_info=model_info)
+    use_real_home = (
+        _opencode_real_home_enabled(runtime, env)
+        or _opencode_external_skills_enabled(runtime, env)
+    )
+    env["MMS_OPENCODE_REAL_HOME"] = "1" if use_real_home else "0"
+    env[_OPENCODE_SHARED_CACHE_ENV] = "1" if _opencode_shared_cache_enabled(runtime, env) else "0"
     set_opencode_soft_home(env, session_home, profile_id=opencode_profile_id)
+    opencode_apply_external_skill_policy(env, runtime)
     if env.get("MMS_OPENCODE_MIGRATION_FAILED") != "1":
         cleanup_stale_sessions(sessions_dir)
 
@@ -811,6 +949,7 @@ def opencode_provider_export_env(
 
 
 __all__ = [
+    "opencode_apply_external_skill_policy",
     "opencode_export_config_path",
     "opencode_gateway_env",
     "opencode_global_export_env",

--- a/mms_opencode_session.py
+++ b/mms_opencode_session.py
@@ -41,14 +41,16 @@ def opencode_rtk_plugin_path(
     env_bool=opencode_env_bool,
     which=shutil.which,
 ):
+    runtime = runtime if isinstance(runtime, dict) else {}
     disabled_hooks = normalize_session_surface_disabled(
-        (runtime or {}).get("disabled_session_surfaces") if isinstance(runtime, dict) else None
+        runtime.get("disabled_session_surfaces")
     ).get("hooks", set())
     if "opencode-rtk" in disabled_hooks:
         return ""
-    if not runtime_bool(runtime or {}, "opencode_rtk", True):
-        return ""
-    if not env_bool("MMS_OPENCODE_RTK", True):
+    if "opencode_rtk" in runtime:
+        if not runtime_bool(runtime, "opencode_rtk", False):
+            return ""
+    elif not env_bool("MMS_OPENCODE_RTK", False):
         return ""
     if not which("rtk"):
         return ""

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -956,6 +956,9 @@ def test_opencode_gateway_env_can_opt_into_external_skills(monkeypatch, tmp_path
     monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setenv("NPM_CONFIG_CACHE", "/tmp/inherited-npm")
+    monkeypatch.setenv("npm_config_cache", "/tmp/inherited-npm-lower")
+    monkeypatch.setenv("BUN_INSTALL_CACHE_DIR", "/tmp/inherited-bun")
 
     env = mms_launchers._opencode_gateway_env(
         _runtime(opencode_profile="lite_pro_orchestrated", opencode_external_skills=True),
@@ -971,6 +974,9 @@ def test_opencode_gateway_env_can_opt_into_external_skills(monkeypatch, tmp_path
     assert env["MMS_OPENCODE_SHARED_CACHE"] == "1"
     assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
     assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "0"
+    assert "NPM_CONFIG_CACHE" not in env
+    assert "npm_config_cache" not in env
+    assert "BUN_INSTALL_CACHE_DIR" not in env
 
 
 def test_opencode_gateway_env_can_opt_into_real_home_without_external_skills(monkeypatch, tmp_path):
@@ -986,6 +992,9 @@ def test_opencode_gateway_env_can_opt_into_real_home_without_external_skills(mon
     monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setenv("NPM_CONFIG_CACHE", "/tmp/inherited-npm")
+    monkeypatch.setenv("npm_config_cache", "/tmp/inherited-npm-lower")
+    monkeypatch.setenv("BUN_INSTALL_CACHE_DIR", "/tmp/inherited-bun")
 
     env = mms_launchers._opencode_gateway_env(
         _runtime(opencode_profile="lite_pro_orchestrated", opencode_real_home=True),
@@ -1001,6 +1010,9 @@ def test_opencode_gateway_env_can_opt_into_real_home_without_external_skills(mon
     assert env["MMS_OPENCODE_SHARED_CACHE"] == "1"
     assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
     assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "0"
+    assert "NPM_CONFIG_CACHE" not in env
+    assert "npm_config_cache" not in env
+    assert "BUN_INSTALL_CACHE_DIR" not in env
 
 
 def test_opencode_gateway_env_requires_explicit_profile(monkeypatch, tmp_path):

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -865,15 +865,33 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     assert config_path == session_home / ".config" / "opencode" / "opencode.json"
     config_payload = json.loads(config_path.read_text(encoding="utf-8"))
     assert config_payload["provider"]["mms"]["options"]["apiKey"] == "{env:MMS_OPENCODE_API_KEY}"
-    assert env["HOME"] == str(real_home)
+    assert env["HOME"] == str(session_home)
+    assert env["MMS_REAL_HOME"] == str(real_home)
     assert env["XDG_CONFIG_HOME"] == str(session_home / ".config")
     assert env["XDG_CACHE_HOME"] == str(session_home / ".cache")
+    shared_cache = real_home / ".local" / "share" / "mms-opencode" / "cache" / "lite_pro_orchestrated"
+    assert env["MMS_OPENCODE_SHARED_CACHE"] == "1"
+    assert env["MMS_OPENCODE_CACHE_ROOT"] == str(shared_cache)
+    assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
+    assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "1"
+    assert env["NPM_CONFIG_CACHE"] == str(shared_cache / "npm")
+    assert env["BUN_INSTALL_CACHE_DIR"] == str(shared_cache / "bun-install-cache")
+    assert (session_home / ".cache" / "opencode").is_symlink()
+    assert (session_home / ".cache" / "opencode").resolve() == shared_cache / "xdg-cache" / "opencode"
+    assert (session_home / ".npm").is_symlink()
+    assert (session_home / ".npm").resolve() == shared_cache / "npm"
+    assert (session_home / ".bun" / "install" / "cache").is_symlink()
+    assert (session_home / ".bun" / "install" / "cache").resolve() == shared_cache / "bun-install-cache"
+    assert (session_home / "Library" / "Caches").is_symlink()
+    assert (session_home / "Library" / "Caches").resolve() == shared_cache / "darwin-caches"
     shared_state = real_home / ".local" / "share" / "mms-opencode" / "state" / "lite_pro_orchestrated"
     assert env["XDG_DATA_HOME"] == str(shared_state)
     assert env["XDG_STATE_HOME"] == str(shared_state)
     assert env["MMS_SESSION_HOME"] == str(session_home)
     assert env["MMS_HOME_ISOLATION_MODE"] == "soft"
     assert env["MMS_OPENCODE_SOFT_HOME"] == "1"
+    assert env["MMS_OPENCODE_HOME_ISOLATED"] == "1"
+    assert env["MMS_OPENCODE_REAL_HOME"] == "0"
     assert env["MMS_OPENCODE_STATE_SHARED"] == "1"
     assert env["MMS_OPENCODE_PROFILE"] == "lite_pro_orchestrated"
     assert env["MMS_OPENCODE_API_KEY"] == "sk-runtime"
@@ -881,7 +899,98 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     assert env["OPENCODE_CLIENT"] == "mms"
     assert env["OPENCODE_PERMISSION"] == mms_launchers.OPENCODE_BYPASS_PERMISSION_ENV
     assert env["MMS_OPENCODE_BYPASS"] == "1"
+    assert env["OPENCODE_DISABLE_EXTERNAL_SKILLS"] == "1"
+    assert env["OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"] == "1"
+    assert env["MMS_OPENCODE_EXTERNAL_SKILLS"] == "0"
     assert "OPENCODE_CONFIG_CONTENT" not in env
+
+
+def test_opencode_gateway_env_can_disable_shared_cache(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated", opencode_shared_cache=False),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    session_home = Path(env["MMS_SESSION_HOME"])
+    assert env["MMS_OPENCODE_SHARED_CACHE"] == "0"
+    assert "MMS_OPENCODE_CACHE_ROOT" not in env
+    assert not (session_home / ".cache" / "opencode").exists()
+    assert not (session_home / ".npm").exists()
+    assert not (session_home / ".bun" / "install" / "cache").exists()
+    assert not (session_home / "Library" / "Caches").exists()
+
+
+def test_opencode_gateway_env_can_opt_into_external_skills(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated", opencode_external_skills=True),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert "OPENCODE_DISABLE_EXTERNAL_SKILLS" not in env
+    assert "OPENCODE_DISABLE_CLAUDE_CODE_SKILLS" not in env
+    assert env["MMS_OPENCODE_EXTERNAL_SKILLS"] == "1"
+    assert env["HOME"] == str(real_home)
+    assert env["MMS_OPENCODE_HOME_ISOLATED"] == "0"
+    assert env["MMS_OPENCODE_REAL_HOME"] == "1"
+    assert env["MMS_OPENCODE_SHARED_CACHE"] == "1"
+    assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
+    assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "0"
+
+
+def test_opencode_gateway_env_can_opt_into_real_home_without_external_skills(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(mms_launchers, "_real_user_home", lambda: str(real_home))
+    monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_link_shared_dotfiles", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_command_wrappers", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda env, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+
+    env = mms_launchers._opencode_gateway_env(
+        _runtime(opencode_profile="lite_pro_orchestrated", opencode_real_home=True),
+        model_info={"model": "deepseek-chat"},
+    )
+
+    assert env["HOME"] == str(real_home)
+    assert env["OPENCODE_DISABLE_EXTERNAL_SKILLS"] == "1"
+    assert env["OPENCODE_DISABLE_CLAUDE_CODE_SKILLS"] == "1"
+    assert env["MMS_OPENCODE_EXTERNAL_SKILLS"] == "0"
+    assert env["MMS_OPENCODE_HOME_ISOLATED"] == "0"
+    assert env["MMS_OPENCODE_REAL_HOME"] == "1"
+    assert env["MMS_OPENCODE_SHARED_CACHE"] == "1"
+    assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
+    assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "0"
 
 
 def test_opencode_gateway_env_requires_explicit_profile(monkeypatch, tmp_path):

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -853,6 +853,9 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setenv("NPM_CONFIG_CACHE", "/tmp/inherited-npm")
+    monkeypatch.setenv("npm_config_cache", "/tmp/inherited-npm-lower")
+    monkeypatch.setenv("BUN_INSTALL_CACHE_DIR", "/tmp/inherited-bun")
 
     env = mms_launchers._opencode_gateway_env(
         _runtime(opencode_profile="lite_pro_orchestrated"),
@@ -875,6 +878,7 @@ def test_opencode_gateway_env_writes_session_local_config(monkeypatch, tmp_path)
     assert env["MMS_OPENCODE_XDG_CACHE_SHARED"] == "1"
     assert env["MMS_OPENCODE_HOME_CACHE_SHARED"] == "1"
     assert env["NPM_CONFIG_CACHE"] == str(shared_cache / "npm")
+    assert env["npm_config_cache"] == str(shared_cache / "npm")
     assert env["BUN_INSTALL_CACHE_DIR"] == str(shared_cache / "bun-install-cache")
     assert (session_home / ".cache" / "opencode").is_symlink()
     assert (session_home / ".cache" / "opencode").resolve() == shared_cache / "xdg-cache" / "opencode"
@@ -918,6 +922,9 @@ def test_opencode_gateway_env_can_disable_shared_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, *_args, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, *_args, **_kwargs: env)
+    monkeypatch.setenv("NPM_CONFIG_CACHE", "/tmp/inherited-npm")
+    monkeypatch.setenv("npm_config_cache", "/tmp/inherited-npm-lower")
+    monkeypatch.setenv("BUN_INSTALL_CACHE_DIR", "/tmp/inherited-bun")
 
     env = mms_launchers._opencode_gateway_env(
         _runtime(opencode_profile="lite_pro_orchestrated", opencode_shared_cache=False),
@@ -927,6 +934,9 @@ def test_opencode_gateway_env_can_disable_shared_cache(monkeypatch, tmp_path):
     session_home = Path(env["MMS_SESSION_HOME"])
     assert env["MMS_OPENCODE_SHARED_CACHE"] == "0"
     assert "MMS_OPENCODE_CACHE_ROOT" not in env
+    assert "NPM_CONFIG_CACHE" not in env
+    assert "npm_config_cache" not in env
+    assert "BUN_INSTALL_CACHE_DIR" not in env
     assert not (session_home / ".cache" / "opencode").exists()
     assert not (session_home / ".npm").exists()
     assert not (session_home / ".bun" / "install" / "cache").exists()

--- a/tests/test_opencode_session_assets.py
+++ b/tests/test_opencode_session_assets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mms_opencode_session import overlay_opencode_session_assets
+from mms_opencode_session import opencode_rtk_plugin_path, overlay_opencode_session_assets
 
 
 def test_overlay_opencode_session_assets_accepts_managed_dynamic_skill_overlay(tmp_path):
@@ -28,3 +28,56 @@ def test_overlay_opencode_session_assets_accepts_managed_dynamic_skill_overlay(t
     assert "managed-dynamic-skills" in calls
     assert "xmem" not in calls
     assert "opencode-xmem" not in calls
+
+
+def test_opencode_rtk_plugin_path_defaults_off(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "opencode-rtk.ts").write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda _value: {"hooks": set()},
+        runtime_bool=lambda _runtime, _key, default: default,
+        env_bool=lambda _key, default: default,
+        which=lambda _name: "/usr/bin/rtk",
+    )
+
+    assert path == ""
+
+
+def test_opencode_rtk_plugin_path_can_opt_in_by_runtime(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    plugin = hooks_dir / "opencode-rtk.ts"
+    plugin.write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {"opencode_rtk": True},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda _value: {"hooks": set()},
+        runtime_bool=lambda runtime, key, default: bool(runtime.get(key, default)),
+        env_bool=lambda _key, default: default,
+        which=lambda _name: "/usr/bin/rtk",
+    )
+
+    assert path == str(plugin)
+
+
+def test_opencode_rtk_plugin_path_can_opt_in_by_env(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    plugin = hooks_dir / "opencode-rtk.ts"
+    plugin.write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda _value: {"hooks": set()},
+        runtime_bool=lambda _runtime, _key, default: default,
+        env_bool=lambda key, default: True if key == "MMS_OPENCODE_RTK" else default,
+        which=lambda _name: "/usr/bin/rtk",
+    )
+
+    assert path == str(plugin)

--- a/tests/test_opencode_session_assets.py
+++ b/tests/test_opencode_session_assets.py
@@ -81,3 +81,54 @@ def test_opencode_rtk_plugin_path_can_opt_in_by_env(tmp_path):
     )
 
     assert path == str(plugin)
+
+
+def test_opencode_rtk_plugin_path_runtime_disable_overrides_env_opt_in(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "opencode-rtk.ts").write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {"opencode_rtk": False},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda _value: {"hooks": set()},
+        runtime_bool=lambda runtime, key, default: bool(runtime.get(key, default)),
+        env_bool=lambda key, default: True if key == "MMS_OPENCODE_RTK" else default,
+        which=lambda _name: "/usr/bin/rtk",
+    )
+
+    assert path == ""
+
+
+def test_opencode_rtk_plugin_path_disabled_surface_wins_over_runtime_opt_in(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "opencode-rtk.ts").write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {"opencode_rtk": True, "disabled_session_surfaces": {"hooks": {"opencode-rtk"}}},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda value: value,
+        runtime_bool=lambda runtime, key, default: bool(runtime.get(key, default)),
+        env_bool=lambda _key, default: default,
+        which=lambda _name: "/usr/bin/rtk",
+    )
+
+    assert path == ""
+
+
+def test_opencode_rtk_plugin_path_requires_rtk_binary_even_when_enabled(tmp_path):
+    hooks_dir = tmp_path / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "opencode-rtk.ts").write_text("export {}\n", encoding="utf-8")
+
+    path = opencode_rtk_plugin_path(
+        {"opencode_rtk": True},
+        module_file=str(tmp_path / "mms_launchers.py"),
+        normalize_session_surface_disabled=lambda _value: {"hooks": set()},
+        runtime_bool=lambda runtime, key, default: bool(runtime.get(key, default)),
+        env_bool=lambda _key, default: default,
+        which=lambda _name: None,
+    )
+
+    assert path == ""


### PR DESCRIPTION
## What Changed

- Keep OpenCode `HOME` isolated while sharing MMS-owned per-profile cold-start cache surfaces for npm, OpenCode XDG cache, Bun install cache, and Darwin cache lookups.
- Add fail-closed escape hatches so `MMS_OPENCODE_SHARED_CACHE=0` / runtime `opencode_shared_cache=false` clears inherited npm/Bun cache env vars.
- Clear inherited npm/Bun cache env vars on `use_real_home=True` paths.
- Make the OpenCode RTK plugin explicit opt-in (`MMS_OPENCODE_RTK=1` or runtime `opencode_rtk=true`) to avoid per-session `@opencode-ai/plugin` dependency installs.
- Add RTK opt-in precedence tests.

## Why

`committee` OpenCode startup had a several-second blank delay after the HOME-isolation change. The remaining startup tax came from two sources:

- per-session cold npm/Bun/OpenCode cache rebuilds;
- default RTK plugin overlay causing OpenCode to create `package.json`, `package-lock.json`, and a large `node_modules` tree inside every session config dir.

This keeps isolation by default while moving safe caches to MMS-owned profile-scoped paths and making RTK an explicit opt-in instead of a default startup cost.

## Validation

- `python3 -m py_compile mms_opencode_env.py mms_opencode_session.py mms_launchers.py` -> pass
- `PYTHONPATH=. pytest -q tests/test_opencode_session_assets.py tests/test_opencode_launcher.py -k "opencode_rtk or opencode_gateway_env"` -> pass, 20 passed / 105 deselected
- `python3 -m pytest -q tests/test_opencode_launcher.py tests/test_opencode_session_assets.py tests/test_opencode_nsr_overlay.py` -> pass, 129 passed
- live smoke from clean PR branch with stable config root:
  - command: `MMS_CONFIG_ROOT=/Users/xin/.config/mms MMS_LOCAL_UPDATE_SKIP=1 MMS_TTY_TIMING_TIMEOUT=45 MMS_TTY_STOP_ON_PAINT=1 /tmp/mms_tty_timing2.py ./mmf opencode --profile committee --committee-host-model gpt-5.4 --committee-models glm gpt-5.5 minimax`
  - first paint: 4.010s after Enter
  - latest session had no `.config/opencode/plugins`, `node_modules`, `package.json`, or `package-lock.json`

## Trace

MMS-MISSION: mms-20260620-opencode-shared-cache-49b7e3e3
MMS-TARGET: branch issue/opencode-shared-cache-20260620-pr
