### PR TITLE
fix: route flywheel cn tiers through claude

### DIFF
--- a/docs/FLYWHEEL_MMS_CONTRACT.md
+++ b/docs/FLYWHEEL_MMS_CONTRACT.md
@@ -23,8 +23,9 @@ mmf flywheel run --lane worker --priority AI-P3 --cwd <worktree> --artifact-dir 
 ```
 
 `run` resolves the same profile, writes `<run-dir>/resolved-route.json` and
-`<run-dir>/run-result.json`, then launches Codex headlessly through the selected
-MMS route. The command accepts Looper's Codex-shaped tail
+`<run-dir>/run-result.json`, then launches the selected MMS runtime headlessly.
+OpenAI/GPT-family models use Codex CLI; non-GPT Anthropic-compatible worker/fixer
+routes use Claude CLI through MMS' Claude bridge. The command accepts Looper's Codex-shaped tail
 (`exec [--model <ignored>] <prompt>`). MMS owns the actual model/provider
 choice; Looper's `--model` is ignored.
 
@@ -39,6 +40,9 @@ keys, endpoint URLs, or proxy fields. The transport evidence records the
 concrete upstream `request_path` (for example `/v1/messages`) while leaving
 `request_url` blank because MMS provider hosts can be private. The raw key and
 endpoint are used only in-process to launch the selected runtime.
+If the preferred generated route export is sanitized, `run` may read the
+matching legacy secret-bearing route inside the same config root for launch-only
+credentials while keeping artifacts redacted.
 
 The runner also exposes the same evidence in the JSON result and
 `run-result.json`:
@@ -88,7 +92,7 @@ default = "flywheel.fixer.default"
 "AI-P4" = "opencode-committee-fast"
 
 [flywheel.profiles."flywheel.worker.p3"]
-runtime = "codex"
+runtime = "claude"
 model = "qwen3.7-max"
 provider = "direct-qwen"
 reasoning_effort = "high"
@@ -98,8 +102,8 @@ max_context_tokens = 1000000
 
 Supported resolver profile fields:
 
-- `runtime` / `runtime_kind` / `cli`: `codex`, `opencode`, `opencode_profile`, or future runner ids. `mmf flywheel run` currently executes only `codex`; other runtimes are resolver-only until their runner adapters land.
-- `model` / `model_id`: MMS model route key or OpenCode profile id.
+- `runtime` / `runtime_kind` / `cli`: `codex`, `claude`, `opencode`, `opencode_profile`, or future runner ids. `mmf flywheel run` executes `codex` for GPT/OpenAI-family worker/fixer routes and `claude` for non-GPT worker/fixer routes; committee profiles remain resolver-only here.
+- `model` / `model_id` / `model_name`: MMS model route key or OpenCode profile id.
 - `provider` / `provider_id` / `route_provider` / `model_route_provider` / `channel`: optional provider override.
 - `thinking_mode`: `auto`, `enable`, or `disable`.
 - `reasoning_effort`: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`.
@@ -111,6 +115,9 @@ If no Flywheel config exists, the resolver preserves current Flywheel behavior:
 
 - `worker`: `flywheel.worker.default` -> `codex`, `gpt-5.5`, `reasoning_effort=medium`.
 - `fixer`: `flywheel.fixer.default` -> `codex`, `gpt-5.5`, `reasoning_effort=medium`.
+- `worker/fixer AI-P2`: `claude`, `glm-5.2`, `reasoning_effort=medium`.
+- `worker/fixer AI-P3`: `claude`, `qwen3.7-max`, `reasoning_effort=medium`.
+- `worker/fixer AI-P4`: `claude`, `MiniMax-M3`, `reasoning_effort=medium`.
 - `committee`: `AI-P0 -> heavy`, `AI-P1 -> standard`, `AI-P2 -> light`, `AI-P3/P4 -> fast`.
 
 ## Remaining Follow-Up

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -7,6 +7,8 @@ preserving Looper's raw completion-marker output contract.
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+import io
 import json
 import os
 import subprocess
