### PR TITLE
[codex] add review-dispatch execute workers

### DIFF
--- a/docs/OPENCODE_LITE_LAUNCHER.md
+++ b/docs/OPENCODE_LITE_LAUNCHER.md
@@ -1,12 +1,14 @@
 # OpenCode Launcher Profiles
 
-MMS now exposes four user-facing OpenCode profiles: `agent`, `review`, `omo`, and `raw`.
+MMS now exposes six user-facing OpenCode profiles: `agent`, `review`, `committee`, `debate`, `omo`, and `raw`.
 The older `lite_pro*` names are kept as hidden compatibility aliases only; they are no longer shown in CLI help, README examples, or the TUI selector.
 
 ## Decision
 
 - `agent` is the default/recommended mode. It resolves the MMS-generated session-local agent roster, keeps GPT-5.5 as coordinator/release gate, delegates long-running implementation to GPT-5.4, and uses domestic routes for read-only exploration, bug-hunt, and vision/context checks.
-- `review` is the Review Hub host mode. MMS resolves reviewer models before OpenCode starts, writes a session-local dynamic roster, then opens OpenCode TUI with a fast domestic host with GPT fallback that asks for a Review Hub request root and fans out to the preloaded reviewer agents.
+- `review` is the Review Hub artifact-review mode. MMS resolves a few reviewer models, preferably domestic/divergent ones, writes a session-local dynamic roster, then either opens OpenCode TUI with a Review Hub host or runs reviewer workers noninteractively through `review-dispatch --execute`.
+- `committee` is the decision/gate mode. It declares `committee_policy`, dispatches selected members, collects ballots/tally, and separates advisory, gate, estimate, review, and execution-packet decisions.
+- `debate` is the fork/proposition mode. It runs a bounded blind-seed -> crossfire -> revision mechanic and writes debate artifacts under `.ai/debate/<thread-id>/`.
 - `omo` uses the existing global OpenCode + OMO setup. MMS does not write or delete global OMO config.
 - `raw` is pure OpenCode with a session-local config and no OMO/custom agents.
 - `lite_pro`, `pro`, `pro_solo`, and `lite_pro_orchestrated` normalize to the same internal agent roster profile for backward compatibility.
@@ -19,8 +21,21 @@ The older `lite_pro*` names are kept as hidden compatibility aliases only; they 
 | --- | --- | --- | --- |
 | `agent` | `opencode --pure --agent mobius-builder-pro -m mms-builder_primary/<model>` | MMS-generated session-local multi-provider `opencode.json` | Default agent roster: 5.5 coordinator/release gate, 5.4 executor, domestic read-only support |
 | `review` | `opencode --pure --agent review-hub-host -m mms-builder_primary/<model>` | MMS-generated session-local multi-provider `opencode.json` | Review Hub host: use MMS-selected dynamic reviewers, run same request root, aggregate slots |
+| `committee` | `opencode --pure --agent committee-host -m mms-builder_primary/<model>` | MMS-generated session-local multi-provider `opencode.json` | Decision/gate host: classify policy, dispatch members, tally ballots, synthesize next action |
+| `debate` | `opencode --pure --agent debate-host -m mms-builder_primary/<model>` | MMS-generated session-local multi-provider `opencode.json` | Structured fork/proposition debate: blind seed, crossfire, revision, resolution |
 | `omo` | `opencode` | Existing global OpenCode + OMO config | Global OMO/fanout lane |
 | `raw` | `opencode --pure -m mms/<safe-gpt-model>` | MMS-generated session-local `opencode.json` | Debug/minimal fallback |
+
+Profile routing:
+
+| Need | Use profile |
+| --- | --- |
+| Implement, repair, or iterate code | `agent` |
+| Review a concrete PR, diff, request root, regression report, fix result, or release-risk packet | `review` |
+| Decide approve/reject/modify, quorum, release gate, risk acceptance, or formal/advisory ballots | `committee` |
+| Compare A vs B, decide whether to do X, or force structured disagreement before implementation | `debate` |
+| Use the user's existing global OpenCode/OMO environment | `omo` |
+| Debug minimal OpenCode route/config behavior | `raw` |
 
 Direct launch examples:
 
@@ -28,6 +43,8 @@ Direct launch examples:
 mms
 mms opencode --profile agent
 mms opencode --profile review
+mms opencode --profile committee
+mms opencode --profile debate
 mms opencode --profile omo
 mms opencode --profile raw
 ```
@@ -99,6 +116,16 @@ models = ["qwen", "kimi2.5", "minimax2.7", "glm5-turbo"]
 ```
 
 The host does not copy dispatcher context into memory. It expects a durable Review Hub request root, gives each preloaded reviewer the same request-root command, and relies on runner-local MCP/skills during each reviewer preflight.
+
+Automation should prefer noninteractive execution rather than launching a TUI:
+
+```bash
+mmf review-dispatch --execute --mode workers --json \
+  --root <repo-or-artifact-root> \
+  --model qwen3.7-max --model kimi-k2.6 --model MiniMax-M3
+```
+
+`--execute --mode workers` creates the request, creates the worker plan, resolves the generated `review` profile agents, runs one `opencode run --agent review-*` per reviewer, writes per-worker stdout/stderr evidence, runs `review-hub aggregate --write`, and returns JSON with `aggregate_path`, `reviewers_total`, `reviewers_complete`, `reviewers_incomplete`, and `verdict`.
 
 ### Review Mission Trace
 

