### PR TITLE
Fix relay JSON parser fallback

### DIFF
--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -2100,6 +2100,7 @@ def _should_try_chatcompletions_fallback(status_code, body_text):
     unsupported_markers = (
         "messages array is required",
         "field messages is required",
+        "request body must be valid json",
         "unsupported path",
         "route /",
         "not found",

--- a/tests/test_native_fallback.py
+++ b/tests/test_native_fallback.py
@@ -9,6 +9,23 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 
+def test_responses_json_parse_error_uses_chatcompletions_fallback():
+    import mms_bridge
+
+    assert mms_bridge._should_try_chatcompletions_fallback(
+        400,
+        '{"error":{"message":"Request body must be valid JSON"}}',
+    ) is True
+    assert mms_bridge._should_try_chatcompletions_fallback(
+        400,
+        '{"error":{"message":"input is required"}}',
+    ) is False
+    assert mms_bridge._should_try_chatcompletions_fallback(
+        422,
+        '{"error":{"message":"Request body must be valid JSON"}}',
+    ) is False
+
+
 def test_resolve_native_fallback_routes_finds_same_vendor_direct():
     from mms_native_fallback import resolve_native_fallback_routes
 


### PR DESCRIPTION
## Summary
- treat the observed upstream `400 Request body must be valid JSON` as a Responses transport compatibility signal
- reuse the existing Chat Completions fallback
- add positive and negative regression coverage

## Verification
- `python3 -m pytest -q tests/test_native_fallback.py` - 18 passed
- `python3 -m py_compile mms_bridge.py`
- `python3 scripts/regression_fresh_user_gate.py --quick` - 64 passed
- Pi committee: 4/4 members across GPT, Gemini, and Qwen; no blockers

## Residual Risk
- Existing six-hour bridge-mode cache applies after fallback; documented in committee evidence.