@@ -25,6 +27,16 @@ PRIORITIES = {"AI-P0", "AI-P1", "AI-P2", "AI-P3", "AI-P4"}
 EFFORTS = {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 THINKING_MODES = {"auto", "enable", "disable"}
 SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD")
+SAFE_TOKEN_METADATA_KEYS = {
+    "MAX_CONTEXT_TOKENS",
+    "CONTEXT_TOKENS",
+    "MAX_OUTPUT_TOKENS",
+    "INPUT_TOKENS",
+    "OUTPUT_TOKENS",
+    "CACHE_READ_INPUT_TOKENS",
+    "CACHE_CREATION_INPUT_TOKENS",
+    "CACHED_TOKENS",
+}
 FAKE_RESPONSE_ENV = "MMS_FLYWHEEL_RUN_FAKE_RESPONSE"
 FAKE_JSONL_ENV = "MMS_FLYWHEEL_RUN_FAKE_JSONL"
 RUN_RESULT_SCHEMA = "mms.flywheel_run_result.v1"
@@ -42,7 +54,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "AI-P1": "flywheel.worker.default",
             "AI-P2": "flywheel.worker.cn-glm",
             "AI-P3": "flywheel.worker.cn-qwen",
-            "AI-P4": "flywheel.worker.cn-qwen",
+            "AI-P4": "flywheel.worker.cn-minimax",
         },
         "fixer": {
             "default": "flywheel.fixer.default",
@@ -50,7 +62,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "AI-P1": "flywheel.fixer.default",
             "AI-P2": "flywheel.fixer.cn-glm",
             "AI-P3": "flywheel.fixer.cn-qwen",
-            "AI-P4": "flywheel.fixer.cn-qwen",
+            "AI-P4": "flywheel.fixer.cn-minimax",
         },
         "committee": {
             "default": "opencode-committee",
@@ -69,7 +81,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
         },
         "flywheel.worker.cn-glm": {
-            "runtime": "codex",
+            "runtime": "claude",
             "model": "glm-5.2",
             "provider": "direct-zai",
             "reasoning_effort": "medium",
@@ -80,9 +92,20 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             },
         },
         "flywheel.worker.cn-qwen": {
-            "runtime": "codex",
+            "runtime": "claude",
             "model": "qwen3.7-max",
             "provider": "direct-qwen",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.worker.cn-minimax": {
+            "runtime": "claude",
+            "model": "MiniMax-M3",
+            "provider": "direct-minimax",
             "reasoning_effort": "medium",
             "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
             "fallback_model_by_provider": {
@@ -97,7 +120,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
         },
         "flywheel.fixer.cn-glm": {
-            "runtime": "codex",
+            "runtime": "claude",
             "model": "glm-5.2",
             "provider": "direct-zai",
             "reasoning_effort": "medium",
@@ -108,9 +131,20 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             },
         },
         "flywheel.fixer.cn-qwen": {
-            "runtime": "codex",
+            "runtime": "claude",
             "model": "qwen3.7-max",
             "provider": "direct-qwen",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
+                "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.fixer.cn-minimax": {
+            "runtime": "claude",
+            "model": "MiniMax-M3",
+            "provider": "direct-minimax",
             "reasoning_effort": "medium",
             "fallback_providers": ["newapi-personal-tokyo", "newapi-tencent", "us-cpa-local-codex", "newapi-company"],
             "fallback_model_by_provider": {
@@ -267,6 +301,8 @@ def _metadata_by_provider(entry: Any) -> dict[str, dict[str, Any]]:
 
 def _is_secret_key(key: str) -> bool:
     upper = key.upper()
+    if upper in SAFE_TOKEN_METADATA_KEYS:
+        return False
     return any(marker in upper for marker in SECRET_MARKERS)
 
 
@@ -520,9 +556,9 @@ def _infer_runtime(profile_id: str, model: str) -> str:
     raw = f"{profile_id} {model}".lower()
     if "opencode-committee" in raw:
         return "opencode_profile"
-    if model.lower() in {"gpt-5.5", "gpt-5.4"}:
+    if _is_openai_family_model(model):
         return "codex"
-    return "opencode"
+    return "claude"
 
 
 def _select_profile(config: dict[str, Any], lane: str, priority: str, explicit_profile: str = "") -> str:
@@ -569,7 +605,7 @@ def resolve_flywheel_profile(
 
     profile_id = _select_profile(config, lane, priority, profile)
     profile_cfg = _profile_config(config, profile_id, routes)
-    model = str(_profile_value(profile_cfg, "model", "model_id") or "").strip()
+    model = str(_profile_value(profile_cfg, "model", "model_id", "model_name") or "").strip()
     if not model:
         raise FlywheelConfigError(f"flywheel profile {profile_id!r} has no model")
 
@@ -694,19 +730,67 @@ def _native_fallback_routes_for_resolved(resolved: dict[str, Any]) -> list[dict[
         return []
 
 
+def _route_has_launch_secret(route: dict[str, Any]) -> bool:
+    return bool(str(route.get("api_key") or route.get("openai_api_key") or "").strip())
+
+
+def _merge_launch_secret_route(route: dict[str, Any], secret_route: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(route)
+    for key in (
+        "api_key",
+        "openai_api_key",
+        "openai_base_url",
+        "anthropic_base_url",
+        "base_url",
+        "proxy",
+        "no_proxy",
+        "provider_profile",
+        "profile",
+        "protocols",
+        "model_id",
+    ):
+        value = secret_route.get(key)
+        if value not in (None, "", []):
+            merged[key] = value
+    return merged
+
+
+def _find_raw_route(path: Path, *, model: str, selected_slot: str, provider_id: str) -> dict[str, Any]:
+    routes = _routes_from(path)
+    entry = routes.get(model)
+    provider_id = str(provider_id or "").strip()
+    fallback_by_provider: dict[str, Any] = {}
+    for slot, candidate in _route_candidates(entry):
+        candidate_provider = str(candidate.get("provider_id") or "").strip()
+        if slot == selected_slot:
+            return dict(candidate)
+        if candidate_provider:
+            fallback_by_provider[candidate_provider] = candidate
+    if provider_id and provider_id in fallback_by_provider:
+        return dict(fallback_by_provider[provider_id])
+    return {}
+
+
 def _raw_selected_route(resolved: dict[str, Any]) -> dict[str, Any]:
     config = resolved.get("config") if isinstance(resolved.get("config"), dict) else {}
+    root = Path(str(config.get("root") or "")).expanduser()
     route_path = Path(str(config.get("route_path") or "")).expanduser()
     model = str(resolved.get("model") or "").strip()
+    provider_id = str(resolved.get("provider_id") or "").strip()
     selected = resolved.get("selected_route") if isinstance(resolved.get("selected_route"), dict) else {}
     selected_slot = str(selected.get("slot") or "").strip()
     if not route_path or not model or not selected_slot:
         return {}
-    routes = _routes_from(route_path)
-    entry = routes.get(model)
-    for slot, candidate in _route_candidates(entry):
-        if slot == selected_slot:
-            return dict(candidate)
+    route = _find_raw_route(route_path, model=model, selected_slot=selected_slot, provider_id=provider_id)
+    if _route_has_launch_secret(route):
+        return route
+    legacy_route_path = (root / "model-routes.json").expanduser() if root else Path()
+    if legacy_route_path and legacy_route_path.exists() and legacy_route_path.resolve() != route_path.resolve():
+        secret_route = _find_raw_route(legacy_route_path, model=model, selected_slot=selected_slot, provider_id=provider_id)
+        if _route_has_launch_secret(secret_route):
+            return _merge_launch_secret_route(route, secret_route)
+    if route:
+        return route
     raise FlywheelConfigError(f"selected route slot {selected_slot!r} not found for model {model!r}")
 
 
@@ -897,6 +981,9 @@ def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict
         "thinking_mode": str(resolved.get("thinking_mode") or "auto").strip().lower(),
         "native_fallback": True,
     }
+    context_tokens = _normalize_context(resolved.get("max_context_tokens"))
+    if context_tokens:
+        runtime["max_context_tokens"] = context_tokens
     native_fallback_routes = _native_fallback_routes_for_resolved(resolved)
     if native_fallback_routes:
         runtime["native_fallback_routes"] = native_fallback_routes
@@ -1126,6 +1213,144 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
         return proc.returncode, proc.stdout or "", proc.stderr or ""
 
 
+@contextmanager
+def _quiet_launcher_output():
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+    with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+        yield
+
+
+@contextmanager
+def _pushd(path: Path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _claude_shell_model(model: str, mms_launchers: Any) -> tuple[str, str]:
+    if mms_launchers._is_claude_family_model_name(model):  # noqa: SLF001
+        return model, ""
+    return "claude-sonnet-4-6", model
+
+
+def _claude_print_args(*, cwd: Path, prompt: str, sandbox: str) -> list[str]:
+    args: list[str] = []
+    if sandbox in {"workspace-write", "danger-full-access"}:
+        args.extend(["--add-dir", str(cwd)])
+    if sandbox == "danger-full-access":
+        args.append("--dangerously-skip-permissions")
+    args.extend(["-p", prompt])
+    return args
+
+
+def _run_claude_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd: Path, sandbox: str) -> tuple[int, str, str]:
+    import mms_launchers
+
+    mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
+    mms_launchers._ensure_speed_stats()  # noqa: SLF001 - keep launcher lazy imports initialized.
+    runtime = dict(runtime)
+    if sandbox == "danger-full-access":
+        runtime["bypass"] = True
+    provider_id = str(runtime.get("id") or runtime.get("provider_id") or "").strip()
+    provider_profile = str(runtime.get("profile") or runtime.get("provider_profile") or "")
+    model = str(model or runtime.get("model") or "").strip()
+    if not model:
+        raise FlywheelConfigError("claude runtime requires a model")
+
+    with _pushd(cwd), _quiet_launcher_output():
+        mms_launchers.gateway_health_check(runtime)
+        try:
+            advertised_models = list(mms_launchers._probe_models(runtime, emit_output=False).get("models") or [])  # noqa: SLF001
+        except Exception:
+            advertised_models = [model]
+        speed_scope = mms_launchers.build_provider_speed_scope(runtime)
+        env_model, display_model = _claude_shell_model(model, mms_launchers)
+        anthropic_url, _detect_method = mms_launchers._resolve_anthropic_base_url(runtime, probe_model=model)  # noqa: SLF001
+        configured_anthropic = str(mms_launchers._anthropic_base_url(runtime) or "").strip()  # noqa: SLF001
+        openai_url = str(mms_launchers._openai_base_url(runtime) or "").strip()  # noqa: SLF001
+        bridge_url = str(anthropic_url or configured_anthropic or openai_url or "").strip().rstrip("/")
+        if not bridge_url:
+            raise FlywheelConfigError(f"claude runtime route {provider_id!r} has no usable endpoint")
+        if (anthropic_url or configured_anthropic) and not bridge_url.endswith("/v1"):
+            bridge_url += "/v1"
+
+        thinking_enabled = bool(mms_launchers._runtime_thinking_enabled(runtime))  # noqa: SLF001
+        reasoning_effort = mms_launchers._runtime_reasoning_effort(runtime, default="high")  # noqa: SLF001
+        native_fallback_routes = list(runtime.get("native_fallback_routes") or [])
+        context_window = int(runtime.get("max_context_tokens") or 0)
+        if context_window <= 0:
+            context_window = mms_launchers._effective_context_window(  # noqa: SLF001
+                model,
+                enable_claude_1m=mms_launchers._runtime_supports_claude_1m(runtime),  # noqa: SLF001
+                provider_id=provider_id,
+            )
+        model_capabilities = mms_launchers._runtime_model_capabilities(runtime, model)  # noqa: SLF001
+        vision_sidecar = mms_launchers._runtime_vision_sidecar(runtime)  # noqa: SLF001
+        if mms_launchers._model_capabilities_support_vision(model_capabilities, model) is True:  # noqa: SLF001
+            vision_sidecar = {}
+
+        bridge_kwargs = {
+            "heavy_model": model,
+            "advertised_models": advertised_models,
+            "speed_scope": speed_scope,
+            "route_status_paths": mms_launchers._claude_route_status_paths(),  # noqa: SLF001
+            "provider_id": provider_id,
+            "provider_profile": provider_profile,
+            "openai_url": openai_url or None,
+            "proxy_url": runtime.get("proxy"),
+            "no_proxy": runtime.get("no_proxy"),
+            "strip_upstream_user_agent": "cliproxyapi" in provider_id.lower(),
+            "minimal_claude_header_passthrough": mms_launchers._runtime_is_sensitive_claude_provider(runtime),  # noqa: SLF001
+            "reasoning_enabled": thinking_enabled,
+            "reasoning_effort": reasoning_effort,
+            "native_fallback_routes": native_fallback_routes,
+            "vision_sidecar": vision_sidecar,
+            "model_capabilities": model_capabilities,
+            "context_windows": mms_launchers._context_windows_for_models(  # noqa: SLF001
+                model,
+                enable_claude_1m=mms_launchers._runtime_supports_claude_1m(runtime),  # noqa: SLF001
+                provider_id=provider_id,
+            ),
+            "session_context_window": context_window,
+            **mms_launchers._rescue_bridge_kwargs(),  # noqa: SLF001
+        }
+        with mms_launchers._gateway_claude_bridge_context(bridge_url, runtime["api_key"], **bridge_kwargs) as bridge_cfg:  # noqa: SLF001
+            env = mms_launchers._claude_gateway_env(  # noqa: SLF001
+                runtime,
+                base_url=bridge_cfg["base_url"],
+                auth_token=bridge_cfg["api_key"],
+                heavy_model=env_model,
+                selected_model=env_model,
+                display_model=display_model,
+            )
+            env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+            env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
+            env["API_TIMEOUT_MS"] = "3000000"
+            env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(context_window)
+            env["CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE"] = str(max(context_window - 3000, 10000))
+            effort_env = mms_launchers._claude_code_effort_env_value(model, runtime)  # noqa: SLF001
+            if effort_env:
+                env["CLAUDE_CODE_EFFORT_LEVEL"] = effort_env
+            mms_launchers._apply_claude_shell_context_slots(  # noqa: SLF001
+                env,
+                context_window=context_window,
+                fallback_model=env.get("ANTHROPIC_MODEL") or env_model,
+                enable_1m=mms_launchers._runtime_supports_claude_1m(runtime),  # noqa: SLF001
+                provider_id=provider_id,
+            )
+            claude_bin = mms_launchers._resolve_real_home_command_path("claude", env) or "claude"  # noqa: SLF001
+            cmd = [claude_bin, *_claude_print_args(cwd=cwd, prompt=prompt, sandbox=sandbox)]
+            cmd, env, exe = mms_launchers.prepare_cli_command(cmd, env)
+            if not exe:
+                raise FlywheelConfigError("claude executable not found")
+            proc = subprocess.run(cmd, cwd=str(cwd), env=env, capture_output=True, text=True, check=False)
+            return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
 def run_flywheel_lane(
     *,
     lane: str,
@@ -1154,8 +1379,11 @@ def run_flywheel_lane(
         lineup_path=lineup_path,
     )
     runtime_kind = str(resolved.get("runtime_kind") or "").strip()
-    if runtime_kind not in {"codex"}:
-        raise FlywheelConfigError(f"flywheel run currently supports codex runtime only, got {runtime_kind!r}")
+    model = str(resolved.get("model") or "")
+    if runtime_kind not in {"codex", "claude"}:
+        raise FlywheelConfigError(f"flywheel run currently supports codex/claude runtime only, got {runtime_kind!r}")
+    if runtime_kind == "codex" and not _is_openai_family_model(model):
+        raise FlywheelConfigError(f"codex runtime is limited to GPT/OpenAI-family models, got {model!r}; use runtime_kind='claude'")
     raw_route = _raw_selected_route(resolved)
     runtime = _runtime_from_route(resolved, raw_route)
     prompt_text, forwarded_args, prompt_source = _extract_prompt(
@@ -1200,8 +1428,12 @@ def run_flywheel_lane(
     }
     if dry_run:
         result["command_preview"] = {
-            "cli": "codex",
-            "args": _codex_exec_args(cwd=workdir, prompt="<prompt>", sandbox=sandbox),
+            "cli": runtime_kind,
+            "args": (
+                _codex_exec_args(cwd=workdir, prompt="<prompt>", sandbox=sandbox)
+                if runtime_kind == "codex"
+                else _claude_print_args(cwd=workdir, prompt="<prompt>", sandbox=sandbox)
+            ),
         }
         _write_run_result_artifact(run_result_artifact, result)
         return result
@@ -1219,14 +1451,15 @@ def run_flywheel_lane(
         _write_run_result_artifact(run_result_artifact, result)
         return result
 
-    rc, stdout_text, stderr_text = _run_codex_headless(
+    runner = _run_codex_headless if runtime_kind == "codex" else _run_claude_headless
+    rc, stdout_text, stderr_text = runner(
         runtime=runtime,
-        model=str(resolved.get("model") or ""),
+        model=model,
         prompt=prompt_text,
         cwd=workdir,
         sandbox=sandbox,
     )
-    agent_text = _extract_codex_agent_text(stdout_text)
+    agent_text = _extract_codex_agent_text(stdout_text) if runtime_kind == "codex" else stdout_text
     if not agent_text and stdout_text:
         agent_text = stdout_text
     result["exit_code"] = rc

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -115,6 +115,7 @@ def _seed_flywheel_tier_routes(root):
                     "anthropic_base_url": "https://qwen.example/v1",
                     "openai_base_url": "https://qwen.example/v1",
                     "api_key": "secret-qwen",
+                    "max_context_tokens": 1000000,
                 },
                 "fallbacks": [
                     {
@@ -152,6 +153,32 @@ def _seed_flywheel_tier_routes(root):
                     {
                         "provider_id": "newapi-tencent",
                         "model_id": "glm-5.2",
+                        "anthropic_base_url": "https://tencent.example/v1",
+                        "openai_base_url": "https://tencent.example/v1",
+                        "api_key": "secret-tencent",
+                    },
+                ],
+            },
+            "MiniMax-M3": {
+                "primary": {
+                    "provider_id": "direct-minimax",
+                    "model_id": "MiniMax-M3",
+                    "anthropic_base_url": "https://minimax.example/anthropic",
+                    "openai_base_url": "https://minimax.example/v1",
+                    "api_key": "secret-minimax",
+                    "max_context_tokens": 1000000,
+                },
+                "fallbacks": [
+                    {
+                        "provider_id": "newapi-personal-tokyo",
+                        "model_id": "MiniMax-M3",
+                        "anthropic_base_url": "https://tokyo.example/v1",
+                        "openai_base_url": "https://tokyo.example/v1",
+                        "api_key": "secret-tokyo",
+                    },
+                    {
+                        "provider_id": "newapi-tencent",
+                        "model_id": "MiniMax-M3",
                         "anthropic_base_url": "https://tencent.example/v1",
                         "openai_base_url": "https://tencent.example/v1",
                         "api_key": "secret-tencent",
@@ -202,26 +229,26 @@ api_key = "secret-tokyo"
 openai_base_url = "https://tokyo.example/v1"
 anthropic_base_url = "https://tokyo.example/v1"
 protocols = ["anthropic_messages", "openai_chat_completions"]
-fallback_models = ["gpt-5.5", "qwen3.7-max", "glm-5.2"]
+fallback_models = ["gpt-5.5", "qwen3.7-max", "glm-5.2", "MiniMax-M3"]
 supported_clis = ["codex"]
 """.strip(),
         encoding="utf-8",
     )
 
 
-def _write_qwen_worker_config(root: Path, *, effort: str = "high"):
+def _write_qwen_worker_config(root: Path, *, effort: str = "high", runtime: str = "claude"):
     (root / "config.toml").write_text(
         """
 [flywheel.lanes.worker]
 "AI-P3" = "flywheel.worker.p3"
 
 [flywheel.profiles."flywheel.worker.p3"]
-runtime = "codex"
+runtime = "{runtime}"
 model = "qwen3.7-max"
 provider = "direct-qwen"
 reasoning_effort = "{effort}"
 thinking_mode = "enable"
-""".strip().format(effort=effort),
+""".strip().format(effort=effort, runtime=runtime),
         encoding="utf-8",
     )
 
@@ -238,13 +265,20 @@ def test_default_worker_and_fixer_tiers_use_domestic_models_and_ordered_fallback
     worker_p0 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P0", config_root=str(root))
 
     assert worker_p3["profile_id"] == "flywheel.worker.cn-qwen"
+    assert worker_p3["runtime_kind"] == "claude"
     assert worker_p3["model"] == "qwen3.7-max"
     assert worker_p3["provider_id"] == "direct-qwen"
-    assert worker_p4["model"] == "qwen3.7-max"
-    assert fixer_p4["profile_id"] == "flywheel.fixer.cn-qwen"
-    assert fixer_p4["model"] == "qwen3.7-max"
+    assert worker_p4["runtime_kind"] == "claude"
+    assert worker_p4["profile_id"] == "flywheel.worker.cn-minimax"
+    assert worker_p4["model"] == "MiniMax-M3"
+    assert worker_p4["provider_id"] == "direct-minimax"
+    assert fixer_p4["profile_id"] == "flywheel.fixer.cn-minimax"
+    assert fixer_p4["runtime_kind"] == "claude"
+    assert fixer_p4["model"] == "MiniMax-M3"
     assert worker_p2["profile_id"] == "flywheel.worker.cn-glm"
+    assert worker_p2["runtime_kind"] == "claude"
     assert worker_p2["model"] == "glm-5.2"
+    assert worker_p0["runtime_kind"] == "codex"
     assert [item["provider_id"] for item in worker_p3["fallback_routes"]] == [
         "newapi-personal-tokyo",
         "newapi-tencent",
@@ -278,16 +312,12 @@ def test_flywheel_runtime_passes_ordered_native_fallback_routes_without_artifact
     _seed_flywheel_tier_routes(root)
     captured = {}
 
-    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
         captured["runtime"] = runtime
         captured["model"] = model
-        return (
-            0,
-            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
-            "",
-        )
+        return (0, "agent text", "")
 
-    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
 
     result = mms_flywheel.run_flywheel_lane(
         lane="worker",
@@ -299,6 +329,7 @@ def test_flywheel_runtime_passes_ordered_native_fallback_routes_without_artifact
     )
 
     assert result["ok"] is True
+    assert result["runtime_kind"] == "claude"
     assert captured["model"] == "qwen3.7-max"
     assert [item["provider_id"] for item in captured["runtime"]["native_fallback_routes"]] == [
         "newapi-personal-tokyo",
@@ -336,7 +367,7 @@ def test_flywheel_run_preserves_explicit_config_for_native_fallback_routes(tmp_p
 "AI-P3" = "flywheel.worker.custom"
 
 [profiles."flywheel.worker.custom"]
-runtime = "codex"
+runtime = "claude"
 model = "qwen3.7-max"
 provider = "direct-qwen"
 fallback_providers = ["us-cpa-local-codex"]
@@ -348,16 +379,12 @@ us-cpa-local-codex = "gpt-5.5"
     )
     captured = {}
 
-    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
         captured["runtime"] = runtime
         captured["model"] = model
-        return (
-            0,
-            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
-            "",
-        )
+        return (0, "agent text", "")
 
-    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
 
     result = mms_flywheel.run_flywheel_lane(
         lane="worker",
@@ -370,6 +397,7 @@ us-cpa-local-codex = "gpt-5.5"
     )
 
     assert result["ok"] is True
+    assert result["runtime_kind"] == "claude"
     assert captured["model"] == "qwen3.7-max"
     assert [item["provider_id"] for item in captured["runtime"]["native_fallback_routes"]] == [
         "us-cpa-local-codex",
@@ -419,6 +447,67 @@ thinking_mode = "disable"
         "newapi-personal-tokyo",
         "newapi-tencent",
     ]
+
+
+@pytest.mark.parametrize("model_name", ["minimax-m3", "kimi-for-coding", "step-fun3.7"])
+def test_resolve_claude_runtime_accepts_future_domestic_model_name_alias(tmp_path, model_name):
+    root = tmp_path / "mms-next"
+    root.mkdir()
+    _write_json(
+        root / "model-routes.json",
+        {
+            "version": 1,
+            "routes": {
+                model_name: {
+                    "primary": {
+                        "provider_id": "direct-cn",
+                        "model_id": model_name,
+                        "anthropic_base_url": "https://cn.example/v1",
+                        "openai_base_url": "https://cn.example/v1",
+                        "api_key": "secret-cn",
+                    }
+                }
+            },
+        },
+    )
+    _write_json(
+        root / "model-routes.lineup.json",
+        {
+            "version": 1,
+            "routes": {
+                model_name: {
+                    "primary": {
+                        "provider_id": "direct-cn",
+                        "model_id": model_name,
+                        "reasoning_effort": "high",
+                        "thinking_mode": "disable",
+                        "max_context_tokens": 600000,
+                    }
+                }
+            },
+        },
+    )
+    (root / "flywheel.toml").write_text(
+        f"""
+[lanes.worker]
+"AI-P4" = "flywheel.worker.future-cn"
+
+[profiles."flywheel.worker.future-cn"]
+runtime_kind = "claude"
+model_name = "{model_name}"
+provider = "direct-cn"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    resolved = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P4", config_root=str(root))
+
+    assert resolved["runtime_kind"] == "claude"
+    assert resolved["model"] == model_name
+    assert resolved["provider_id"] == "direct-cn"
+    assert resolved["thinking_mode"] == "disable"
+    assert resolved["reasoning_effort"] == "high"
+    assert resolved["max_context_tokens"] == 600000
 
 
 def test_resolve_committee_default_without_model_route(tmp_path):
@@ -515,7 +604,10 @@ def test_run_dry_run_writes_sanitized_resolved_route_artifact(tmp_path):
     assert result["status"] == "dry_run"
     assert result["model"] == "qwen3.7-max"
     assert result["provider_id"] == "direct-qwen"
+    assert result["command_preview"]["cli"] == "claude"
     assert payload["runtime"]["reasoning_effort"] == "xhigh"
+    assert payload["runtime"]["thinking_mode"] == "enable"
+    assert payload["runtime"]["max_context_tokens"] == 1000000
     serialized = json.dumps(payload, ensure_ascii=False)
     assert "secret-qwen" not in serialized
     assert "https://qwen.example" not in serialized
@@ -536,7 +628,7 @@ def test_run_dry_run_emits_cache_transport_evidence_for_dual_protocol_route(tmp_
 "AI-P3" = "flywheel.worker.p3"
 
 [flywheel.profiles."flywheel.worker.p3"]
-runtime = "codex"
+runtime = "claude"
 model = "qwen3.7-max"
 provider = "dual-qwen"
 """.strip(),
@@ -574,7 +666,7 @@ def test_run_fake_response_emits_raw_looper_marker(tmp_path, monkeypatch, capsys
     workdir = tmp_path / "work"
     root.mkdir()
     workdir.mkdir()
-    _seed_routes(root)
+    _seed_flywheel_tier_routes(root)
     _write_qwen_worker_config(root)
     monkeypatch.setenv(
         "MMS_FLYWHEEL_RUN_FAKE_RESPONSE",
@@ -605,28 +697,24 @@ def test_run_fake_response_emits_raw_looper_marker(tmp_path, monkeypatch, capsys
     assert 'done\n__LOOPER_RESULT__={"summary":"ok"' in out
 
 
-def test_run_invokes_codex_runner_with_raw_runtime_but_json_output_is_safe(tmp_path, monkeypatch, capsys):
+def test_run_invokes_claude_runner_with_raw_runtime_but_json_output_is_safe(tmp_path, monkeypatch, capsys):
     root = tmp_path / "mms-next"
     workdir = tmp_path / "work"
     root.mkdir()
     workdir.mkdir()
-    _seed_routes(root)
+    _seed_flywheel_tier_routes(root)
     _write_qwen_worker_config(root)
     captured = {}
 
-    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
         captured["runtime"] = runtime
         captured["model"] = model
         captured["prompt"] = prompt
         captured["cwd"] = cwd
         captured["sandbox"] = sandbox
-        return (
-            0,
-            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
-            "",
-        )
+        return (0, "agent text", "")
 
-    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
 
     rc = mms_flywheel.handle_flywheel_command(
         [
@@ -649,9 +737,14 @@ def test_run_invokes_codex_runner_with_raw_runtime_but_json_output_is_safe(tmp_p
     payload = json.loads(capsys.readouterr().out)
     assert rc == 0
     assert payload["ok"] is True
+    assert payload["result"]["runtime_kind"] == "claude"
     assert payload["result"]["agent_text"] == "agent text"
     assert captured["runtime"]["api_key"] == "secret-qwen"
     assert captured["runtime"]["openai_base_url"] == "https://qwen.example/v1"
+    assert captured["runtime"]["anthropic_base_url"] == "https://qwen.example/v1"
+    assert captured["runtime"]["thinking_mode"] == "enable"
+    assert captured["runtime"]["reasoning_effort"] == "high"
+    assert captured["runtime"]["max_context_tokens"] == 1000000
     assert captured["model"] == "qwen3.7-max"
     assert captured["prompt"] == "fix this"
     serialized = json.dumps(payload, ensure_ascii=False)
@@ -659,7 +752,7 @@ def test_run_invokes_codex_runner_with_raw_runtime_but_json_output_is_safe(tmp_p
     assert "https://qwen.example" not in serialized
 
 
-def test_run_invokes_codex_runner_with_anthropic_transport_for_dual_protocol_route(tmp_path, monkeypatch):
+def test_run_invokes_claude_runner_with_anthropic_transport_for_dual_protocol_route(tmp_path, monkeypatch):
     root = tmp_path / "mms-next"
     workdir = tmp_path / "work"
     root.mkdir()
@@ -671,7 +764,7 @@ def test_run_invokes_codex_runner_with_anthropic_transport_for_dual_protocol_rou
 "AI-P3" = "flywheel.worker.p3"
 
 [flywheel.profiles."flywheel.worker.p3"]
-runtime = "codex"
+runtime = "claude"
 model = "qwen3.7-max"
 provider = "dual-qwen"
 """.strip(),
@@ -679,16 +772,12 @@ provider = "dual-qwen"
     )
     captured = {}
 
-    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
         captured["runtime"] = runtime
         captured["model"] = model
-        return (
-            0,
-            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "agent text"}}),
-            "",
-        )
+        return (0, "agent text", "")
 
-    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
 
     result = mms_flywheel.run_flywheel_lane(
         lane="worker",
@@ -699,11 +788,182 @@ provider = "dual-qwen"
     )
 
     assert result["ok"] is True
+    assert result["runtime_kind"] == "claude"
     assert captured["runtime"]["preferred_transport"] == "anthropic_messages"
     assert captured["runtime"]["transport_request_path"] == "/v1/messages"
     assert captured["runtime"]["cache_transport_evidence"]["protocol"] == "anthropic_messages"
     assert captured["runtime"]["api_key"] == "secret-qwen"
     assert captured["model"] == "qwen3.7-max"
+
+
+def test_run_uses_legacy_secret_route_when_generated_route_is_sanitized(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+    _write_qwen_worker_config(root)
+    generated = root / "generated"
+    generated.mkdir()
+    routes_payload = json.loads((root / "model-routes.json").read_text(encoding="utf-8"))
+    generated_primary = routes_payload["routes"]["qwen3.7-max"]["primary"]
+    generated_primary["api_key"] = ""
+    _write_json(generated / "model-routes.json", routes_payload)
+    _write_json(generated / "model-routes.lineup.json", json.loads((root / "model-routes.lineup.json").read_text(encoding="utf-8")))
+    captured = {}
+
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        return (0, "agent text", "")
+
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        runner_args=["exec", "fix this"],
+    )
+
+    assert result["ok"] is True
+    assert captured["runtime"]["api_key"] == "secret-qwen"
+    artifact = json.loads(Path(result["resolved_route_path"]).read_text(encoding="utf-8"))
+    assert artifact["resolved"]["config"]["route_path"].endswith("generated/model-routes.json")
+    serialized = json.dumps(artifact, ensure_ascii=False)
+    assert "secret-qwen" not in serialized
+
+
+def test_run_invokes_codex_runner_for_gpt_worker(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+    captured = {}
+
+    def fake_run_codex_headless(*, runtime, model, prompt, cwd, sandbox):
+        captured["runtime"] = runtime
+        captured["model"] = model
+        captured["prompt"] = prompt
+        return (
+            0,
+            json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "codex text"}}),
+            "",
+        )
+
+    monkeypatch.setattr(mms_flywheel, "_run_codex_headless", fake_run_codex_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P0",
+        config_root=str(root),
+        cwd=str(workdir),
+        runner_args=["exec", "fix this"],
+    )
+
+    assert result["ok"] is True
+    assert result["runtime_kind"] == "codex"
+    assert result["agent_text"] == "codex text"
+    assert captured["model"] == "gpt-5.5"
+    assert captured["runtime"]["preferred_transport"] == "openai_responses"
+    assert captured["prompt"] == "fix this"
+
+
+def test_claude_headless_uses_bridge_with_thinking_effort_and_context(tmp_path, monkeypatch):
+    import mms_launchers
+
+    captured = {}
+    runtime = {
+        "id": "direct-qwen",
+        "api_key": "secret-qwen",
+        "openai_api_key": "secret-qwen",
+        "openai_base_url": "https://qwen.example/v1",
+        "anthropic_base_url": "https://qwen.example/v1",
+        "protocols": ["anthropic_messages", "openai_chat_completions"],
+        "preferred_transport": "anthropic_messages",
+        "thinking_mode": "disable",
+        "reasoning_effort": "xhigh",
+        "max_context_tokens": 777000,
+        "native_fallback_routes": [
+            {"provider_id": "newapi-personal-tokyo", "gateway_url": "https://tokyo.example/v1", "gateway_key": "secret-tokyo"}
+        ],
+    }
+
+    @contextmanager
+    def fake_bridge(gateway_url, api_key, **kwargs):
+        captured["bridge_gateway_url"] = gateway_url
+        captured["bridge_api_key"] = api_key
+        captured["bridge_kwargs"] = kwargs
+        yield {"base_url": "http://127.0.0.1:9999", "api_key": "bridge-token"}
+
+    def fake_claude_env(_runtime, **kwargs):
+        captured["env_kwargs"] = kwargs
+        return {"HOME": str(tmp_path / "home"), "ANTHROPIC_MODEL": "claude-sonnet-4-6"}
+
+    def fake_prepare_cli_command(cmd, env):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        return cmd, env, "claude"
+
+    def fake_subprocess_run(cmd, **kwargs):
+        captured["run_cmd"] = cmd
+        captured["run_kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="claude text", stderr="")
+
+    monkeypatch.setattr(mms_launchers, "_ensure_bridge_helpers", lambda: None)
+    monkeypatch.setattr(mms_launchers, "_ensure_speed_stats", lambda: None)
+    monkeypatch.setattr(mms_launchers, "gateway_health_check", lambda _runtime: None)
+    monkeypatch.setattr(mms_launchers, "_probe_models", lambda _runtime, emit_output=False: {"models": ["qwen3.7-max"]})
+    monkeypatch.setattr(mms_launchers, "build_provider_speed_scope", lambda _runtime: {"provider": "direct-qwen"})
+    monkeypatch.setattr(mms_launchers, "_is_claude_family_model_name", lambda _model: False)
+    monkeypatch.setattr(mms_launchers, "_resolve_anthropic_base_url", lambda _runtime, probe_model="": ("https://qwen.example", "normalized"))
+    monkeypatch.setattr(mms_launchers, "_anthropic_base_url", lambda _runtime: _runtime["anthropic_base_url"])
+    monkeypatch.setattr(mms_launchers, "_openai_base_url", lambda _runtime: _runtime["openai_base_url"])
+    monkeypatch.setattr(mms_launchers, "_runtime_thinking_enabled", lambda _runtime: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_reasoning_effort", lambda _runtime, default="high": _runtime["reasoning_effort"])
+    monkeypatch.setattr(mms_launchers, "_runtime_supports_claude_1m", lambda _runtime: False)
+    monkeypatch.setattr(mms_launchers, "_runtime_model_capabilities", lambda _runtime, _model: {})
+    monkeypatch.setattr(mms_launchers, "_runtime_vision_sidecar", lambda _runtime: {})
+    monkeypatch.setattr(mms_launchers, "_model_capabilities_support_vision", lambda _capabilities, _model: False)
+    monkeypatch.setattr(mms_launchers, "_context_windows_for_models", lambda *_models, **_kwargs: {"qwen3.7-max": 777000})
+    monkeypatch.setattr(mms_launchers, "_claude_route_status_paths", lambda: [str(tmp_path / "route-status.json")])
+    monkeypatch.setattr(mms_launchers, "_runtime_is_sensitive_claude_provider", lambda _runtime: False)
+    monkeypatch.setattr(mms_launchers, "_rescue_bridge_kwargs", lambda: {})
+    monkeypatch.setattr(mms_launchers, "_gateway_claude_bridge_context", fake_bridge)
+    monkeypatch.setattr(mms_launchers, "_claude_gateway_env", fake_claude_env)
+    monkeypatch.setattr(mms_launchers, "_claude_code_effort_env_value", lambda _model, _runtime: "max")
+    monkeypatch.setattr(mms_launchers, "_apply_claude_shell_context_slots", lambda env, **kwargs: captured.setdefault("context_kwargs", kwargs))
+    monkeypatch.setattr(mms_launchers, "_resolve_real_home_command_path", lambda _name, _env: "claude")
+    monkeypatch.setattr(mms_launchers, "prepare_cli_command", fake_prepare_cli_command)
+    monkeypatch.setattr(mms_flywheel.subprocess, "run", fake_subprocess_run)
+
+    rc, stdout, stderr = mms_flywheel._run_claude_headless(
+        runtime=runtime,
+        model="qwen3.7-max",
+        prompt="do it",
+        cwd=tmp_path,
+        sandbox="danger-full-access",
+    )
+
+    assert rc == 0
+    assert stdout == "claude text"
+    assert stderr == ""
+    assert captured["bridge_gateway_url"] == "https://qwen.example/v1"
+    assert captured["bridge_api_key"] == "secret-qwen"
+    assert captured["bridge_kwargs"]["heavy_model"] == "qwen3.7-max"
+    assert captured["bridge_kwargs"]["reasoning_enabled"] is False
+    assert captured["bridge_kwargs"]["reasoning_effort"] == "xhigh"
+    assert captured["bridge_kwargs"]["native_fallback_routes"] == runtime["native_fallback_routes"]
+    assert captured["env_kwargs"]["selected_model"] == "claude-sonnet-4-6"
+    assert captured["env_kwargs"]["display_model"] == "qwen3.7-max"
+    assert captured["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "777000"
+    assert captured["env"]["CLAUDE_CODE_EFFORT_LEVEL"] == "max"
+    assert captured["context_kwargs"]["context_window"] == 777000
+    assert captured["run_kwargs"]["cwd"] == str(tmp_path)
+    assert "--dangerously-skip-permissions" in captured["cmd"]
+    assert captured["cmd"][-2:] == ["-p", "do it"]
 
 
 def test_codex_headless_initializes_lazy_speed_stats(tmp_path, monkeypatch):
@@ -841,10 +1101,28 @@ def test_run_rejects_committee_profile_for_headless_worker_runner(tmp_path):
     root = tmp_path / "mms-next"
     root.mkdir()
 
-    with pytest.raises(mms_flywheel.FlywheelConfigError, match="codex runtime only"):
+    with pytest.raises(mms_flywheel.FlywheelConfigError, match="codex/claude runtime only"):
         mms_flywheel.run_flywheel_lane(
             lane="committee",
             priority="AI-P0",
             config_root=str(root),
             prompt="review",
+        )
+
+
+def test_run_rejects_non_gpt_codex_runtime(tmp_path):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_routes(root)
+    _write_qwen_worker_config(root, runtime="codex")
+
+    with pytest.raises(mms_flywheel.FlywheelConfigError, match="GPT/OpenAI-family"):
+        mms_flywheel.run_flywheel_lane(
+            lane="worker",
+            priority="AI-P3",
+            config_root=str(root),
+            cwd=str(workdir),
+            prompt="do it",
         )


### PR DESCRIPTION
## 做了什么

- Flywheel worker/fixer 国内 tier 改为 non-GPT 走 `claude` runtime；GPT/OpenAI-family 仍走 `codex`。
- `AI-P4` 默认改为 `claude + MiniMax-M3`，`AI-P2/P3` 分别保持 `glm-5.2` / `qwen3.7-max`。
- 支持 `model_name` alias，方便后续配置 `minimax-m3` / `kimi-for-coding` / `step-fun3.7`。
- 将 MMS profile/route resolve 出来的 `thinking_mode`、`reasoning_effort`、`max_context_tokens` 透传到 Claude bridge。
- 支持 sanitized generated route 缺 key 时，从同 config root legacy route 补 launch-only secret，同时 artifact 继续 redacted。

## 验证

- `python3 -m py_compile mms_flywheel.py mms_launchers.py tests/test_mms_flywheel.py`
- `pytest -q tests/test_mms_flywheel.py tests/test_native_fallback.py tests/test_gateway_bridge_model_override.py` → `57 passed`
- `python3 scripts/regression_fresh_user_gate.py --quick` → PASS
- `git diff --check`
- live dry-run P0-P4：
  - `AI-P0/P1 -> codex gpt-5.5`
  - `AI-P2 -> claude glm-5.2`
  - `AI-P3 -> claude qwen3.7-max`
  - `AI-P4 -> claude MiniMax-M3`

## Review Hub

- request root: `.mission/review-dispatch/opencode/20260620T073913Z-review-flywheel-claude-runtime-dispatch`
- reviewers: `qwen3.7-max`, `MiniMax-M3`
- aggregate: `reviewers_complete=2`, `reviewers_incomplete=0`
- qwen verdict: `APPROVE`
- MiniMax verdict: `ACCEPT`
- note: MiniMax reported one low/pre-existing `config/provider-profiles.json` mimo reference URL data gap; not a Flywheel runtime dispatch blocker.

## Trace

MMS-MISSION: `20260620T073913Z-review-flywheel-claude-runtime-dispatch`
MMS-TARGET: branch `issue-77-flywheel-runtime-dispatch` @ `ffb62ecb`