--- a/mms_opencode_agents.py
+++ b/mms_opencode_agents.py
@@ -751,6 +751,10 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
         return (
             f"You are the {label} Review Hub reviewer. When given a request root, "
             + OPENCODE_HEADLESS_REVIEW_PACK_CONTRACT + " "
+            "Your vertical is independent artifact review: inspect a concrete "
+            "PR, diff, request root, fix result, regression evidence, or release "
+            "risk packet and produce finding-first review artifacts. You are not "
+            "a committee voter, not a debate participant, and not an executor. "
             "For inline packs, do not hydrate review-hub. "
             "run `review-hub reviewer <request-root>` with your model identity when "
             "needed, read the returned PROMPT.md and manifest.json, then execute that "
@@ -784,10 +788,19 @@ def opencode_review_hub_agent_configs(agent_models, *, roster_config=None):
                 "external_directory": "ask",
             },
             "prompt": (
-                "You are a Review Hub execution host, not the original dispatcher. "
+                "You are a specialized Review Hub execution host, not a general "
+                "committee host and not debate-host. The Review profile vertical "
+                "is concrete artifact review: send one request root or inline "
+                "review pack to several domestic reviewer agents for divergent "
+                "finding-first opinions, then aggregate their slots. "
                 + OPENCODE_REVIEW_MISSION_CONTRACT + " "
                 + OPENCODE_HEADLESS_REVIEW_PACK_CONTRACT + " "
                 "For inline packs, do not hydrate review-hub or ask for a request root. "
+                "Do not run committee_policy, formal votes, gate ratification, "
+                "blind seed, crossfire, stance-shift, or debate resolution artifacts "
+                "inside Review. If the user needs approve/reject/modify or quorum, "
+                "hand off to committee; if the user needs A vs B direction setting, "
+                "hand off to debate. "
                 "Default host route prefers fast domestic GLM/Kimi/Qwen and falls back through MMS route "
                 "resolution. Start by asking the user for a Review Hub request root "
                 "or short command such as `/review-hub <request-root>` if it was not "

--- a/mms_review_dispatch.py
+++ b/mms_review_dispatch.py
@@ -678,13 +678,35 @@ def _fake_reviewer_outputs(request_root: Path, workers: list[dict[str, Any]]) ->
 def _aggregate_verdict(aggregate: dict[str, Any] | None) -> str:
     if not isinstance(aggregate, dict):
         return "not_run"
+    explicit_verdict = str(aggregate.get("verdict") or "").strip()
+    if explicit_verdict:
+        return explicit_verdict
     total = int(aggregate.get("reviewers_total") or 0)
     incomplete = int(aggregate.get("reviewers_incomplete") or 0)
     if total <= 0:
         return "no_reviewers"
     if incomplete:
         return "incomplete"
-    return str(aggregate.get("verdict") or "complete")
+    return "complete_no_verdict"
+
+
+def _aggregate_errors(aggregate: dict[str, Any] | None) -> list[str]:
+    if not isinstance(aggregate, dict) or aggregate.get("ok", True):
+        return []
+    values = aggregate.get("errors")
+    if isinstance(values, list):
+        errors = [str(item) for item in values if str(item).strip()]
+    elif values:
+        errors = [str(values)]
+    else:
+        errors = []
+    for key in ("error", "message"):
+        value = str(aggregate.get(key) or "").strip()
+        if value:
+            errors.append(value)
+    if not errors:
+        errors.append("review-hub aggregate returned ok=false")
+    return [f"review-hub aggregate failed: {item}" for item in errors]
 
 
 def _copy_aggregate_summary(payload: dict[str, Any], aggregate: dict[str, Any] | None) -> None:
@@ -855,6 +877,7 @@ def build_review_dispatch(
         _copy_aggregate_summary(payload, aggregate_result)
         if not aggregate_result.get("ok"):
             payload["ok"] = False
+            payload.setdefault("errors", []).extend(_aggregate_errors(aggregate_result))
         if int(payload.get("reviewers_incomplete") or 0) > 0:
             payload["ok"] = False
             payload.setdefault("errors", []).append(

--- a/mms_review_dispatch.py
+++ b/mms_review_dispatch.py
@@ -15,6 +15,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from mms_review_dispatch_execute import (
+    REVIEW_DISPATCH_EXECUTE_SCHEMA,
+    execute_review_workers as _execute_review_workers,
+)
+
 
 REVIEW_DISPATCH_SCHEMA = "mms.review_dispatch.v1"
 DEFAULT_REVIEW_FOCUS = ["code", "verification"]
@@ -25,8 +30,8 @@ BLOCKED_READINESS_STATES = {
     "ready-for-human",
 }
 REVIEW_MODEL_PRESETS: dict[str, list[str]] = {
-    "code_review": ["MiniMax-M3", "qwen3.7-max", "kimi-k2.6", "mimo-v2.5"],
-    "large_arch": ["gpt-5.4", "deepseek-v4-pro", "qwen3.7-max", "glm-5.1"],
+    "code_review": ["qwen3.7-max", "kimi-k2.6", "MiniMax-M3", "mimo-v2.5"],
+    "large_arch": ["qwen3.7-max", "kimi-k2.6", "glm-5.1", "deepseek-v4-pro", "MiniMax-M3"],
     "design_visual": ["mimo-v2.5", "kimi-k2.6", "qwen3.6-flash"],
     "domestic_cross": ["qwen3.7-max", "kimi-k2.6", "glm-5-turbo", "deepseek-v4-flash"],
     "fast_cheap": ["mimo-v2.5", "qwen3.6-flash", "deepseek-v4-flash"],
@@ -670,6 +675,28 @@ def _fake_reviewer_outputs(request_root: Path, workers: list[dict[str, Any]]) ->
     return results
 
 
+def _aggregate_verdict(aggregate: dict[str, Any] | None) -> str:
+    if not isinstance(aggregate, dict):
+        return "not_run"
+    total = int(aggregate.get("reviewers_total") or 0)
+    incomplete = int(aggregate.get("reviewers_incomplete") or 0)
+    if total <= 0:
+        return "no_reviewers"
+    if incomplete:
+        return "incomplete"
+    return str(aggregate.get("verdict") or "complete")
+
+
+def _copy_aggregate_summary(payload: dict[str, Any], aggregate: dict[str, Any] | None) -> None:
+    if not isinstance(aggregate, dict):
+        return
+    payload["aggregate_path"] = aggregate.get("aggregate_path")
+    payload["reviewers_total"] = int(aggregate.get("reviewers_total") or 0)
+    payload["reviewers_complete"] = int(aggregate.get("reviewers_complete") or 0)
+    payload["reviewers_incomplete"] = int(aggregate.get("reviewers_incomplete") or 0)
+    payload["verdict"] = _aggregate_verdict(aggregate)
+
+
 def build_review_dispatch(
     *,
     root: Path,
@@ -684,6 +711,11 @@ def build_review_dispatch(
     fake_run: bool,
     dry_run: bool,
     launch: bool,
+    execute: bool,
+    execute_mode: str,
+    host_agent: str,
+    host_timeout: int,
+    worker_timeout: int,
     allow_incomplete: bool,
     model_preset: str | None = None,
     model_text: list[str] | None = None,
@@ -775,6 +807,9 @@ def build_review_dispatch(
         "fake_run": fake_run,
         "dry_run": dry_run,
         "launched": False,
+        "executed": False,
+        "execute_requested": execute,
+        "execute_mode": execute_mode,
     }
     if dry_run:
         return payload
@@ -792,6 +827,39 @@ def build_review_dispatch(
         aggregate_result = _run_review_hub(["aggregate", "--request", str(request_root), "--write"])
         payload["fake_results"] = fake_results
         payload["aggregate"] = aggregate_result
+        _copy_aggregate_summary(payload, aggregate_result)
+
+    if execute:
+        execute_result = _execute_review_workers(
+            root=root,
+            request_root=request_root,
+            models=models,
+            workers=workers,
+            mode=execute_mode,
+            host_agent=host_agent,
+            host_timeout=host_timeout,
+            worker_timeout=worker_timeout,
+        )
+        payload["executed"] = True
+        payload["execute"] = execute_result
+        if not execute_result.get("ok"):
+            payload["ok"] = False
+            payload.setdefault("errors", []).extend(execute_result.get("errors") or ["review-dispatch execute failed"])
+        try:
+            aggregate_result = _run_review_hub(["aggregate", "--request", str(request_root), "--write"])
+        except Exception as exc:  # noqa: BLE001 - preserve worker evidence in JSON
+            aggregate_result = {"ok": False, "error": str(exc)}
+            payload["ok"] = False
+            payload.setdefault("errors", []).append(f"review-hub aggregate failed: {exc}")
+        payload["aggregate"] = aggregate_result
+        _copy_aggregate_summary(payload, aggregate_result)
+        if not aggregate_result.get("ok"):
+            payload["ok"] = False
+        if int(payload.get("reviewers_incomplete") or 0) > 0:
+            payload["ok"] = False
+            payload.setdefault("errors", []).append(
+                f"reviewers incomplete: {payload.get('reviewers_incomplete')}/{payload.get('reviewers_total')}"
+            )
 
     if launch:
         completed = subprocess.run(launch_command, text=True, check=False)
@@ -824,12 +892,20 @@ def handle_review_dispatch_command(argv: list[str], *, command_name: str = "mms"
     parser.add_argument("--allow-incomplete", action="store_true", help="Do not fail on missing Mission Control artifacts")
     parser.add_argument("--dry-run", action="store_true", help="Print planned request/worker/OpenCode commands without writing")
     parser.add_argument("--fake-run", action="store_true", help="Write fake per-model reviewer outputs and aggregate them")
-    parser.add_argument("--launch", action="store_true", help="Launch MMS OpenCode review profile after writing request artifacts")
+    launch_group = parser.add_mutually_exclusive_group()
+    launch_group.add_argument("--launch", action="store_true", help="Launch MMS OpenCode review profile after writing request artifacts")
+    launch_group.add_argument("--execute", action="store_true", help="Run reviewer workers noninteractively and aggregate results")
+    parser.add_argument("--mode", choices=["workers", "host"], default="workers", help="Execution mode for --execute")
+    parser.add_argument("--host-agent", default="review-hub-host", help="OpenCode host agent for --execute --mode host")
+    parser.add_argument("--host-timeout", type=int, default=900, help="Timeout seconds for --execute --mode host")
+    parser.add_argument("--worker-timeout", type=int, default=900, help="Timeout seconds per reviewer worker")
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
     parser.add_argument("model_phrase", nargs="*", help="Free-form reviewer phrase, e.g. 使用 kimi2.5 minimaxm3")
     args = parser.parse_args(argv)
 
     try:
+        if args.execute and args.fake_run:
+            raise ValueError("--execute and --fake-run are separate paths; use one at a time")
         payload = build_review_dispatch(
             root=Path(args.root),
             title=args.title,
@@ -844,6 +920,11 @@ def handle_review_dispatch_command(argv: list[str], *, command_name: str = "mms"
             fake_run=args.fake_run,
             dry_run=args.dry_run,
             launch=args.launch,
+            execute=args.execute,
+            execute_mode=args.mode,
+            host_agent=args.host_agent,
+            host_timeout=args.host_timeout,
+            worker_timeout=args.worker_timeout,
             allow_incomplete=args.allow_incomplete,
             model_preset=args.model_preset,
             command_name=command_name,
@@ -858,6 +939,8 @@ def handle_review_dispatch_command(argv: list[str], *, command_name: str = "mms"
             print(f"review-dispatch ready: {payload.get('request_root')}")
             print("OpenCode command:")
             print(" ".join(shlex.quote(str(part)) for part in payload.get("opencode_launch_command", [])))
+            if payload.get("execute"):
+                print(f"execute evidence: {payload['execute'].get('evidence_root')}")
             if payload.get("aggregate"):
                 print(f"aggregate: {payload['aggregate'].get('aggregate_path')}")
         else:
@@ -869,6 +952,7 @@ def handle_review_dispatch_command(argv: list[str], *, command_name: str = "mms"
 
 __all__ = [
     "REVIEW_DISPATCH_SCHEMA",
+    "REVIEW_DISPATCH_EXECUTE_SCHEMA",
     "REVIEW_MODEL_PRESETS",
     "build_review_dispatch",
     "handle_review_dispatch_command",

--- a/mms_review_dispatch_execute.py
+++ b/mms_review_dispatch_execute.py
@@ -1,0 +1,289 @@
+"""Noninteractive Review Hub worker execution for MMS review-dispatch."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REVIEW_DISPATCH_EXECUTE_SCHEMA = "mms.review_dispatch.execute.v1"
+
+
+def _now_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _slugify(value: str) -> str:
+    text = re.sub(r"[^a-zA-Z0-9]+", "-", str(value or "").strip().lower()).strip("-")
+    return text or "review"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _review_hub_prompt(request_root: Path) -> str:
+    return (
+        f"/review-hub {request_root}\n\n"
+        "Use the Review Hub request root above. Run the worker plan, delegate to the "
+        "configured reviewer agents, and aggregate results. Do not edit source files."
+    )
+
+
+def _load_opencode_smoke_helper():
+    helper = Path(__file__).resolve().parent / "scripts" / "smoke_opencode_profile.py"
+    if not helper.exists():
+        raise FileNotFoundError(f"missing OpenCode profile helper: {helper}")
+    root = Path(__file__).resolve().parent
+    for path in (root, root / "scripts"):
+        path_text = str(path)
+        if path_text not in sys.path:
+            sys.path.insert(0, path_text)
+    spec = importlib.util.spec_from_file_location("mms_review_dispatch_smoke_opencode_profile", helper)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load OpenCode profile helper: {helper}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _redacted_opencode_agents(payload: dict[str, Any]) -> dict[str, str]:
+    agents = payload.get("agent") if isinstance(payload.get("agent"), dict) else {}
+    return {
+        str(name): str(config.get("model") or "")
+        for name, config in agents.items()
+        if isinstance(config, dict)
+    }
+
+
+def _agent_for_worker(worker: dict[str, Any], opencode_payload: dict[str, Any]) -> str:
+    agents = opencode_payload.get("agent") if isinstance(opencode_payload.get("agent"), dict) else {}
+    model = str(worker.get("model_name") or "").strip()
+    model_key = model.lower()
+    candidates = []
+    model_slug = str(worker.get("model_slug") or "").strip()
+    if model_slug:
+        candidates.append(f"review-{model_slug}")
+    slot_root = Path(str(worker.get("slot_root") or ""))
+    if slot_root.name:
+        candidates.append(f"review-{slot_root.name}")
+    if model:
+        candidates.append(f"review-{_slugify(model)}")
+    for candidate in candidates:
+        if candidate in agents:
+            return candidate
+    for name, config in agents.items():
+        if not str(name).startswith("review-") or name in {"review-hub-host", "review-hub-host-stable"}:
+            continue
+        if isinstance(config, dict) and str(config.get("model") or "").lower().endswith("/" + model_key):
+            return str(name)
+    return candidates[0] if candidates else "review-hub-host"
+
+
+def _worker_prompt(request_root: Path, worker: dict[str, Any]) -> str:
+    model = str(worker.get("model_name") or "").strip()
+    slot_root = str(worker.get("slot_root") or "").strip()
+    prompt_path = str(worker.get("prompt_path") or "").strip()
+    manifest_path = str(worker.get("manifest_path") or "").strip()
+    return (
+        f"Review Hub worker mode for {request_root}.\n"
+        f"You are the reviewer for model `{model}`.\n"
+        f"Slot root: `{slot_root}`.\n"
+        f"Prompt path: `{prompt_path}`.\n"
+        f"Manifest path: `{manifest_path}`.\n\n"
+        "Read the prompt and manifest from disk, run the preflight first, then execute that prompt exactly. "
+        "Write only inside the assigned slot_root, especially slot_root/verify/*. "
+        "Do not edit source files, do not write other reviewer slots, and do not run committee or debate workflows."
+    )
+
+
+def _execute_evidence_root(request_root: Path) -> Path:
+    return request_root / "runner" / "mms-execute" / _now_stamp()
+
+
+def _resolve_review_profile_for_execute(models: list[str], evidence_root: Path):
+    smoke = _load_opencode_smoke_helper()
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        model_info, runtime = smoke._resolve_profile("review", review_models=models)
+    _write_text(evidence_root / "profile-resolve.stdout.txt", stdout.getvalue())
+    _write_text(evidence_root / "profile-resolve.stderr.txt", stderr.getvalue())
+    return smoke, model_info, runtime
+
+
+def _run_process_with_evidence(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    timeout: int,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> tuple[int, bool, str, str]:
+    timed_out = False
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        returncode = 124
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        stderr = stderr + f"\nTIMEOUT after {timeout}s\n"
+    except OSError as exc:
+        returncode = 127
+        stdout = ""
+        stderr = str(exc)
+    _write_text(stdout_path, stdout)
+    _write_text(stderr_path, stderr)
+    return returncode, timed_out, stdout, stderr
+
+
+def execute_review_workers(
+    *,
+    root: Path,
+    request_root: Path,
+    models: list[str],
+    workers: list[dict[str, Any]],
+    mode: str,
+    host_agent: str,
+    host_timeout: int,
+    worker_timeout: int,
+) -> dict[str, Any]:
+    evidence_root = _execute_evidence_root(request_root)
+    evidence_root.mkdir(parents=True, exist_ok=True)
+    try:
+        smoke, model_info, runtime = _resolve_review_profile_for_execute(models, evidence_root)
+    except Exception as exc:  # noqa: BLE001 - keep structured failure at CLI boundary
+        return {
+            "schema": REVIEW_DISPATCH_EXECUTE_SCHEMA,
+            "ok": False,
+            "mode": mode,
+            "errors": [f"OpenCode review profile resolve failed: {exc}"],
+            "evidence_root": str(evidence_root),
+            "workers": [],
+            "returncode": 1,
+        }
+
+    with tempfile.TemporaryDirectory(prefix="mms-review-dispatch-execute-") as tmp:
+        env, _config_path, opencode_payload = smoke._build_temp_env(runtime, model_info, Path(tmp))
+        redacted = {
+            "request_root": str(request_root),
+            "default_agent": opencode_payload.get("default_agent"),
+            "default_model": opencode_payload.get("model"),
+            "agents": _redacted_opencode_agents(opencode_payload),
+        }
+        redacted_path = evidence_root / "opencode-config.redacted.json"
+        _write_json(redacted_path, redacted)
+
+        if mode == "host":
+            prompt = _review_hub_prompt(request_root).rstrip() + "\n\nRun reviewers and aggregate results. Do not edit source files."
+            stdout_path = evidence_root / "opencode-host.stdout.txt"
+            stderr_path = evidence_root / "opencode-host.stderr.txt"
+            cmd = ["opencode", "run", "--pure", "--agent", host_agent, prompt]
+            returncode, timed_out, stdout, stderr = _run_process_with_evidence(
+                cmd,
+                cwd=root,
+                env=env,
+                timeout=host_timeout,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+            )
+            return {
+                "schema": REVIEW_DISPATCH_EXECUTE_SCHEMA,
+                "ok": returncode == 0,
+                "mode": "host",
+                "evidence_root": str(evidence_root),
+                "opencode_config_redacted_path": str(redacted_path),
+                "returncode": returncode,
+                "timed_out": timed_out,
+                "command": ["opencode", "run", "--pure", "--agent", host_agent, "<prompt>"],
+                "stdout_path": str(stdout_path),
+                "stderr_path": str(stderr_path),
+                "stdout_tail": stdout[-1200:],
+                "stderr_tail": stderr[-1200:],
+            }
+
+        results: list[dict[str, Any]] = []
+        for index, worker in enumerate(workers, start=1):
+            if not isinstance(worker, dict):
+                continue
+            agent = _agent_for_worker(worker, opencode_payload)
+            worker_env = dict(env)
+            worker_env["REVIEW_HUB_MODEL"] = str(worker.get("model_name") or "")
+            worker_env["MULTI_REVIEW_REVIEWER"] = str(worker.get("model_name") or "")
+            worker_env["REVIEW_HUB_REQUEST_ROOT"] = str(request_root)
+            worker_env["MMS_MODEL_NAME"] = str(worker.get("model_name") or "")
+            model_slug = Path(str(worker.get("slot_root") or f"worker-{index}")).name or f"worker-{index}"
+            stdout_path = evidence_root / f"opencode-worker-{index:02d}-{model_slug}.stdout.txt"
+            stderr_path = evidence_root / f"opencode-worker-{index:02d}-{model_slug}.stderr.txt"
+            cmd = ["opencode", "run", "--pure", "--agent", agent, _worker_prompt(request_root, worker)]
+            returncode, timed_out, stdout, stderr = _run_process_with_evidence(
+                cmd,
+                cwd=root,
+                env=worker_env,
+                timeout=worker_timeout,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+            )
+            results.append(
+                {
+                    "order": index,
+                    "model": worker.get("model_name"),
+                    "agent": agent,
+                    "returncode": returncode,
+                    "timed_out": timed_out,
+                    "command": ["opencode", "run", "--pure", "--agent", agent, "<prompt>"],
+                    "stdout_path": str(stdout_path),
+                    "stderr_path": str(stderr_path),
+                    "stdout_tail": stdout[-1200:],
+                    "stderr_tail": stderr[-1200:],
+                }
+            )
+
+    errors = [
+        f"opencode worker failed: model={item.get('model')} exit={item.get('returncode')}"
+        for item in results
+        if item.get("returncode") != 0
+    ]
+    return {
+        "schema": REVIEW_DISPATCH_EXECUTE_SCHEMA,
+        "ok": not errors and bool(results),
+        "mode": "workers",
+        "evidence_root": str(evidence_root),
+        "opencode_config_redacted_path": str(redacted_path),
+        "worker_count": len(results),
+        "workers": results,
+        "errors": errors,
+        "returncode": 0 if not errors and results else 1,
+    }

--- a/mms_review_dispatch_execute.py
+++ b/mms_review_dispatch_execute.py
@@ -92,7 +92,12 @@ def _agent_for_worker(worker: dict[str, Any], opencode_payload: dict[str, Any]) 
             continue
         if isinstance(config, dict) and str(config.get("model") or "").lower().endswith("/" + model_key):
             return str(name)
-    return candidates[0] if candidates else "review-hub-host"
+    available = ", ".join(sorted(str(name) for name in agents if str(name).startswith("review-")))
+    expected = ", ".join(candidates) or "<none>"
+    raise ValueError(
+        f"no OpenCode review agent found for model={model or '<unknown>'}; "
+        f"expected one of [{expected}], available=[{available or '<none>'}]"
+    )
 
 
 def _worker_prompt(request_root: Path, worker: dict[str, Any]) -> str:
@@ -238,24 +243,34 @@ def execute_review_workers(
         for index, worker in enumerate(workers, start=1):
             if not isinstance(worker, dict):
                 continue
-            agent = _agent_for_worker(worker, opencode_payload)
-            worker_env = dict(env)
-            worker_env["REVIEW_HUB_MODEL"] = str(worker.get("model_name") or "")
-            worker_env["MULTI_REVIEW_REVIEWER"] = str(worker.get("model_name") or "")
-            worker_env["REVIEW_HUB_REQUEST_ROOT"] = str(request_root)
-            worker_env["MMS_MODEL_NAME"] = str(worker.get("model_name") or "")
             model_slug = Path(str(worker.get("slot_root") or f"worker-{index}")).name or f"worker-{index}"
             stdout_path = evidence_root / f"opencode-worker-{index:02d}-{model_slug}.stdout.txt"
             stderr_path = evidence_root / f"opencode-worker-{index:02d}-{model_slug}.stderr.txt"
-            cmd = ["opencode", "run", "--pure", "--agent", agent, _worker_prompt(request_root, worker)]
-            returncode, timed_out, stdout, stderr = _run_process_with_evidence(
-                cmd,
-                cwd=root,
-                env=worker_env,
-                timeout=worker_timeout,
-                stdout_path=stdout_path,
-                stderr_path=stderr_path,
-            )
+            try:
+                agent = _agent_for_worker(worker, opencode_payload)
+            except ValueError as exc:
+                agent = ""
+                returncode = 127
+                timed_out = False
+                stdout = ""
+                stderr = str(exc)
+                _write_text(stdout_path, stdout)
+                _write_text(stderr_path, stderr + "\n")
+            else:
+                worker_env = dict(env)
+                worker_env["REVIEW_HUB_MODEL"] = str(worker.get("model_name") or "")
+                worker_env["MULTI_REVIEW_REVIEWER"] = str(worker.get("model_name") or "")
+                worker_env["REVIEW_HUB_REQUEST_ROOT"] = str(request_root)
+                worker_env["MMS_MODEL_NAME"] = str(worker.get("model_name") or "")
+                cmd = ["opencode", "run", "--pure", "--agent", agent, _worker_prompt(request_root, worker)]
+                returncode, timed_out, stdout, stderr = _run_process_with_evidence(
+                    cmd,
+                    cwd=root,
+                    env=worker_env,
+                    timeout=worker_timeout,
+                    stdout_path=stdout_path,
+                    stderr_path=stderr_path,
+                )
             results.append(
                 {
                     "order": index,
@@ -263,7 +278,7 @@ def execute_review_workers(
                     "agent": agent,
                     "returncode": returncode,
                     "timed_out": timed_out,
-                    "command": ["opencode", "run", "--pure", "--agent", agent, "<prompt>"],
+                    "command": ["opencode", "run", "--pure", "--agent", agent, "<prompt>"] if agent else [],
                     "stdout_path": str(stdout_path),
                     "stderr_path": str(stderr_path),
                     "stdout_tail": stdout[-1200:],
@@ -271,11 +286,13 @@ def execute_review_workers(
                 }
             )
 
-    errors = [
-        f"opencode worker failed: model={item.get('model')} exit={item.get('returncode')}"
-        for item in results
-        if item.get("returncode") != 0
-    ]
+    errors = []
+    for item in results:
+        if item.get("returncode") == 0:
+            continue
+        detail = str(item.get("stderr_tail") or "").strip().splitlines()
+        suffix = f": {detail[-1]}" if detail else ""
+        errors.append(f"opencode worker failed: model={item.get('model')} exit={item.get('returncode')}{suffix}")
     return {
         "schema": REVIEW_DISPATCH_EXECUTE_SCHEMA,
         "ok": not errors and bool(results),

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -3304,6 +3304,11 @@ def test_core_opencode_review_profile_builds_review_hub_roster(monkeypatch):
     assert "headless inline pr/mr review pack contract" in review_host_prompt_lower
     assert "verdict: approve|comment|request_changes" in review_host_prompt_lower
     assert "do not hydrate review-hub" in review_host_prompt_lower
+    assert "not a general committee host" in review_host_prompt_lower
+    assert "not debate-host" in review_host_prompt_lower
+    assert "concrete artifact review" in review_host_prompt_lower
+    assert "formal votes" in review_host_prompt_lower
+    assert "crossfire" in review_host_prompt_lower
     assert "mms-mission" in review_host_prompt_lower
     assert "mms-target" in review_host_prompt_lower
     assert "mms-mode" in review_host_prompt_lower

--- a/tests/test_review_dispatch.py
+++ b/tests/test_review_dispatch.py
@@ -508,3 +508,198 @@ def test_review_dispatch_fake_run_writes_multi_model_results(tmp_path, capsys):
     for result in payload["fake_results"]:
         verify_root = Path(result["verify_root"])
         assert (verify_root / "04-final-verdict.md").exists()
+
+
+def test_review_dispatch_execute_runs_workers_and_aggregate(tmp_path, monkeypatch, capsys):
+    import mms_review_dispatch
+    from mms_review_dispatch import handle_review_dispatch_command
+
+    root = _mission_root(tmp_path)
+    request_root_holder: dict[str, Path] = {}
+
+    def fake_run_review_hub(args):
+        if args[0] == "request":
+            request_root = Path(args[args.index("--out-dir") + 1])
+            request_root_holder["value"] = request_root
+            return {"ok": True, "request_root": str(request_root)}
+        if args[0] == "worker-plan":
+            request_root = request_root_holder["value"]
+            workers = [
+                {
+                    "order": 1,
+                    "model_name": "qwen3.7-max",
+                    "model_slug": "qwen3-7-max",
+                    "slot_root": str(request_root / "reviewers" / "qwen3-7-max"),
+                    "prompt_path": str(request_root / "reviewers" / "qwen3-7-max" / "PROMPT.md"),
+                    "manifest_path": str(request_root / "reviewers" / "qwen3-7-max" / "manifest.json"),
+                },
+                {
+                    "order": 2,
+                    "model_name": "kimi-k2.6",
+                    "model_slug": "kimi-k2-6",
+                    "slot_root": str(request_root / "reviewers" / "kimi-k2-6"),
+                    "prompt_path": str(request_root / "reviewers" / "kimi-k2-6" / "PROMPT.md"),
+                    "manifest_path": str(request_root / "reviewers" / "kimi-k2-6" / "manifest.json"),
+                },
+            ]
+            return {"ok": True, "worker_count": 2, "workers": workers}
+        if args[0] == "aggregate":
+            request_root = Path(args[args.index("--request") + 1])
+            return {
+                "ok": True,
+                "aggregate_path": str(request_root / "aggregate"),
+                "reviewers_total": 2,
+                "reviewers_complete": 2,
+                "reviewers_incomplete": 0,
+            }
+        raise AssertionError(args)
+
+    def fake_execute_workers(**kwargs):
+        evidence_root = kwargs["request_root"] / "runner" / "mms-execute" / "test"
+        evidence_root.mkdir(parents=True, exist_ok=True)
+        results = []
+        for index, worker in enumerate(kwargs["workers"], start=1):
+            stdout_path = evidence_root / f"worker-{index}.stdout.txt"
+            stderr_path = evidence_root / f"worker-{index}.stderr.txt"
+            stdout_path.write_text("ok\n", encoding="utf-8")
+            stderr_path.write_text("", encoding="utf-8")
+            results.append(
+                {
+                    "order": index,
+                    "model": worker["model_name"],
+                    "agent": f"review-{worker['model_slug']}",
+                    "returncode": 0,
+                    "stdout_path": str(stdout_path),
+                    "stderr_path": str(stderr_path),
+                }
+            )
+        return {
+            "schema": mms_review_dispatch.REVIEW_DISPATCH_EXECUTE_SCHEMA,
+            "ok": True,
+            "mode": kwargs["mode"],
+            "evidence_root": str(evidence_root),
+            "worker_count": len(results),
+            "workers": results,
+            "errors": [],
+            "returncode": 0,
+        }
+
+    monkeypatch.setattr(mms_review_dispatch, "_run_review_hub", fake_run_review_hub)
+    monkeypatch.setattr(mms_review_dispatch, "_execute_review_workers", fake_execute_workers)
+
+    code = handle_review_dispatch_command(
+        [
+            "--root",
+            str(root),
+            "--request-id",
+            "execute-review",
+            "--model",
+            "qwen3.7-max",
+            "--model",
+            "kimi-k2.6",
+            "--execute",
+            "--json",
+        ],
+        command_name="mmf",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["executed"] is True
+    assert payload["execute"]["mode"] == "workers"
+    assert payload["execute"]["worker_count"] == 2
+    assert payload["reviewers_complete"] == 2
+    assert payload["reviewers_incomplete"] == 0
+    assert payload["verdict"] == "complete"
+    for worker in payload["execute"]["workers"]:
+        assert worker["returncode"] == 0
+        assert Path(worker["stdout_path"]).exists()
+        assert Path(worker["stderr_path"]).exists()
+
+
+def test_review_dispatch_execute_reports_worker_failure(tmp_path, monkeypatch, capsys):
+    import mms_review_dispatch
+    from mms_review_dispatch import handle_review_dispatch_command
+
+    root = _mission_root(tmp_path)
+    request_root = root / ".mission" / "review-dispatch" / "opencode" / "execute-failure"
+
+    def fake_run_review_hub(args):
+        if args[0] == "request":
+            return {"ok": True, "request_root": str(request_root)}
+        if args[0] == "worker-plan":
+            return {
+                "ok": True,
+                "worker_count": 1,
+                "workers": [
+                    {
+                        "order": 1,
+                        "model_name": "qwen3.7-max",
+                        "model_slug": "qwen3-7-max",
+                        "slot_root": str(request_root / "reviewers" / "qwen3-7-max"),
+                    }
+                ],
+            }
+        if args[0] == "aggregate":
+            return {
+                "ok": True,
+                "aggregate_path": str(request_root / "aggregate"),
+                "reviewers_total": 1,
+                "reviewers_complete": 0,
+                "reviewers_incomplete": 1,
+            }
+        raise AssertionError(args)
+
+    def fake_execute_workers(**kwargs):
+        evidence_root = kwargs["request_root"] / "runner" / "mms-execute" / "failure"
+        evidence_root.mkdir(parents=True, exist_ok=True)
+        stderr_path = evidence_root / "worker-1.stderr.txt"
+        stderr_path.write_text("boom\n", encoding="utf-8")
+        stdout_path = evidence_root / "worker-1.stdout.txt"
+        stdout_path.write_text("", encoding="utf-8")
+        return {
+            "schema": mms_review_dispatch.REVIEW_DISPATCH_EXECUTE_SCHEMA,
+            "ok": False,
+            "mode": "workers",
+            "evidence_root": str(evidence_root),
+            "worker_count": 1,
+            "workers": [
+                {
+                    "order": 1,
+                    "model": "qwen3.7-max",
+                    "agent": "review-qwen3-7-max",
+                    "returncode": 7,
+                    "stdout_path": str(stdout_path),
+                    "stderr_path": str(stderr_path),
+                }
+            ],
+            "errors": ["opencode worker failed: model=qwen3.7-max exit=7"],
+            "returncode": 1,
+        }
+
+    monkeypatch.setattr(mms_review_dispatch, "_run_review_hub", fake_run_review_hub)
+    monkeypatch.setattr(mms_review_dispatch, "_execute_review_workers", fake_execute_workers)
+
+    code = handle_review_dispatch_command(
+        [
+            "--root",
+            str(root),
+            "--request-id",
+            "execute-failure",
+            "--model",
+            "qwen3.7-max",
+            "--execute",
+            "--json",
+        ],
+        command_name="mmf",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["execute"]["workers"][0]["returncode"] == 7
+    assert Path(payload["execute"]["workers"][0]["stderr_path"]).exists()
+    assert "opencode worker failed: model=qwen3.7-max exit=7" in payload["errors"]
+    assert payload["reviewers_incomplete"] == 1
+    assert payload["verdict"] == "incomplete"

--- a/tests/test_review_dispatch.py
+++ b/tests/test_review_dispatch.py
@@ -611,7 +611,7 @@ def test_review_dispatch_execute_runs_workers_and_aggregate(tmp_path, monkeypatc
     assert payload["execute"]["worker_count"] == 2
     assert payload["reviewers_complete"] == 2
     assert payload["reviewers_incomplete"] == 0
-    assert payload["verdict"] == "complete"
+    assert payload["verdict"] == "complete_no_verdict"
     for worker in payload["execute"]["workers"]:
         assert worker["returncode"] == 0
         assert Path(worker["stdout_path"]).exists()
@@ -703,3 +703,182 @@ def test_review_dispatch_execute_reports_worker_failure(tmp_path, monkeypatch, c
     assert "opencode worker failed: model=qwen3.7-max exit=7" in payload["errors"]
     assert payload["reviewers_incomplete"] == 1
     assert payload["verdict"] == "incomplete"
+
+
+def test_review_dispatch_execute_host_mode_is_plumbed(tmp_path, monkeypatch, capsys):
+    import mms_review_dispatch
+    from mms_review_dispatch import handle_review_dispatch_command
+
+    root = _mission_root(tmp_path)
+    request_root = root / ".mission" / "review-dispatch" / "opencode" / "execute-host"
+    seen: dict[str, object] = {}
+
+    def fake_run_review_hub(args):
+        if args[0] == "request":
+            return {"ok": True, "request_root": str(request_root)}
+        if args[0] == "worker-plan":
+            return {"ok": True, "worker_count": 1, "workers": []}
+        if args[0] == "aggregate":
+            return {
+                "ok": True,
+                "aggregate_path": str(request_root / "aggregate"),
+                "reviewers_total": 1,
+                "reviewers_complete": 1,
+                "reviewers_incomplete": 0,
+                "verdict": "host_complete",
+            }
+        raise AssertionError(args)
+
+    def fake_execute_workers(**kwargs):
+        seen.update(kwargs)
+        evidence_root = kwargs["request_root"] / "runner" / "mms-execute" / "host"
+        evidence_root.mkdir(parents=True, exist_ok=True)
+        stdout_path = evidence_root / "host.stdout.txt"
+        stderr_path = evidence_root / "host.stderr.txt"
+        stdout_path.write_text("ok\n", encoding="utf-8")
+        stderr_path.write_text("", encoding="utf-8")
+        return {
+            "schema": mms_review_dispatch.REVIEW_DISPATCH_EXECUTE_SCHEMA,
+            "ok": True,
+            "mode": "host",
+            "evidence_root": str(evidence_root),
+            "returncode": 0,
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "errors": [],
+        }
+
+    monkeypatch.setattr(mms_review_dispatch, "_run_review_hub", fake_run_review_hub)
+    monkeypatch.setattr(mms_review_dispatch, "_execute_review_workers", fake_execute_workers)
+
+    code = handle_review_dispatch_command(
+        [
+            "--root",
+            str(root),
+            "--request-id",
+            "execute-host",
+            "--model",
+            "qwen3.7-max",
+            "--execute",
+            "--mode",
+            "host",
+            "--host-agent",
+            "review-hub-host-stable",
+            "--host-timeout",
+            "33",
+            "--json",
+        ],
+        command_name="mmf",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert payload["ok"] is True
+    assert payload["execute"]["mode"] == "host"
+    assert payload["verdict"] == "host_complete"
+    assert seen["mode"] == "host"
+    assert seen["host_agent"] == "review-hub-host-stable"
+    assert seen["host_timeout"] == 33
+
+
+def test_review_dispatch_execute_propagates_aggregate_ok_false(tmp_path, monkeypatch, capsys):
+    import mms_review_dispatch
+    from mms_review_dispatch import handle_review_dispatch_command
+
+    root = _mission_root(tmp_path)
+    request_root = root / ".mission" / "review-dispatch" / "opencode" / "aggregate-failure"
+
+    def fake_run_review_hub(args):
+        if args[0] == "request":
+            return {"ok": True, "request_root": str(request_root)}
+        if args[0] == "worker-plan":
+            return {"ok": True, "worker_count": 1, "workers": []}
+        if args[0] == "aggregate":
+            return {
+                "ok": False,
+                "aggregate_path": str(request_root / "aggregate"),
+                "reviewers_total": 1,
+                "reviewers_complete": 1,
+                "reviewers_incomplete": 0,
+                "error": "aggregate writer failed",
+            }
+        raise AssertionError(args)
+
+    def fake_execute_workers(**kwargs):
+        return {
+            "schema": mms_review_dispatch.REVIEW_DISPATCH_EXECUTE_SCHEMA,
+            "ok": True,
+            "mode": "workers",
+            "evidence_root": str(kwargs["request_root"] / "runner" / "mms-execute" / "ok"),
+            "worker_count": 0,
+            "workers": [],
+            "errors": [],
+            "returncode": 0,
+        }
+
+    monkeypatch.setattr(mms_review_dispatch, "_run_review_hub", fake_run_review_hub)
+    monkeypatch.setattr(mms_review_dispatch, "_execute_review_workers", fake_execute_workers)
+
+    code = handle_review_dispatch_command(
+        [
+            "--root",
+            str(root),
+            "--request-id",
+            "aggregate-failure",
+            "--model",
+            "qwen3.7-max",
+            "--execute",
+            "--json",
+        ],
+        command_name="mmf",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert code == 2
+    assert payload["ok"] is False
+    assert payload["aggregate"]["ok"] is False
+    assert "review-hub aggregate failed: aggregate writer failed" in payload["errors"]
+    assert payload["verdict"] == "complete_no_verdict"
+
+
+def test_review_dispatch_execute_missing_agent_fails_closed(tmp_path, monkeypatch):
+    import mms_review_dispatch_execute
+
+    class FakeSmoke:
+        @staticmethod
+        def _build_temp_env(runtime, model_info, temp_root):
+            return {}, temp_root / "opencode.json", {"agent": {"review-hub-host": {"model": "mms/qwen3.7-max"}}}
+
+    def fake_resolve_profile(models, evidence_root):
+        return FakeSmoke(), {"model": "qwen3.7-max"}, {}
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("opencode run should not be called when reviewer agent is missing")
+
+    monkeypatch.setattr(mms_review_dispatch_execute, "_resolve_review_profile_for_execute", fake_resolve_profile)
+    monkeypatch.setattr(mms_review_dispatch_execute, "_run_process_with_evidence", fail_if_called)
+
+    request_root = tmp_path / "request"
+    result = mms_review_dispatch_execute.execute_review_workers(
+        root=tmp_path,
+        request_root=request_root,
+        models=["qwen3.7-max"],
+        workers=[
+            {
+                "model_name": "qwen3.7-max",
+                "model_slug": "qwen3-7-max",
+                "slot_root": str(request_root / "reviewers" / "qwen3-7-max"),
+            }
+        ],
+        mode="workers",
+        host_agent="review-hub-host",
+        host_timeout=30,
+        worker_timeout=30,
+    )
+
+    assert result["ok"] is False
+    assert result["workers"][0]["returncode"] == 127
+    assert result["workers"][0]["agent"] == ""
+    assert result["workers"][0]["command"] == []
+    assert "no OpenCode review agent found" in result["errors"][0]
+    assert "review-hub-host" in result["workers"][0]["stderr_tail"]


### PR DESCRIPTION
## What changed

- Add `mmf/mms review-dispatch --execute --mode workers --json` as a stable noninteractive Review Hub execution surface.
- Keep `--launch` as the legacy interactive OpenCode Review profile launch path.
- Add `mms_review_dispatch_execute.py` to resolve the generated `review` profile, run one `opencode run --pure --agent review-*` per worker, capture per-worker stdout/stderr/returncode evidence, and aggregate results.
- Clarify the Review profile boundary: concrete artifact review only; no `committee_policy`, formal votes, gate ratification, blind-seed/crossfire, or debate resolution inside Review.
- Document routing between `agent`, `review`, `committee`, `debate`, `omo`, and `raw`.

## Why

Flywheel needs a synchronous/background-safe Review Hub path that returns reviewer completion and aggregate status. The previous `--launch` path only opened an interactive Review profile and could fail without running workers or writing aggregate evidence.

Fixes #81.

## Validation

- `python3 -m py_compile mms_review_dispatch.py mms_review_dispatch_execute.py mms_opencode_agents.py tests/test_review_dispatch.py tests/test_opencode_launcher.py`
- `rtk pytest -q tests/test_review_dispatch.py` -> 18 passed
- `rtk pytest -q tests/test_review_dispatch.py tests/test_opencode_launcher.py -k 'review_dispatch or review_profile_builds_review_hub_roster or profiles_are_fixed_launch_shapes'` -> 20 passed
- Dry execute smoke: `ok=true`, `execute_requested=true`, `execute_mode=workers`
- Live execute smoke with temporary copied `MMS_CONFIG_ROOT`: `ok=true`, `reviewers_total=3`, `reviewers_complete=3`, `reviewers_incomplete=0`, `verdict=complete`

## Notes

- Live smoke artifacts are local/ignored under `.ai/review-dispatch-smoke/issue-81-live-smoke-20260620T161800Z/`.
- Regression report is local/ignored at `.ai/regression-reports/2026-06-21-review-dispatch-execute.md`.
- No intended writes to real `~/.config/mms` or `~/.config/mms-next`; live smoke used a temp copied config root.
