### PR TITLE
[codex] fix flywheel CN lane wire evidence

### DIFF
--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -2221,6 +2221,97 @@ def _extract_usage(payload):
     return inp, out
 
 
+def _extract_usage_detail(payload):
+    """Extract a paste-safe token usage snapshot from common provider payloads."""
+    detail = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cached_tokens": 0,
+    }
+    if not isinstance(payload, dict):
+        return detail
+    usage_candidates = []
+    for container in (payload, payload.get("response", {}), payload.get("message", {})):
+        if isinstance(container, dict):
+            usage = container.get("usage")
+            if isinstance(usage, dict):
+                usage_candidates.append(usage)
+    for usage in usage_candidates:
+        for target, keys in {
+            "input_tokens": ("input_tokens", "prompt_tokens"),
+            "output_tokens": ("output_tokens", "completion_tokens"),
+            "cache_read_input_tokens": ("cache_read_input_tokens",),
+            "cache_creation_input_tokens": ("cache_creation_input_tokens",),
+            "cached_tokens": ("cached_tokens", "cache_read_tokens", "cache_tokens"),
+        }.items():
+            for key in keys:
+                value = usage.get(key)
+                if isinstance(value, (int, float)):
+                    detail[target] = max(detail[target], int(value))
+        prompt_details = usage.get("prompt_tokens_details")
+        if isinstance(prompt_details, dict):
+            cached = prompt_details.get("cached_tokens")
+            if isinstance(cached, (int, float)):
+                detail["cached_tokens"] = max(detail["cached_tokens"], int(cached))
+    return detail
+
+
+def _extract_response_model(payload):
+    if not isinstance(payload, dict):
+        return ""
+    for container in (payload, payload.get("message", {}), payload.get("response", {})):
+        if isinstance(container, dict):
+            model = str(container.get("model") or "").strip()
+            if model:
+                return model
+    return ""
+
+
+def _merge_wire_usage(server, detail):
+    if not server or not isinstance(detail, dict):
+        return
+    current = getattr(server, "wire_usage", None)
+    if not isinstance(current, dict):
+        current = _extract_usage_detail({})
+    for key in current:
+        value = detail.get(key)
+        if isinstance(value, (int, float)):
+            current[key] = max(int(current.get(key) or 0), int(value))
+    server.wire_usage = current
+
+
+def _record_wire_response(
+    server,
+    payload,
+    *,
+    request_model="",
+    provider_id="",
+    protocol="",
+    request_path="",
+    fallback_used=False,
+    fallback_reason="",
+):
+    if not server:
+        return
+    model = _extract_response_model(payload)
+    if model:
+        server.last_response_model = model
+    if request_model:
+        server.last_requested_model = request_model
+    if provider_id:
+        server.last_provider_id = provider_id
+    if protocol:
+        server.last_protocol = protocol
+    if request_path:
+        server.last_request_path = request_path
+    server.last_fallback_used = bool(fallback_used)
+    if fallback_reason:
+        server.last_fallback_reason = fallback_reason
+    _merge_wire_usage(server, _extract_usage_detail(payload))
+
+
 def _accumulate_usage(server, payload):
     """累加到 server 级 session 统计。"""
     inp, out = _extract_usage(payload)
