### PR TITLE
fix(statusline): isolate route_status per gateway session; drop tier arrow

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -2415,11 +2415,16 @@ def _claude_gateway_home():
     return os.path.join(sessions_dir, str(os.getpid()))
 
 
-def _claude_route_status_paths():
+def _claude_route_status_paths(*, gateway_home=None):
+    # 优先用当前 launch 显式传入的 gateway_home（per-PID 会话隔离），
+    # 不读 ambient MMS_SESSION_HOME env（继承链不可靠，多 session 会串改）。
+    gh = str(gateway_home or "").strip()
+    if gh:
+        return [os.path.join(gh, ".config", "mms", "route_status.json")]
     if str(os.environ.get("MMS_CONFIG_ROOT") or os.environ.get("MMS_CONFIG_DIR") or "").strip():
         return [os.path.join(_resolve_mms_config_dir(), "route_status.json")]
-    gateway_home = _claude_gateway_home()
-    return [os.path.join(gateway_home, ".config", "mms", "route_status.json")]
+    fallback = _claude_gateway_home()
+    return [os.path.join(fallback, ".config", "mms", "route_status.json")]
 
 
 def _anthropic_cache_key(provider_id, configured_url):
@@ -9303,7 +9308,7 @@ def launch_claude(model_info, runtime, once=False, extra_args=None):
             _print_launch_step_done("gateway 健康检查", step_start)
 
         speed_scope = build_provider_speed_scope(runtime)
-        route_status_paths = _claude_route_status_paths()
+        route_status_paths = _claude_route_status_paths(gateway_home=_claude_gateway_home())
         probe_result = runtime.get("_launch_prefetched_probe")
         if probe_result is None:
             try:
@@ -10586,7 +10591,7 @@ def _claude_gateway_env(
         stale_callback=_finalize_claude_slot,
         timings=_timings,
     )
-    route_status_path = _claude_route_status_paths()[0]
+    route_status_path = _claude_route_status_paths(gateway_home=gateway_home)[0]
     os.makedirs(gateway_home, exist_ok=True)
     disabled_session_surfaces = runtime.get("disabled_session_surfaces")
     agent_pack = _runtime_agent_pack(runtime)

--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -134,12 +134,12 @@ pick_route_status_file() {
     [ -n "$best_path" ] && echo "$best_path"
 }
 
-_ROUTE_STATUS="$(pick_route_status_file)"
+# per-session 优先：MMS launch 时注入 MMS_ROUTE_STATUS_PATH 指向本 session 隔离文件
+_ROUTE_STATUS="${MMS_ROUTE_STATUS_PATH:-$(pick_route_status_file)}"
 route_tag=""
 if [[ "$HOME" == *"/.config/mms/claude-gateway/"* ]] && [ -n "$_ROUTE_STATUS" ] && [ -f "$_ROUTE_STATUS" ]; then
     route_age=$(( $(date +%s) - $(stat -f %m "$_ROUTE_STATUS" 2>/dev/null || echo 0) ))
     if [ "$route_age" -lt 600 ]; then
-        r_tier=$(jq -r '.tier // empty' "$_ROUTE_STATUS" 2>/dev/null)
         r_model=$(jq -r '.model // empty' "$_ROUTE_STATUS" 2>/dev/null)
         r_ctx=$(jq -r '.context_window_tokens // .context_window_size // empty' "$_ROUTE_STATUS" 2>/dev/null)
         if [ -n "$r_ctx" ] && [ "$r_ctx" != "null" ] && [ "$r_ctx" -gt 0 ] 2>/dev/null; then
@@ -147,13 +147,7 @@ if [[ "$HOME" == *"/.config/mms/claude-gateway/"* ]] && [ -n "$_ROUTE_STATUS" ] 
         fi
         if [ -n "$r_model" ]; then
             r_model_short=$(echo "$r_model" | sed 's/^claude-//;s/-[0-9]*-[0-9]*$//;s/-[0-9]*$//')
-            case "$r_tier" in
-                heavy)  route_tag="▲ ${r_model_short}" ;;
-                medium) route_tag="● ${r_model_short}" ;;
-                light)  route_tag="▼ ${r_model_short}" ;;
-                *)      route_tag="→ ${r_model_short}" ;;
-            esac
-            model_short="${route_tag}"
+            model_short="${r_model_short}"
         fi
     fi
 fi
@@ -268,29 +262,13 @@ ORANGE=$'\033[38;5;208m'
 PURPLE=$'\033[38;5;141m'
 TEAL=$'\033[38;5;80m'
 
-if [ -n "$route_tag" ]; then
-    case "$route_tag" in
-        ▼*)  MODEL_C="${BOLD}${GREEN}"  ;;
-        ●*)  MODEL_C="${BOLD}${YELLOW}" ;;
-        ▲*)  MODEL_C="${BOLD}${PURPLE}" ;;
-        *)
-              case "$route_tag" in
-                  *opus*)   MODEL_C="${BOLD}${PURPLE}" ;;
-                  *sonnet*) MODEL_C="${BOLD}${TEAL}"   ;;
-                  *haiku*)  MODEL_C="${BOLD}${GREEN}"  ;;
-                  *gpt*)    MODEL_C="${BOLD}${CYAN}"   ;;
-                  *kimi*)   MODEL_C="${BOLD}${YELLOW}" ;;
-                  *)        MODEL_C="${BOLD}${CYAN}"   ;;
-              esac ;;
-    esac
-else
-    case "$model_short" in
-        *Opus*)   MODEL_C="${BOLD}${PURPLE}" ;;
-        *Sonnet*) MODEL_C="${BOLD}${TEAL}"   ;;
-        *Haiku*)  MODEL_C="${BOLD}${GREEN}"  ;;
-        *)        MODEL_C="${BOLD}${CYAN}"   ;;
-    esac
-fi
+case "$model_short" in
+    *[Oo]pus*|*[Gg]lm*)   MODEL_C="${BOLD}${PURPLE}" ;;
+    *[Ss]onnet*)          MODEL_C="${BOLD}${TEAL}"   ;;
+    *[Hh]aiku*)           MODEL_C="${BOLD}${GREEN}"  ;;
+    *[Gg]pt*|*[Kk]imi*)   MODEL_C="${BOLD}${YELLOW}" ;;
+    *)                    MODEL_C="${BOLD}${CYAN}"   ;;
+esac
 
 if   [ "$pct" -ge 80 ]; then BAR_C="${RED}"
 elif [ "$pct" -ge 50 ]; then BAR_C="${YELLOW}"