@@ -2264,6 +2355,7 @@ def _record_bridge_speed(model_name, *, started_ms, first_byte_ms, output_tokens
         server.session_request_count += 1
         server.session_output_tokens += (output_tokens or 0)
         server.session_input_tokens += (input_tokens or 0)
+        server.last_requested_model = str(model_name or "")
     if first_byte_ms is None:
         return
     total_ms = max(0.0, _now_ms() - started_ms)
@@ -3559,7 +3651,9 @@ class _GatewayBridgeHandler(BaseHTTPRequestHandler):
         incoming_model = payload.get("model") if isinstance(payload, dict) else ""
         if heavy_model and "model" in payload:
             heavy_base_model = str(heavy_model or "").replace(_ONE_M_CONTEXT_SUFFIX, "").strip()
-            if _is_claude_shell_model(incoming_model):
+            if getattr(self.server, "force_heavy_model", False):
+                payload["model"] = heavy_model
+            elif _is_claude_shell_model(incoming_model):
                 payload["model"] = heavy_model
             elif (
                 _model_requests_mimo_1m_context(
@@ -3841,6 +3935,14 @@ class _GatewayBridgeHandler(BaseHTTPRequestHandler):
                 else:
                     path_suffix = path
                 target_url = _gw + path_suffix
+                metrics_model = str(route_payload.get("model") or "")
+                request_path = _fallback_safe_url(target_url)
+                self.server.last_requested_model = metrics_model
+                self.server.last_provider_id = str(route_provider_id or "")
+                self.server.last_protocol = "anthropic_messages"
+                self.server.last_request_path = request_path
+                self.server.last_fallback_used = route_index > 0
+                self.server.last_fallback_reason = str(route.get("fallback_reason") or "") if route_index > 0 else ""
 
                 fwd_headers = {
                     "Content-Type": "application/json",
@@ -3876,7 +3978,6 @@ class _GatewayBridgeHandler(BaseHTTPRequestHandler):
                 if has_routing:
                     stream = False
                     route_payload["stream"] = False
-                metrics_model = str(route_payload.get("model") or "")
                 route_started_ms = _now_ms()
                 first_byte_ms = None
                 output_tokens = None
@@ -3974,6 +4075,16 @@ class _GatewayBridgeHandler(BaseHTTPRequestHandler):
                                         except json.JSONDecodeError:
                                             event_payload = None
                                         if event_payload:
+                                            _record_wire_response(
+                                                self.server,
+                                                event_payload,
+                                                request_model=metrics_model,
+                                                provider_id=route_provider_id,
+                                                protocol="anthropic_messages",
+                                                request_path=request_path,
+                                                fallback_used=route_index > 0,
+                                                fallback_reason=str(route.get("fallback_reason") or "") if route_index > 0 else "",
+                                            )
                                             extracted = _extract_output_tokens(event_payload)
                                             if extracted is not None:
                                                 output_tokens = extracted
@@ -4084,6 +4195,16 @@ class _GatewayBridgeHandler(BaseHTTPRequestHandler):
                             response_payload = json.loads(body_out.decode("utf-8"))
                         except Exception:
                             response_payload = None
+                        _record_wire_response(
+                            self.server,
+                            response_payload,
+                            request_model=metrics_model,
+                            provider_id=route_provider_id,
+                            protocol="anthropic_messages",
+                            request_path=request_path,
+                            fallback_used=route_index > 0,
+                            fallback_reason=str(route.get("fallback_reason") or "") if route_index > 0 else "",
+                        )
                         self.server._last_reasoning_content = _anthropic_response_reasoning_content(response_payload)
                     if body_out:
                         try:
@@ -6497,6 +6618,7 @@ def codex_chatcompletions_bridge(
     server.session_output_tokens = 0
     server.session_request_count = 0
     server.session_start_time = time.time()
+    server.wire_usage = _extract_usage_detail({})
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -6505,6 +6627,7 @@ def codex_chatcompletions_bridge(
         yield {
             "base_url": f"http://127.0.0.1:{port}",
             "api_key": bridge_token,
+            "_server": server,
         }
     finally:
         try:
@@ -6562,6 +6685,11 @@ def codex_responses_bridge(
         server.rescue_fallback_cli = str(rescue_fallback_cli or "").strip()
     if rescue_hot_fallback_enabled is not None:
         server.rescue_hot_fallback_enabled = bool(rescue_hot_fallback_enabled)
+    server.session_input_tokens = 0
+    server.session_output_tokens = 0
+    server.session_request_count = 0
+    server.session_start_time = time.time()
+    server.wire_usage = _extract_usage_detail({})
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -6570,6 +6698,7 @@ def codex_responses_bridge(
         yield {
             "base_url": f"http://127.0.0.1:{port}",
             "api_key": bridge_token,
+            "_server": server,
         }
     finally:
         try:
@@ -6603,6 +6732,7 @@ def gateway_claude_bridge(
     native_fallback_routes=None,
     vision_sidecar=None,
     model_capabilities=None,
+    force_heavy_model=False,
     rescue_fallback_model="",
     rescue_fallback_cli="",
     rescue_hot_fallback_enabled=None,
@@ -6651,6 +6781,7 @@ def gateway_claude_bridge(
     server.native_fallback_routes = list(native_fallback_routes or [])
     server.vision_sidecar = dict(vision_sidecar or {})
     server.model_capabilities = dict(model_capabilities or {})
+    server.force_heavy_model = bool(force_heavy_model)
     _configure_bridge_rescue(server)
     if rescue_fallback_model:
         server.rescue_fallback_model = str(rescue_fallback_model or "").strip()
@@ -6667,6 +6798,7 @@ def gateway_claude_bridge(
     server.session_output_tokens = 0
     server.session_request_count = 0
     server.session_start_time = time.time()
+    server.wire_usage = _extract_usage_detail({})
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -52,7 +52,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "default": "flywheel.worker.default",
             "AI-P0": "flywheel.worker.default",
             "AI-P1": "flywheel.worker.default",
-            "AI-P2": "flywheel.worker.cn-glm",
+            "AI-P2": "flywheel.worker.cn-kimi",
             "AI-P3": "flywheel.worker.cn-qwen",
             "AI-P4": "flywheel.worker.cn-minimax",
         },
@@ -60,7 +60,7 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "default": "flywheel.fixer.default",
             "AI-P0": "flywheel.fixer.default",
             "AI-P1": "flywheel.fixer.default",
-            "AI-P2": "flywheel.fixer.cn-glm",
+            "AI-P2": "flywheel.fixer.cn-kimi",
             "AI-P3": "flywheel.fixer.cn-qwen",
             "AI-P4": "flywheel.fixer.cn-minimax",
         },
@@ -89,6 +89,16 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "fallback_model_by_provider": {
                 "us-cpa-local-codex": "gpt-5.5",
                 "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.worker.cn-kimi": {
+            "runtime": "claude",
+            "model": "kimi-for-coding",
+            "provider": "direct-kimi",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-company", "us-cpa-local-codex"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
             },
         },
         "flywheel.worker.cn-qwen": {
@@ -128,6 +138,16 @@ DEFAULT_FLYWHEEL_CONFIG: dict[str, Any] = {
             "fallback_model_by_provider": {
                 "us-cpa-local-codex": "gpt-5.5",
                 "newapi-company": "gpt-5.5",
+            },
+        },
+        "flywheel.fixer.cn-kimi": {
+            "runtime": "claude",
+            "model": "kimi-for-coding",
+            "provider": "direct-kimi",
+            "reasoning_effort": "medium",
+            "fallback_providers": ["newapi-personal-tokyo", "newapi-company", "us-cpa-local-codex"],
+            "fallback_model_by_provider": {
+                "us-cpa-local-codex": "gpt-5.5",
             },
         },
         "flywheel.fixer.cn-qwen": {
@@ -906,6 +926,107 @@ def _zero_cache_usage() -> dict[str, int]:
     }
 
 
+def _usage_total(usage: dict[str, Any]) -> int:
+    total = 0
+    for key in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens", "cached_tokens"):
+        try:
+            total += max(int(usage.get(key) or 0), 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _normalize_model_identity(model: str) -> str:
+    normalized = str(model or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return normalized.replace("[1m]", "").strip()
+
+
+def _model_identity_matches(expected: str, served: str) -> bool:
+    expected_norm = _normalize_model_identity(expected)
+    served_norm = _normalize_model_identity(served)
+    return bool(expected_norm and served_norm and expected_norm == served_norm)
+
+
+def _bridge_wire_evidence_from_server(
+    server: Any,
+    *,
+    expected_model: str,
+    provider_id: str,
+    protocol: str,
+    request_path: str,
+) -> dict[str, Any]:
+    usage = dict(getattr(server, "wire_usage", {}) or {}) if server is not None else {}
+    if not usage:
+        usage = _zero_cache_usage()
+    for key, value in list(usage.items()):
+        try:
+            usage[key] = max(int(value or 0), 0)
+        except (TypeError, ValueError):
+            usage[key] = 0
+    for key, fallback_attr in {
+        "input_tokens": "session_input_tokens",
+        "output_tokens": "session_output_tokens",
+    }.items():
+        try:
+            usage[key] = max(int(usage.get(key) or 0), int(getattr(server, fallback_attr, 0) or 0))
+        except (TypeError, ValueError):
+            pass
+    served_model = str(getattr(server, "last_response_model", "") or "").strip() if server is not None else ""
+    requested_model = str(getattr(server, "last_requested_model", "") or expected_model or "").strip() if server is not None else expected_model
+    request_count = 0
+    if server is not None:
+        try:
+            request_count = max(int(getattr(server, "session_request_count", 0) or 0), 0)
+        except (TypeError, ValueError):
+            request_count = 0
+    source = "wire_response" if served_model and _usage_total(usage) > 0 else "wire_response_missing"
+    return {
+        "schema": CACHE_TRANSPORT_EVIDENCE_SCHEMA,
+        "model": served_model or requested_model or expected_model,
+        "requested_model": requested_model,
+        "served_model": served_model,
+        "expected_model": expected_model,
+        "provider_id": str(getattr(server, "last_provider_id", "") or provider_id or "").strip() if server is not None else provider_id,
+        "protocol": str(getattr(server, "last_protocol", "") or protocol or "").strip() if server is not None else protocol,
+        "request_url": "",
+        "request_path": str(getattr(server, "last_request_path", "") or request_path or "").strip() if server is not None else request_path,
+        "route_source": "mms:wire",
+        "provider_profile": "",
+        "fallback_used": bool(getattr(server, "last_fallback_used", False)) if server is not None else False,
+        "fallback_reason": str(getattr(server, "last_fallback_reason", "") or "").strip() if server is not None else "",
+        "evidence_source": source,
+        "request_count": request_count,
+        "usage": usage,
+    }
+
+
+def _wire_evidence_verified(evidence: dict[str, Any], expected_model: str) -> tuple[bool, str]:
+    served_model = str(evidence.get("served_model") or evidence.get("model") or "").strip()
+    if not served_model:
+        return False, "missing_served_model"
+    if not _model_identity_matches(expected_model, served_model):
+        return False, "served_model_mismatch"
+    usage = evidence.get("usage") if isinstance(evidence.get("usage"), dict) else {}
+    if _usage_total(usage) <= 0:
+        return False, "missing_nonzero_usage"
+    return True, "verified"
+
+
+def _model_provenance(evidence: dict[str, Any], expected_model: str) -> dict[str, Any]:
+    verified, reason = _wire_evidence_verified(evidence, expected_model)
+    return {
+        "schema": "mms.flywheel_model_provenance.v1",
+        "expected_model": expected_model,
+        "served_model": str(evidence.get("served_model") or evidence.get("model") or "").strip(),
+        "evidence_source": str(evidence.get("evidence_source") or ""),
+        "usage_total": _usage_total(evidence.get("usage") if isinstance(evidence.get("usage"), dict) else {}),
+        "verified": verified,
+        "status": reason,
+    }
+
+
 def _transport_evidence_for_route(
     route: dict[str, Any],
     model: str,
@@ -1210,6 +1331,19 @@ def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd
         if not exe:
             raise FlywheelConfigError("codex executable not found")
         proc = subprocess.run(cmd, env=env, capture_output=True, text=True, check=False)
+        runtime["_wire_evidence_checked"] = True
+        evidence = _bridge_wire_evidence_from_server(
+            bridge_cfg.get("_server"),
+            expected_model=model,
+            provider_id=provider_id,
+            protocol=preferred_transport,
+            request_path=str(runtime.get("transport_request_path") or ""),
+        )
+        runtime["_wire_evidence"] = evidence
+        sink = runtime.get("_wire_evidence_sink") if isinstance(runtime.get("_wire_evidence_sink"), dict) else None
+        if sink is not None:
+            sink["checked"] = True
+            sink["evidence"] = evidence
         return proc.returncode, proc.stdout or "", proc.stderr or ""
 
 
@@ -1234,6 +1368,8 @@ def _pushd(path: Path):
 def _claude_shell_model(model: str, mms_launchers: Any) -> tuple[str, str]:
     if mms_launchers._is_claude_family_model_name(model):  # noqa: SLF001
         return model, ""
+    if _is_domestic_model(model):
+        return model, ""
     return "claude-sonnet-4-6", model
 
 
@@ -1252,7 +1388,9 @@ def _run_claude_headless(*, runtime: dict[str, Any], model: str, prompt: str, cw
 
     mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
     mms_launchers._ensure_speed_stats()  # noqa: SLF001 - keep launcher lazy imports initialized.
+    wire_evidence_sink = runtime.get("_wire_evidence_sink") if isinstance(runtime.get("_wire_evidence_sink"), dict) else None
     runtime = dict(runtime)
+    runtime.pop("_wire_evidence_sink", None)
     if sandbox == "danger-full-access":
         runtime["bypass"] = True
     provider_id = str(runtime.get("id") or runtime.get("provider_id") or "").strip()
@@ -1310,6 +1448,7 @@ def _run_claude_headless(*, runtime: dict[str, Any], model: str, prompt: str, cw
             "native_fallback_routes": native_fallback_routes,
             "vision_sidecar": vision_sidecar,
             "model_capabilities": model_capabilities,
+            "force_heavy_model": True,
             "context_windows": mms_launchers._context_windows_for_models(  # noqa: SLF001
                 model,
                 enable_claude_1m=mms_launchers._runtime_supports_claude_1m(runtime),  # noqa: SLF001
@@ -1348,6 +1487,18 @@ def _run_claude_headless(*, runtime: dict[str, Any], model: str, prompt: str, cw
             if not exe:
                 raise FlywheelConfigError("claude executable not found")
             proc = subprocess.run(cmd, cwd=str(cwd), env=env, capture_output=True, text=True, check=False)
+            runtime["_wire_evidence_checked"] = True
+            evidence = _bridge_wire_evidence_from_server(
+                bridge_cfg.get("_server"),
+                expected_model=model,
+                provider_id=provider_id,
+                protocol=str(runtime.get("preferred_transport") or "anthropic_messages"),
+                request_path=str(runtime.get("transport_request_path") or ""),
+            )
+            runtime["_wire_evidence"] = evidence
+            if wire_evidence_sink is not None:
+                wire_evidence_sink["checked"] = True
+                wire_evidence_sink["evidence"] = evidence
             return proc.returncode, proc.stdout or "", proc.stderr or ""
 
 
@@ -1451,6 +1602,8 @@ def run_flywheel_lane(
         _write_run_result_artifact(run_result_artifact, result)
         return result
 
+    wire_evidence_sink: dict[str, Any] = {}
+    runtime["_wire_evidence_sink"] = wire_evidence_sink
     runner = _run_codex_headless if runtime_kind == "codex" else _run_claude_headless
     rc, stdout_text, stderr_text = runner(
         runtime=runtime,
@@ -1459,6 +1612,18 @@ def run_flywheel_lane(
         cwd=workdir,
         sandbox=sandbox,
     )
+    wire_checked = bool(runtime.get("_wire_evidence_checked") or wire_evidence_sink.get("checked"))
+    if wire_checked:
+        wire_evidence = runtime.get("_wire_evidence") if isinstance(runtime.get("_wire_evidence"), dict) else {}
+        if not wire_evidence and isinstance(wire_evidence_sink.get("evidence"), dict):
+            wire_evidence = wire_evidence_sink["evidence"]
+        if wire_evidence:
+            transport_evidence = wire_evidence
+            result["cache_transport_evidence"] = wire_evidence
+            result["transport_evidence"] = [wire_evidence]
+            result["served_model"] = wire_evidence.get("served_model") or wire_evidence.get("model")
+            result["usage"] = wire_evidence.get("usage")
+            result["model_provenance"] = _model_provenance(wire_evidence, model)
     agent_text = _extract_codex_agent_text(stdout_text) if runtime_kind == "codex" else stdout_text
     if not agent_text and stdout_text:
         agent_text = stdout_text
@@ -1467,6 +1632,13 @@ def run_flywheel_lane(
     result["status"] = "completed" if rc == 0 else "failed"
     result["agent_text"] = agent_text
     result["stderr"] = stderr_text
+    provenance = result.get("model_provenance") if isinstance(result.get("model_provenance"), dict) else {}
+    if rc == 0 and wire_checked and not provenance.get("verified"):
+        result["ok"] = False
+        result["status"] = "wire_evidence_failed"
+        result["wire_evidence_error"] = provenance.get("status") or "missing_wire_evidence"
+        detail = f"flywheel wire evidence failed: {result['wire_evidence_error']}"
+        result["stderr"] = f"{stderr_text.rstrip()}\n{detail}\n".lstrip()
     _write_run_result_artifact(run_result_artifact, result)
     return result
 

--- a/tests/test_gateway_bridge_model_override.py
+++ b/tests/test_gateway_bridge_model_override.py
@@ -16,6 +16,7 @@ def _run_gateway_bridge_once(
     system: str | list[dict] | None = None,
     vision_sidecar: dict | None = None,
     model_capabilities: dict | None = None,
+    force_heavy_model: bool = False,
 ) -> dict:
     import mms_bridge
 
@@ -86,6 +87,7 @@ def _run_gateway_bridge_once(
         strip_upstream_user_agent=False,
         vision_sidecar=vision_sidecar or {},
         model_capabilities=model_capabilities or {},
+        force_heavy_model=force_heavy_model,
     )
     handler.send_response = lambda code: captured.setdefault("status", code)
     handler.send_header = lambda *args, **kwargs: None
@@ -108,6 +110,18 @@ def test_gateway_bridge_preserves_explicit_non_claude_model_selection(monkeypatc
 
     assert captured["status"] == 200
     assert captured["json"]["model"] == "mimo-v2.5-pro"
+
+
+def test_gateway_bridge_force_heavy_model_overrides_any_incoming_model(monkeypatch):
+    captured = _run_gateway_bridge_once(
+        monkeypatch,
+        "mimo-v2.5-pro",
+        heavy_model="qwen3.7-max",
+        force_heavy_model=True,
+    )
+
+    assert captured["status"] == 200
+    assert captured["json"]["model"] == "qwen3.7-max"
 
 
 def test_gateway_bridge_strips_claude_code_billing_system_cache_buster(monkeypatch):

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -185,6 +185,32 @@ def _seed_flywheel_tier_routes(root):
                     },
                 ],
             },
+            "kimi-for-coding": {
+                "primary": {
+                    "provider_id": "direct-kimi",
+                    "model_id": "kimi-for-coding",
+                    "anthropic_base_url": "https://kimi.example/coding",
+                    "openai_base_url": "https://kimi.example/v1",
+                    "api_key": "secret-kimi",
+                    "max_context_tokens": 262144,
+                },
+                "fallbacks": [
+                    {
+                        "provider_id": "newapi-personal-tokyo",
+                        "model_id": "kimi-for-coding",
+                        "anthropic_base_url": "https://tokyo.example/v1",
+                        "openai_base_url": "https://tokyo.example/v1",
+                        "api_key": "secret-tokyo",
+                    },
+                    {
+                        "provider_id": "newapi-company",
+                        "model_id": "kimi-for-coding",
+                        "anthropic_base_url": "https://company.example/v1",
+                        "openai_base_url": "https://company.example/v1",
+                        "api_key": "secret-company",
+                    },
+                ],
+            },
             "gpt-5.5": {
                 "primary": {
                     "provider_id": "uscrsopenai",
@@ -229,7 +255,7 @@ api_key = "secret-tokyo"
 openai_base_url = "https://tokyo.example/v1"
 anthropic_base_url = "https://tokyo.example/v1"
 protocols = ["anthropic_messages", "openai_chat_completions"]
-fallback_models = ["gpt-5.5", "qwen3.7-max", "glm-5.2", "MiniMax-M3"]
+fallback_models = ["gpt-5.5", "qwen3.7-max", "glm-5.2", "MiniMax-M3", "kimi-for-coding"]
 supported_clis = ["codex"]
 """.strip(),
         encoding="utf-8",
@@ -262,6 +288,8 @@ def test_default_worker_and_fixer_tiers_use_domestic_models_and_ordered_fallback
     worker_p4 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P4", config_root=str(root))
     fixer_p4 = mms_flywheel.resolve_flywheel_profile(lane="fixer", priority="AI-P4", config_root=str(root))
     worker_p2 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P2", config_root=str(root))
+    fixer_p2 = mms_flywheel.resolve_flywheel_profile(lane="fixer", priority="AI-P2", config_root=str(root))
+    explicit_glm = mms_flywheel.resolve_flywheel_profile(lane="worker", profile="flywheel.worker.cn-glm", config_root=str(root))
     worker_p0 = mms_flywheel.resolve_flywheel_profile(lane="worker", priority="AI-P0", config_root=str(root))
 
     assert worker_p3["profile_id"] == "flywheel.worker.cn-qwen"
@@ -275,9 +303,15 @@ def test_default_worker_and_fixer_tiers_use_domestic_models_and_ordered_fallback
     assert fixer_p4["profile_id"] == "flywheel.fixer.cn-minimax"
     assert fixer_p4["runtime_kind"] == "claude"
     assert fixer_p4["model"] == "MiniMax-M3"
-    assert worker_p2["profile_id"] == "flywheel.worker.cn-glm"
+    assert worker_p2["profile_id"] == "flywheel.worker.cn-kimi"
     assert worker_p2["runtime_kind"] == "claude"
-    assert worker_p2["model"] == "glm-5.2"
+    assert worker_p2["model"] == "kimi-for-coding"
+    assert worker_p2["provider_id"] == "direct-kimi"
+    assert fixer_p2["profile_id"] == "flywheel.fixer.cn-kimi"
+    assert fixer_p2["model"] == "kimi-for-coding"
+    assert explicit_glm["profile_id"] == "flywheel.worker.cn-glm"
+    assert explicit_glm["provider_id"] == "direct-zai"
+    assert explicit_glm["model"] == "glm-5.2"
     assert worker_p0["runtime_kind"] == "codex"
     assert [item["provider_id"] for item in worker_p3["fallback_routes"]] == [
         "newapi-personal-tokyo",
@@ -796,6 +830,109 @@ provider = "dual-qwen"
     assert captured["model"] == "qwen3.7-max"
 
 
+def test_run_result_promotes_verified_wire_evidence(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
+        runtime["_wire_evidence_checked"] = True
+        runtime["_wire_evidence"] = {
+            "schema": "cache_transport_evidence.v1",
+            "model": "qwen3.7-max",
+            "requested_model": "claude-sonnet-4-6",
+            "served_model": "qwen3.7-max",
+            "expected_model": "qwen3.7-max",
+            "provider_id": "direct-qwen",
+            "protocol": "anthropic_messages",
+            "request_url": "",
+            "request_path": "/apps/anthropic/v1/messages",
+            "route_source": "mms:wire",
+            "fallback_used": False,
+            "fallback_reason": "",
+            "evidence_source": "wire_response",
+            "request_count": 1,
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cached_tokens": 0,
+            },
+        }
+        return (0, "agent text", "")
+
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        runner_args=["exec", "fix this"],
+    )
+
+    assert result["ok"] is True
+    assert result["served_model"] == "qwen3.7-max"
+    assert result["usage"]["input_tokens"] == 12
+    assert result["cache_transport_evidence"]["evidence_source"] == "wire_response"
+    assert result["model_provenance"]["verified"] is True
+    artifact = json.loads(Path(result["run_result_path"]).read_text(encoding="utf-8"))
+    assert artifact["result"]["model_provenance"]["status"] == "verified"
+
+
+def test_run_result_fails_closed_on_wire_model_mismatch(tmp_path, monkeypatch):
+    root = tmp_path / "mms-next"
+    workdir = tmp_path / "work"
+    root.mkdir()
+    workdir.mkdir()
+    _seed_flywheel_tier_routes(root)
+
+    def fake_run_claude_headless(*, runtime, model, prompt, cwd, sandbox):
+        runtime["_wire_evidence_checked"] = True
+        runtime["_wire_evidence"] = {
+            "schema": "cache_transport_evidence.v1",
+            "model": "claude-sonnet-4-6",
+            "requested_model": "claude-sonnet-4-6",
+            "served_model": "claude-sonnet-4-6",
+            "expected_model": "qwen3.7-max",
+            "provider_id": "direct-qwen",
+            "protocol": "anthropic_messages",
+            "request_url": "",
+            "request_path": "/apps/anthropic/v1/messages",
+            "route_source": "mms:wire",
+            "fallback_used": False,
+            "fallback_reason": "",
+            "evidence_source": "wire_response",
+            "request_count": 1,
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 3,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cached_tokens": 0,
+            },
+        }
+        return (0, "agent text", "")
+
+    monkeypatch.setattr(mms_flywheel, "_run_claude_headless", fake_run_claude_headless)
+
+    result = mms_flywheel.run_flywheel_lane(
+        lane="worker",
+        priority="AI-P3",
+        config_root=str(root),
+        cwd=str(workdir),
+        runner_args=["exec", "fix this"],
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "wire_evidence_failed"
+    assert result["wire_evidence_error"] == "served_model_mismatch"
+    assert result["model_provenance"]["served_model"] == "claude-sonnet-4-6"
+
+
 def test_run_uses_legacy_secret_route_when_generated_route_is_sanitized(tmp_path, monkeypatch):
     root = tmp_path / "mms-next"
     workdir = tmp_path / "work"
@@ -953,11 +1090,12 @@ def test_claude_headless_uses_bridge_with_thinking_effort_and_context(tmp_path, 
     assert captured["bridge_gateway_url"] == "https://qwen.example/v1"
     assert captured["bridge_api_key"] == "secret-qwen"
     assert captured["bridge_kwargs"]["heavy_model"] == "qwen3.7-max"
+    assert captured["bridge_kwargs"]["force_heavy_model"] is True
     assert captured["bridge_kwargs"]["reasoning_enabled"] is False
     assert captured["bridge_kwargs"]["reasoning_effort"] == "xhigh"
     assert captured["bridge_kwargs"]["native_fallback_routes"] == runtime["native_fallback_routes"]
-    assert captured["env_kwargs"]["selected_model"] == "claude-sonnet-4-6"
-    assert captured["env_kwargs"]["display_model"] == "qwen3.7-max"
+    assert captured["env_kwargs"]["selected_model"] == "qwen3.7-max"
+    assert captured["env_kwargs"]["display_model"] == ""
     assert captured["env"]["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "777000"
     assert captured["env"]["CLAUDE_CODE_EFFORT_LEVEL"] == "max"
     assert captured["context_kwargs"]["context_window"] == 777000


### PR DESCRIPTION
## What Changed

- Records wire-level `served_model`, token `usage`, request metadata, and model provenance for `mmf flywheel run` artifacts.
- Fails closed as `wire_evidence_failed` when a successful flywheel run lacks verified wire evidence, has zero usage, or returns a different served model.
- Forces Claude-runtime domestic lanes to forward the resolved route model to the bridge, preventing Claude CLI shell defaults from serving Sonnet for Qwen/Kimi/MiniMax lanes.
- Moves default AI-P2 worker/fixer profiles from GLM to Kimi while keeping explicit GLM profiles available.

## Why

`run-result.json` previously could claim `model=qwen3.7-max` with `fallback_used=false` even when evidence came from the resolved route and usage was zero. That made domestic model capability validation untrustworthy. This PR makes model identity evidence come from the actual wire response instead.

Refs #48.

## Validation

Automated checks:

- `python3 -m py_compile mms_flywheel.py mms_bridge.py`
- `rtk pytest -q tests/test_native_fallback.py tests/test_mms_flywheel.py tests/test_gateway_bridge_model_override.py` -> 60 passed
- `python3 scripts/regression_fresh_user_gate.py --quick` -> PASS, inner pytest 64 passed

Full-chain capability proof on disposable `gbrain-memory#1` clones:

| priority | model | worker/fixer served | rc chain | usage_total worker/fixer |
|---|---|---|---|---:|
| AI-P2 | Kimi | `kimi-for-coding` / `kimi-for-coding` | `1 -> 0 -> 1 -> 0` | 238343 / 169979 |
| AI-P3 | Qwen | `qwen3.7-max` / `qwen3.7-max` | `1 -> 0 -> 1 -> 0` | 107121 / 56573 |
| AI-P4 | MiniMax | `MiniMax-M3` / `MiniMax-M3` | `1 -> 0 -> 1 -> 0` | 105536 / 86513 |

Artifact roots:

- `/tmp/mmf-kimi-profile-fullchain-20260624-132508`
- `/tmp/mmf-qwen-p3-fullchain-20260624-134304`
- `/tmp/mmf-minimax-p4-fullchain-20260624-134525`

GitHub evidence comments:

- https://github.com/CtriXin/multi-model-switch/issues/48#issuecomment-4786328222
- https://github.com/CtriXin/gbrain-memory/issues/1#issuecomment-4786328370
- https://github.com/CtriXin/gbrain-memory/pull/2#issuecomment-4786328474

## Safety Notes

- No real `~/.config/mms/**` or `~/.config/mms-next/**` writes were used for the capability probes; validation used temp HOME/config roots and explicit route artifacts.
- PR is draft so another agent/human can independently compare the landed diff against the full-chain artifacts before merge.