--- a/tests/test_route_status_session_isolation.py
+++ b/tests/test_route_status_session_isolation.py
@@ -1,0 +1,56 @@
+"""Regression tests for route_status.json per-session isolation.
+
+Covers the committee blocker on issue #86: route_status path must come from
+the current launch's explicit gateway_home, not from ambient MMS_SESSION_HOME.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _paths(gateway_home=None):
+    import mms_launchers
+
+    return mms_launchers._claude_route_status_paths(gateway_home=gateway_home)
+
+
+def test_ignores_ambient_session_home_env(monkeypatch):
+    """显式 gateway_home 必须压过 ambient MMS_SESSION_HOME env。"""
+    monkeypatch.setenv("MMS_SESSION_HOME", "/tmp/ambient-session-home-PID-777")
+    monkeypatch.setenv("MMS_CONFIG_ROOT", "/tmp/ambient-config-root")
+
+    result = _paths(gateway_home="/tmp/explicit-gateway-home/1111")
+
+    assert len(result) == 1
+    assert result[0] == "/tmp/explicit-gateway-home/1111/.config/mms/route_status.json"
+    # ambient env 绝不能渗进来
+    assert "ambient-session-home" not in result[0]
+    assert "ambient-config-root" not in result[0]
+
+
+def test_multi_session_isolation():
+    """两个不同 gateway_home 必须算出两个不同 route_status 路径。"""
+    pid_a = "/tmp/gateway-home/s/7180"
+    pid_b = "/tmp/gateway-home/s/98400"
+
+    paths_a = _paths(gateway_home=pid_a)
+    paths_b = _paths(gateway_home=pid_b)
+
+    assert paths_a != paths_b
+    assert paths_a[0].endswith("/s/7180/.config/mms/route_status.json")
+    assert paths_b[0].endswith("/s/98400/.config/mms/route_status.json")
+
+
+def test_fallback_without_gateway_home_uses_config_root(monkeypatch):
+    """不传 gateway_home 时，退回到 MMS_CONFIG_ROOT 全局路径（非 gateway 场景）。"""
+    monkeypatch.setenv("MMS_CONFIG_ROOT", "/tmp/fallback-config-root")
+    monkeypatch.delenv("MMS_SESSION_HOME", raising=False)
+
+    with patch("mms_launchers._resolve_mms_config_dir", return_value="/tmp/fallback-config-root"):
+        result = _paths(gateway_home=None)
+
+    assert result[0] == "/tmp/fallback-config-root/route_status.json"


### PR DESCRIPTION
## Summary

Closes #86。修复多 gateway session 并发时 statusLine 模型名串改问题。

### 根因
`_claude_route_status_paths()` 在 gateway session 下读到全局 `MMS_CONFIG_ROOT`,所有 session 共享同一个 `route_status.json`,最后写入者覆盖前者 → statusLine 都显示同一模型名。

### 改动
- **`mms_launchers.py`** `_claude_route_status_paths(*, gateway_home=None)`:加显式 `gateway_home` 参数,优先于 ambient env;撤掉 `MMS_SESSION_HOME` 分支(committee 反对的 ambient 继承链)。两个调用点显式传入:
  - `launch_claude` (L9311):传 `_claude_gateway_home()`(per-PID 显式算)
  - `_claude_gateway_env` (L10594):传自己 reserve 的 `gateway_home`
  - `MMS_CONFIG_ROOT` 降为非 gateway fallback
- **`statusline-command.sh`**:优先读 `\$MMS_ROUTE_STATUS_PATH`(core 改完后自动指向 per-session);移除 tier 箭头(▲●▼→,负载均衡已下线);health 指示(◐ 等,来自 health-cache.json)保留。
- **`tests/test_route_status_session_isolation.py`**(新):覆盖 ambient env 忽略 + 多 session 隔离 + fallback。

### statusline UI 变化
- 旧:`[▲ glm-5.2 ◐]`(▲ = heavy tier)
- 新:`[glm-5.2 ◐]`(无箭头,health 保留)
- 颜色:glm → 紫,gpt/kimi → 黄,opus → 紫,sonnet → teal,haiku → 绿

## 未覆盖点(follow-up,低风险)

`mms_flywheel.py:1438` (Codex flywheel 路径) 调 `_claude_route_status_paths()` 仍不传 `gateway_home`,走 fallback。这是 Codex 域,Codex 的 session 隔离与 route_status 落点不在本次 Claude statusline scope 内。若后续 Codex 也需要 per-session route_status,再统一硬化。committee rereview (issue86-rereview-20260625-6e7c1a4b) 标注此点 optional。

## 验证

- [x] `python3 -m py_compile mms_launchers.py`
- [x] 新测试 3/3 通过
- [x] 清 session env 后 `test_route_status_session_isolation.py` + `test_mms_flywheel.py` 共 28 passed
- [x] statusline 渲染实测:`[glm-5.2]` 无箭头
- [ ] 双 gateway session 实测(建议 committee 或人工补一个 smoke)
- 注:`test_claude_isolation.py` 有 5 个预存在 failed(origin/dev 无本改动同样 failed,根因是 session `MMS_CONFIG_ROOT` env 污染测试,非本 PR 引入)

## Committee

- issue86-route-status-20260625-4b9f5c2a:10/10 REQUEST_CHANGES,要求撤 ambient env 用显式 gateway_home(已修)
- issue86-rereview-20260625-6e7c1a4b:COMMENT x2 / APPROVE x1 / REQUEST_CHANGES x0 / veto x0,blocker 已解

## Test plan

- [ ] 双 session 实测:两个 gateway session 各切不同模型,statusLine 各显示各的
- [ ] health 指示在新鲜 health-cache 下正常显示
- [ ] 非 gateway 场景 fallback 路径未回归