### PR TITLE
feat(pi): restore committee runtime and parent adapter

### DIFF
--- a/assets/session-assets/skills/pi-committee/SKILL.md
+++ b/assets/session-assets/skills/pi-committee/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pi-committee
+description: Dispatch the MMS isolated Pi multi-model committee and synthesize its evidence as the current parent. Use when the user explicitly invokes $pi-committee to ask Codex or Claude for independent multi-model review, debate, architecture analysis, bug diagnosis, or a committee verdict without OpenCode.
+---
+
+# Pi Committee
+
+Use the current Codex or Claude session as the parent. Dispatch ephemeral Pi `member-NN` workers, preserve every opinion, and synthesize the final conclusion yourself.
+
+## Boundaries
+
+- This is an opt-in repo-local skill source. Do not assume the MMS launcher auto-injected it; load this `SKILL.md` explicitly or call its runner only after the user requests Pi committee work.
+- Require an explicit verified MMS `config_root`; never fall back to a real/global root.
+- Keep the worker target read-only. Do not use this skill to authorize edits, deploys, messages, or other side effects.
+- Do not invoke OpenCode or start another parent/synthesizer.
+- Do not install this skill globally or edit MMS preferences/config.
+- Treat failed members, fallback use, and raw responses as evidence about coverage.
+
+## Dispatch
+
+Resolve `scripts/run_pi_committee.py` relative to this `SKILL.md`.
+
+1. Put a bounded mission in a UTF-8 task file. State the target, decision needed, evidence standard, and non-goals.
+2. Run a dry-run first and inspect the selected models, families, routes, and isolation block:
+
+```bash
+python3 <skill-dir>/scripts/run_pi_committee.py \
+  --config-root <explicit-mms-config-root> \
+  --task-file <mission-file> \
+  --cwd <read-only-target> \
+  --dry-run
+```
+
+3. If the plan matches the request, run the same command without `--dry-run`. Use `--output <artifact.json>` when durable evidence is needed.
+4. Use `--add-family`, `--add-model`, `--model`, or `--selection-profile balanced` only when the user or task evidence justifies changing the default frontier lineup.
+5. To resynthesize a saved raw committee result without provider calls, pass `--result <result.json>`.
+
+Do not ask for confirmation between dry-run and execution when the user already asked for committee dispatch and the plan stays within these boundaries.
+
+## Synthesize
+
+Read the returned `mms.pi_committee.parent_packet.v1` completely. Produce:
+
+1. `结论`: the parent decision first.
+2. `Committee health`: success/failure/raw/fallback coverage.
+3. `共识`: only claims independently supported by at least two members; cite `member_id` and `evidence_id`.
+4. `分歧`: preserve competing positions and explain which evidence is stronger.
+5. `独立发现`: useful single-member findings, clearly labeled as uncorroborated.
+6. `风险与建议`: actionable recommendation and remaining uncertainty.
+
+Follow `synthesis_contract.rules` from the packet. Never invent semantic consensus from string similarity, hide minority dissent, or drop raw/failed responses. Separate inspected evidence from parent inference.
+
+## Stop Conditions
+
+- Do not treat a dry-run packet as a committee verdict. If dispatch was authorized and the plan is safe, proceed to the real run; otherwise stop after the plan.
+- Report partial coverage when some members fail; synthesize the successful evidence only if it remains sufficient.
+- Stop and report the exact error when bundle verification, route preparation, or isolation fails. Do not recover through global OAuth/default accounts.

--- a/assets/session-assets/skills/pi-committee/agents/openai.yaml
+++ b/assets/session-assets/skills/pi-committee/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Pi Committee"
+  short_description: "派发独立 Pi 多模型委员并由当前 Parent 综合"
+  default_prompt: "Use $pi-committee to dispatch an isolated Pi model committee for this task and synthesize the evidence."
+policy:
+  allow_implicit_invocation: false

--- a/assets/session-assets/skills/pi-committee/scripts/run_pi_committee.py
+++ b/assets/session-assets/skills/pi-committee/scripts/run_pi_committee.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Locate the bundled MMS parent adapter and delegate without global writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+def _runner_from_root(root: Path) -> Path | None:
+    candidate = root.expanduser().resolve() / "scripts" / "pi_committee_parent.py"
+    return candidate if candidate.is_file() else None
+
+
+def _locate_runner() -> Path:
+    explicit = str(os.environ.get("MMS_PI_COMMITTEE_ROOT") or "").strip()
+    if explicit:
+        candidate = _runner_from_root(Path(explicit))
+        if candidate:
+            return candidate
+        raise RuntimeError("MMS_PI_COMMITTEE_ROOT has no scripts/pi_committee_parent.py")
+
+    source = Path(__file__).resolve()
+    for parent in source.parents:
+        candidate = _runner_from_root(parent)
+        if candidate:
+            return candidate
+
+    for command in ("mmf", "mmd", "mmg", "mmm", "mms"):
+        executable = shutil.which(command)
+        if not executable:
+            continue
+        resolved = Path(executable).resolve()
+        for parent in (resolved.parent, *resolved.parents):
+            candidate = _runner_from_root(parent)
+            if candidate:
+                return candidate
+    raise RuntimeError("cannot locate the MMS Pi committee parent adapter")
+
+
+def main() -> int:
+    try:
+        runner = _locate_runner()
+    except RuntimeError as exc:
+        error = {"schema": "mms.pi_committee.skill_error.v1", "status": "error", "error": str(exc)}
+        print(json.dumps(error, ensure_ascii=False), file=sys.stderr)
+        return 2
+    os.execv(sys.executable, [sys.executable, str(runner), *sys.argv[1:]])
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/PI_DYNAMIC_COMMITTEE.md
+++ b/docs/PI_DYNAMIC_COMMITTEE.md
@@ -77,11 +77,32 @@ python3 scripts/pi_committee.py \
 
 ## Parent 集成
 
-Parent 只需要完成两件事：
+Codex 或 Claude 可以显式调用 repo-local `$pi-committee` skill source。该 skill 位于 `assets/session-assets/skills/pi-committee/`，`allow_implicit_invocation` 为 `false`。当前实现不会自动注册或注入这个新 skill；Parent 必须明确读取该 `SKILL.md`，或直接调用它的 runner。这样既不安装进 `~/.codex/skills`、`~/.claude/skills`，也不修改 preferences、launcher 或 OpenCode。
+
+Parent adapter 可以直接派发任务并输出 `mms.pi_committee.parent_packet.v1`：
+
+```bash
+python3 scripts/pi_committee_parent.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task-file /path/to/mission.md \
+  --cwd /path/to/target-repo \
+  --output /path/to/parent-packet.json
+```
+
+也可以把已有 raw result 转成 parent packet，不发起 provider call：
+
+```bash
+python3 scripts/pi_committee_parent.py \
+  --result /path/to/pi-committee-result.json \
+  --output /path/to/parent-packet.json
+```
+
+Parent packet 保留完整 public plan、所有原始 member response、flattened evidence index、route health、failure/raw/fallback 状态和 synthesis contract。Parent 需要完成三件事：
 
 1. 生成 mission text 并调用 sidecar。
-2. 读取 `mms.pi_committee.result.v1`，根据各成员的 `verdict/findings/evidence` 做最终 synthesis。
+2. 完整读取 parent packet，包括失败和 raw response。
+3. 根据 `synthesis_contract` 输出 committee health、共识、分歧、独立发现、风险、建议和 confidence。
 
-Sidecar 本身不绑定 Codex 或 Claude，也不负责替 parent 做最终决策。这样可以随时更换 parent，worker runtime 不需要改名或重配。
+Adapter 不用 string similarity 假装推断 semantic consensus，也不会调用第八个 synthesis model。最终判断始终属于当前 Codex/Claude parent，因此可以随时更换 parent，worker runtime 不需要改名或重配。
 
 每个成功结果都包含 `cache_transport_evidence.v1`；发生 route fallback 时，每次 attempt 也保留独立 evidence。结果不会包含 API key。

--- a/docs/PI_DYNAMIC_COMMITTEE.md
+++ b/docs/PI_DYNAMIC_COMMITTEE.md
@@ -1,5 +1,7 @@
 # Pi Dynamic Committee
 
+For role-aware design/product/development/testing deliberation, use the opt-in [Pi Court](PI_COURT.md). For writable delegation, use the separate [Pi Executor](PI_EXECUTOR.md). This committee remains read-only by design.
+
 ## 结论
 
 MMS 提供一个独立、opt-in 的 Pi committee sidecar。它不经过 OpenCode，不注册到 `mms` 默认 launcher，也不读写默认全局配置。Codex、Claude 或普通脚本都可以把它当作同一个 JSON-in/JSON-out worker pool 使用。
@@ -16,7 +18,45 @@ MMS 提供一个独立、opt-in 的 Pi committee sidecar。它不经过 OpenCode
 - 每个 worker 使用临时 `HOME`、`XDG_*`、Pi agent/session 目录；任务结束自动删除。
 - API key 通过临时 environment variable 交给 Pi，`models.json` 只保存 `$ENV_NAME` 引用。
 - 默认工具只有 `read,grep,find,ls`，并关闭 session、context files、extensions、skills、prompt templates 和 themes。
-- Pi 通过仓库已有的 `scripts/pi-cli-wrapper.sh` 启动；首次运行只会把 npm package cache 放到本仓库 `.ai/cache/pi-npx`，不会做 global install。
+- Pi 通过仓库已有的 `scripts/pi-cli-wrapper.sh` 启动；首次运行只会把 npm package cache 放到本仓库 `.ai/cache/pi-npx`，不会做 global install。冷缓存下 wrapper 会先用 repo-local install lock 做一次轻量 prewarm，避免多 worker 同时让 `npx` 填充同一个 shared cache。
+
+## Worker watchdog
+
+Pi worker 是 agentic session，不是一次短 completion。实测中，读取 diff 和多个文件后再输出结构化评审，单个正常调用可以超过 110s；因此不能把短暂无 stdout 当成 provider 故障，也不能因为一批 `anthropic_messages` route 同时命中旧的 180s 上限，就把协议本身判坏。
+
+当前默认值按“慢但健康”校准：
+
+- member wall timeout：`900s`；同一 member 的 route fallback 共享这段预算。这个值来自重型 agentic review 的实测校准，不代表每个模型都能在 900s 内完成。
+- Kimi route-attempt timeout：默认每条 route 最多 `300s`，并按剩余 attempt 数公平收窄；Tokyo 超时后仍为 Tencent/direct 保留实际执行窗口。`--kimi-attempt-timeout 0` 可在明确的历史复现实验中关闭该 cap。
+- no-output idle timeout：`300s`。Pi JSON event 或 stderr 任意新字节都会刷新 activity；短于这个阈值的静默 provider call 不会被误杀。
+- retained stream tail / single event：`2 MiB`。累计的正常 newline-delimited Pi events 可以超过此值，runtime 只保留 bounded tail；只有单个无法分帧的 event/line 超限才返回 `output_limit`。这避免 `message_update` 的增长快照把健康 worker 误判为输出洪水。
+- exact consecutive repeated events：`32`；达到后返回 `repetition_limit`。
+- committee timeout：默认 `0=auto`，实际值为 `member wall × concurrency waves + 60s`。默认 7 member、并发 4 时是 `1860s`，确保第二波仍有完整 member budget。
+- quorum：默认 `0=disabled`。只有调用方显式设置 `--quorum-successes N` 时，达到 N 个成功并经过 `--quorum-grace` 后才取消剩余 worker；默认不会把一个成功意见当作委员会结论。
+
+每个 Pi 子进程都在独立 POSIX process group 中运行。watchdog 先向整个 group 发 `SIGTERM`，grace 结束后仍在原 group 的 descendant 会收到 `SIGKILL`；Pi 自身的 SIGTERM handler 也会清理它登记的 detached children。主动 `setsid()` 逃离原 group 的任意第三方进程不属于 OS process-group 保证范围。stream reader 与 supervisor 之间使用 bounded queue，极端输出会 backpressure 到 pipe，不会形成 unbounded Python queue。结果和 Parent packet 会保留 `terminal_reason`、elapsed、stdout/stderr bytes、repeat peak、是否 terminate/force-kill，以及 committee stop reason。即使 global deadline 或 opt-in quorum 触发，也会返回所有已完成结果和被取消 member 的明确状态。
+
+同一 member 的多个 route attempt 共享 wall budget，但不再用 `max(1, remaining)` 强行制造一秒 fallback。Kimi 的每个 attempt 还受独立 cap 约束，第一条 route 的 `wall_timeout` 不再等同于 member budget 耗尽。剩余预算不足一秒时，未启动的 route 会记录为 `status=skipped`、`terminal_reason=no_budget_remaining`、`started=false`、`budget_seconds=0`；它不会被标成 provider `wall_timeout`，也不会进入 `fallback_members`。真正启动的 attempt 会记录 `started=true` 和实际分配的 `budget_seconds`。
+
+timestamped latest-approved bundle 默认必须在 `30` 天 freshness window 内。校验顺序是 hash verification → bundle age gate → model selection；旧 root 中 hash 正确但已经漂移的 `kimi-k2.x` 不会再进入 provider dispatch。`--max-bundle-age-days 0` 只用于调用方明确要求的历史 replay。public plan 会保留 resolved `config_root`、manifest path、revision、age 和 freshness status，方便区分 Host 选错 root 与 provider/model 故障。
+
+可按单次 mission 调整，而不写任何全局配置：
+
+```bash
+python3 scripts/pi_committee_parent.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task-file /path/to/mission.md \
+  --cwd /path/to/target-repo \
+  --timeout 900 \
+  --kimi-attempt-timeout 300 \
+  --max-bundle-age-days 30 \
+  --idle-timeout 300 \
+  --max-output-bytes 2097152 \
+  --max-repeated-events 32 \
+  --committee-timeout 0
+```
+
+不建议仅因某个 protocol 较慢就缩短它的 timeout。应先看 member `watchdog` 和 attempt `cache_transport_evidence`，区分 `request_error`、真实 idle、wall budget 不足和输出异常。
 
 ## 使用方式
 
@@ -69,7 +109,7 @@ python3 scripts/pi_committee.py \
 ## Frontier 选择规则
 
 - MiniMax、GPT、Qwen、DeepSeek、GLM：先比较可识别的 model version，再比较同版本 variant。Qwen 默认 `max > plus > flash`；DeepSeek 默认 `flash > pro`。
-- Kimi：优先滚动的 `kimi-for-coding` channel；Gemini 优先滚动的 `flash-agent(high)` channel。
+- Kimi：优先 fresh bundle 中最新版本，例如真实模型 id `k3` 会排在 `kimi-k2.8-code` / `kimi-k2.7-code` 前；同版本再优先 coding/code 系列，不把旧 `kimi-for-coding` alias 固定成永久 champion。Pi committee 会把 Kimi route chain 重排为 Tokyo primary、Tencent fallback、direct later，并限制单 route 不能吞完整个 member budget。Gemini 优先滚动的 `flash-agent(high)` channel。
 - 同级时再参考 policy favorite/tier、context window、可用 route 数量。
 - unavailable、policy-hidden、非对话模型或无法生成 Pi route 的模型会 fail closed，不会偷用 global OAuth/default account。
 
@@ -77,7 +117,7 @@ python3 scripts/pi_committee.py \
 
 ## Parent 集成
 
-Codex 或 Claude 可以显式调用 repo-local `$pi-committee` skill source。该 skill 位于 `assets/session-assets/skills/pi-committee/`，`allow_implicit_invocation` 为 `false`。当前实现不会自动注册或注入这个新 skill；Parent 必须明确读取该 `SKILL.md`，或直接调用它的 runner。这样既不安装进 `~/.codex/skills`、`~/.claude/skills`，也不修改 preferences、launcher 或 OpenCode。
+Codex 或 Claude 可以显式调用 shared `$pi-committee` skill source；仓库内 `assets/session-assets/skills/pi-committee/` 保留可发布镜像，Codex/Claude discovery entry 使用 symlink 指向 canonical shared skill。`allow_implicit_invocation` 仍为 `false`，Parent 必须显式触发。该安装方式不修改 preferences、launcher、OpenCode 或真实 MMS config。
 
 Parent adapter 可以直接派发任务并输出 `mms.pi_committee.parent_packet.v1`：
 
@@ -97,11 +137,11 @@ python3 scripts/pi_committee_parent.py \
   --output /path/to/parent-packet.json
 ```
 
-Parent packet 保留完整 public plan、所有原始 member response、flattened evidence index、route health、failure/raw/fallback 状态和 synthesis contract。Parent 需要完成三件事：
+Parent packet 保留完整 public plan、所有原始 member response、flattened evidence index、route health、failure/raw/fallback 状态和 synthesis contract。`ready_for_synthesis` 不是“有一个成功就算 ready”：默认要求成功数达到 planned member 的 `50%`（向上取整），且多成员委员会至少需要两个成功；因此 `7` 人委员会至少 `4` 人成功，`1/7` 会明确返回 `insufficient_coverage`。Parent 需要完成三件事：
 
 1. 生成 mission text 并调用 sidecar。
 2. 完整读取 parent packet，包括失败和 raw response。
-3. 根据 `synthesis_contract` 输出 committee health、共识、分歧、独立发现、风险、建议和 confidence。
+3. 仅在 `ready_for_synthesis=true` 时，根据 `synthesis_contract` 输出 committee health、共识、分歧、独立发现、风险、建议和 confidence；否则只报告覆盖不足与失败证据。
 
 Adapter 不用 string similarity 假装推断 semantic consensus，也不会调用第八个 synthesis model。最终判断始终属于当前 Codex/Claude parent，因此可以随时更换 parent，worker runtime 不需要改名或重配。
 

--- a/docs/PI_DYNAMIC_COMMITTEE.md
+++ b/docs/PI_DYNAMIC_COMMITTEE.md
@@ -1,0 +1,87 @@
+# Pi Dynamic Committee
+
+## 结论
+
+MMS 提供一个独立、opt-in 的 Pi committee sidecar。它不经过 OpenCode，不注册到 `mms` 默认 launcher，也不读写默认全局配置。Codex、Claude 或普通脚本都可以把它当作同一个 JSON-in/JSON-out worker pool 使用。
+
+成员没有固定模型身份。每次 mission 创建 `member-01`、`member-02` 等临时成员，再从显式选定的 MMS latest-approved bundle 中动态绑定 model、provider、URL 和 API key。
+
+默认 `frontier` profile 会在每次 mission 启动时，从当前 bundle 为以下家族各选一个 champion：`MiniMax / GPT / Kimi / Gemini / Qwen / DeepSeek / GLM`。它保存的是选择规则，不是七个命名 agent；bundle 中出现更新版本后会重新计算。`model-policy` 的 visible/hide 规则仍然是硬约束。
+
+## 安全边界
+
+- 必须显式传入 `--config-root`；不会 fallback 到 `~/.config/mms`。
+- 先校验 latest-approved manifest 和所有 bundle file hashes，再读取 Router。
+- 不读取 SQLite、legacy route files 或 global OAuth/account state。
+- 每个 worker 使用临时 `HOME`、`XDG_*`、Pi agent/session 目录；任务结束自动删除。
+- API key 通过临时 environment variable 交给 Pi，`models.json` 只保存 `$ENV_NAME` 引用。
+- 默认工具只有 `read,grep,find,ls`，并关闭 session、context files、extensions、skills、prompt templates 和 themes。
+- Pi 通过仓库已有的 `scripts/pi-cli-wrapper.sh` 启动；首次运行只会把 npm package cache 放到本仓库 `.ai/cache/pi-npx`，不会做 global install。
+
+## 使用方式
+
+先用 dry-run 查看本次动态成员和 route binding，不发起模型请求：
+
+```bash
+python3 scripts/pi_committee.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task "评估当前实现的架构风险并给出证据" \
+  --cwd /path/to/target-repo \
+  --dry-run
+```
+
+不传 `--count` 时，默认执行七个 frontier family champions：
+
+```bash
+python3 scripts/pi_committee.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task-file /path/to/mission.md \
+  --cwd /path/to/target-repo \
+  --output /path/to/pi-committee-result.json
+```
+
+当前 frontier 家族顺序可以替换，也可以只给这一次临时加家族或模型：
+
+```bash
+python3 scripts/pi_committee.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task "增加 Claude，并额外复核 Qwen Plus" \
+  --cwd /path/to/target-repo \
+  --add-family Claude \
+  --add-model qwen3.7-plus
+```
+
+`--add-family` 追加该家族的当前 champion；`--add-model` 追加一个 exact model。两者都只影响本次 mission。若想改成通用的能力/家族多样性选择，可用 `--selection-profile balanced --count 4 --min-families 3`。
+
+如需人工指定本次 lineup，可以重复传 `--model`。这只是 mission-level binding，不会创建或保存 `committee-glm` 一类永久 agent：
+
+```bash
+python3 scripts/pi_committee.py \
+  --config-root /explicit/path/to/mms-config-root \
+  --task "独立复核这份方案" \
+  --cwd /path/to/target-repo \
+  --model qwen3.7-plus \
+  --model claude-sonnet-4-6
+```
+
+`--model` 是完整 lineup override，不能和 `--add-model` 混用。
+
+## Frontier 选择规则
+
+- MiniMax、GPT、Qwen、DeepSeek、GLM：先比较可识别的 model version，再比较同版本 variant。Qwen 默认 `max > plus > flash`；DeepSeek 默认 `flash > pro`。
+- Kimi：优先滚动的 `kimi-for-coding` channel；Gemini 优先滚动的 `flash-agent(high)` channel。
+- 同级时再参考 policy favorite/tier、context window、可用 route 数量。
+- unavailable、policy-hidden、非对话模型或无法生成 Pi route 的模型会 fail closed，不会偷用 global OAuth/default account。
+
+这套顺序来自一次真实同任务 A/B 基线，只用于设置初始默认值。单次任务中的漏检或 JSON 格式错误不会永久降级某个模型；长期自适应需要累计多任务 health evidence 后再做。
+
+## Parent 集成
+
+Parent 只需要完成两件事：
+
+1. 生成 mission text 并调用 sidecar。
+2. 读取 `mms.pi_committee.result.v1`，根据各成员的 `verdict/findings/evidence` 做最终 synthesis。
+
+Sidecar 本身不绑定 Codex 或 Claude，也不负责替 parent 做最终决策。这样可以随时更换 parent，worker runtime 不需要改名或重配。
+
+每个成功结果都包含 `cache_transport_evidence.v1`；发生 route fallback 时，每次 attempt 也保留独立 evidence。结果不会包含 API key。

--- a/mms_pi_committee.py
+++ b/mms_pi_committee.py
@@ -1,0 +1,1298 @@
+"""Opt-in dynamic Pi committee runtime.
+
+This module is deliberately separate from the MMS launcher and OpenCode paths.
+It consumes an explicitly selected, hash-verified latest-approved bundle and
+spawns isolated, read-only Pi workers with runtime-bound model routes.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import contextlib
+import json
+import os
+import re
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import urlsplit, urlunsplit
+
+import mms_consumer_bundle
+
+
+DEFAULT_MEMBER_COUNT = 4
+DEFAULT_MIN_FAMILIES = 3
+DEFAULT_MAX_CONCURRENCY = 4
+DEFAULT_TIMEOUT_SECONDS = 180
+DEFAULT_SELECTION_PROFILE = "frontier"
+DEFAULT_FRONTIER_FAMILIES = (
+    "MiniMax",
+    "GPT",
+    "Kimi",
+    "Gemini",
+    "Qwen",
+    "DeepSeek",
+    "GLM",
+)
+DEFAULT_LENSES = (
+    "architecture",
+    "failure-risk",
+    "implementation",
+    "verification",
+    "counterexample",
+    "maintainability",
+)
+READ_ONLY_TOOLS = "read,grep,find,ls"
+_OPENAI_FAMILY_PREFIXES = ("gpt-", "o1", "o3", "o4", "codex-")
+_SECRET_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{12,}\b"),
+)
+
+
+class CommitteeError(RuntimeError):
+    """Raised when the committee cannot be planned or run safely."""
+
+
+@dataclass(frozen=True)
+class RouteBinding:
+    model: str
+    wire_model: str
+    provider_id: str
+    protocol: str
+    base_url: str
+    request_url: str
+    request_path: str
+    api_key: str = field(repr=False)
+    provider_profile: str = ""
+    protocol_fallback_reason: str = ""
+    fallback_position: int = 0
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "provider_id": self.provider_id,
+            "wire_model": self.wire_model,
+            "protocol": self.protocol,
+            "request_url": _redact_url(self.request_url),
+            "request_path": self.request_path,
+            "provider_profile": self.provider_profile,
+            "protocol_fallback_reason": self.protocol_fallback_reason,
+            "fallback_position": self.fallback_position,
+        }
+
+
+@dataclass(frozen=True)
+class ModelCandidate:
+    model: str
+    family: str
+    capabilities: Mapping[str, Any]
+    context_window_tokens: int
+    favorite: bool
+    tier: str
+    route_chain: tuple[RouteBinding, ...]
+
+
+@dataclass(frozen=True)
+class MemberSpec:
+    member_id: str
+    lens: str
+    candidate: ModelCandidate
+
+    def public(self) -> dict[str, Any]:
+        return {
+            "member_id": self.member_id,
+            "lens": self.lens,
+            "model": self.candidate.model,
+            "family": self.candidate.family,
+            "context_window_tokens": self.candidate.context_window_tokens,
+            "route_chain": [binding.public() for binding in self.candidate.route_chain],
+        }
+
+
+@dataclass(frozen=True)
+class PreparedAttempt:
+    binding: RouteBinding
+    models_payload: Mapping[str, Any]
+    provider_ref: str
+    selected_model: str
+
+
+def load_catalog(config_root: str | os.PathLike[str]) -> dict[str, Any]:
+    root = Path(config_root).expanduser()
+    try:
+        bundle = mms_consumer_bundle.load_verified_consumer_bundle(
+            config_root=root,
+            include_secret=True,
+            env={},
+            allow_default_root=False,
+        )
+    except mms_consumer_bundle.ConsumerBundleError as exc:
+        raise CommitteeError(str(exc)) from exc
+    payloads = bundle.get("payloads") if isinstance(bundle.get("payloads"), dict) else {}
+    router = payloads.get("router") if isinstance(payloads.get("router"), dict) else {}
+    if not isinstance(router.get("routes"), dict) or not router["routes"]:
+        raise CommitteeError("verified latest-approved Router has no model routes")
+    return bundle
+
+
+def build_candidates(
+    bundle: Mapping[str, Any],
+    *,
+    required_capabilities: Sequence[str] = ("text",),
+) -> tuple[list[ModelCandidate], dict[str, str]]:
+    payloads = bundle.get("payloads") if isinstance(bundle.get("payloads"), Mapping) else {}
+    router = payloads.get("router") if isinstance(payloads.get("router"), Mapping) else {}
+    lineup = payloads.get("lineup") if isinstance(payloads.get("lineup"), Mapping) else {}
+    policy = payloads.get("policy") if isinstance(payloads.get("policy"), Mapping) else {}
+    capabilities = payloads.get("capabilities") if isinstance(payloads.get("capabilities"), Mapping) else {}
+    profile = payloads.get("profile") if isinstance(payloads.get("profile"), Mapping) else {}
+    routes = router.get("routes") if isinstance(router.get("routes"), Mapping) else {}
+
+    candidates: list[ModelCandidate] = []
+    excluded: dict[str, str] = {}
+    for raw_model in sorted(routes):
+        model = str(raw_model or "").strip()
+        route_group = routes.get(raw_model)
+        if not model or not isinstance(route_group, Mapping):
+            continue
+        visible, reason = _policy_visibility(model, policy)
+        if not visible:
+            excluded[model] = reason
+            continue
+        try:
+            route_chain = _build_route_chain(model, route_group, profile)
+        except CommitteeError as exc:
+            excluded[model] = str(exc)
+            continue
+        model_caps = _model_capabilities(model, lineup, policy, capabilities)
+        model_caps = _merge_pi_capabilities(model, route_chain[0], model_caps)
+        missing = [name for name in required_capabilities if not _capability_enabled(model_caps, name)]
+        if missing:
+            excluded[model] = "missing capabilities: " + ", ".join(missing)
+            continue
+        policy_row = _mapping_at(policy, "models", model)
+        candidates.append(
+            ModelCandidate(
+                model=model,
+                family=_infer_family(model),
+                capabilities=model_caps,
+                context_window_tokens=_positive_int(model_caps.get("context_window_tokens")),
+                favorite=bool(policy_row.get("favorite")),
+                tier=str(policy_row.get("tier") or "").strip().lower(),
+                route_chain=route_chain,
+            )
+        )
+    return candidates, excluded
+
+
+def select_members(
+    candidates: Sequence[ModelCandidate],
+    *,
+    count: int | None = None,
+    min_families: int = DEFAULT_MIN_FAMILIES,
+    explicit_models: Sequence[str] = (),
+    selection_profile: str = DEFAULT_SELECTION_PROFILE,
+    frontier_families: Sequence[str] = DEFAULT_FRONTIER_FAMILIES,
+    additional_models: Sequence[str] = (),
+    lenses: Sequence[str] = DEFAULT_LENSES,
+) -> list[MemberSpec]:
+    if count is not None and count < 1:
+        raise CommitteeError("member count must be at least 1")
+    if not lenses:
+        raise CommitteeError("at least one review lens is required")
+    by_model = {candidate.model: candidate for candidate in candidates}
+    if explicit_models:
+        requested = _dedupe(explicit_models)
+        missing = [model for model in requested if model not in by_model]
+        if missing:
+            raise CommitteeError("requested models are unavailable: " + ", ".join(missing))
+        effective_count = count if count is not None else len(requested)
+        selected = [by_model[model] for model in requested[:effective_count]]
+    else:
+        profile = str(selection_profile or "").strip().lower()
+        if profile == "frontier":
+            selected = _select_frontier(
+                candidates,
+                families=frontier_families,
+                additional_models=additional_models,
+                count=count,
+            )
+            effective_count = count if count is not None else len(selected)
+        elif profile == "balanced":
+            if additional_models:
+                raise CommitteeError("additional models require the frontier selection profile")
+            effective_count = count if count is not None else DEFAULT_MEMBER_COUNT
+            selected = _select_diverse(candidates, count=effective_count, min_families=min_families)
+        else:
+            raise CommitteeError(f"unknown selection profile: {selection_profile}")
+    if len(selected) < effective_count:
+        raise CommitteeError(f"only {len(selected)} eligible models are available for {effective_count} members")
+    return [
+        MemberSpec(member_id=f"member-{index:02d}", lens=lenses[(index - 1) % len(lenses)], candidate=candidate)
+        for index, candidate in enumerate(selected, start=1)
+    ]
+
+
+def plan_committee(
+    *,
+    config_root: str | os.PathLike[str],
+    task: str,
+    count: int | None = None,
+    min_families: int = DEFAULT_MIN_FAMILIES,
+    explicit_models: Sequence[str] = (),
+    selection_profile: str = DEFAULT_SELECTION_PROFILE,
+    frontier_families: Sequence[str] = DEFAULT_FRONTIER_FAMILIES,
+    additional_models: Sequence[str] = (),
+    required_capabilities: Sequence[str] = ("text",),
+    lenses: Sequence[str] = DEFAULT_LENSES,
+    mission_id: str | None = None,
+) -> tuple[dict[str, Any], list[MemberSpec], dict[str, Any]]:
+    task_text = str(task or "").strip()
+    if not task_text:
+        raise CommitteeError("task must not be empty")
+    if explicit_models and additional_models:
+        raise CommitteeError("--model cannot be combined with additional models")
+    bundle = load_catalog(config_root)
+    bundle_root = Path(str(bundle.get("config_root") or config_root)).expanduser()
+    with _scoped_mms_config_root(bundle_root):
+        candidates, excluded = build_candidates(bundle, required_capabilities=required_capabilities)
+    members = select_members(
+        candidates,
+        count=count,
+        min_families=min_families,
+        explicit_models=explicit_models,
+        selection_profile=selection_profile,
+        frontier_families=frontier_families,
+        additional_models=additional_models,
+        lenses=lenses,
+    )
+    effective_count = len(members)
+    manifest = bundle.get("manifest") if isinstance(bundle.get("manifest"), Mapping) else {}
+    selected_families = sorted({member.candidate.family for member in members})
+    effective_profile = "explicit" if explicit_models else str(selection_profile).strip().lower()
+    effective_frontier_families = list(_dedupe(_canonical_family(family) for family in frontier_families))
+    plan = {
+        "schema": "mms.pi_committee.plan.v1",
+        "mission_id": mission_id or f"pi-{uuid.uuid4().hex[:12]}",
+        "task": task_text,
+        "route_source": f"mms:latest-approved:{manifest.get('bundle_revision') or ''}",
+        "component_revisions": dict(bundle.get("component_revisions") or {}),
+        "selection": {
+            "requested_count": effective_count,
+            "profile": effective_profile,
+            "min_families": min_families,
+            "selected_families": selected_families,
+            "eligible_models": len(candidates),
+            "excluded_models": excluded,
+            "explicit_models": list(_dedupe(explicit_models)),
+            "target_families": effective_frontier_families if effective_profile == "frontier" else [],
+            "family_champions": {
+                member.candidate.family: member.candidate.model
+                for member in members
+                if effective_profile == "frontier" and member.candidate.family in set(effective_frontier_families)
+            },
+            "additional_models": list(_dedupe(additional_models)),
+        },
+        "members": [member.public() for member in members],
+        "isolation": {
+            "global_config_writes": False,
+            "global_oauth_fallback": False,
+            "opencode_dependency": False,
+            "worker_tools": READ_ONLY_TOOLS,
+        },
+    }
+    return plan, members, bundle
+
+
+def run_committee(
+    *,
+    config_root: str | os.PathLike[str],
+    task: str,
+    cwd: str | os.PathLike[str],
+    count: int | None = None,
+    min_families: int = DEFAULT_MIN_FAMILIES,
+    explicit_models: Sequence[str] = (),
+    selection_profile: str = DEFAULT_SELECTION_PROFILE,
+    frontier_families: Sequence[str] = DEFAULT_FRONTIER_FAMILIES,
+    additional_models: Sequence[str] = (),
+    required_capabilities: Sequence[str] = ("text",),
+    lenses: Sequence[str] = DEFAULT_LENSES,
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    target_cwd = Path(cwd).expanduser().resolve()
+    if not target_cwd.is_dir():
+        raise CommitteeError(f"worker cwd is not a directory: {target_cwd}")
+    plan, members, _bundle = plan_committee(
+        config_root=config_root,
+        task=task,
+        count=count,
+        min_families=min_families,
+        explicit_models=explicit_models,
+        selection_profile=selection_profile,
+        frontier_families=frontier_families,
+        additional_models=additional_models,
+        required_capabilities=required_capabilities,
+        lenses=lenses,
+    )
+    if dry_run:
+        return {
+            "schema": "mms.pi_committee.result.v1",
+            "mission_id": plan["mission_id"],
+            "status": "dry_run",
+            "plan": plan,
+            "results": [],
+        }
+    if max_concurrency < 1:
+        raise CommitteeError("max concurrency must be at least 1")
+    if timeout_seconds < 1:
+        raise CommitteeError("timeout must be at least 1 second")
+
+    prepared = _prepare_members(members, config_root=Path(config_root).expanduser())
+    worker_count = min(max_concurrency, len(members))
+    started = time.monotonic()
+    results: list[dict[str, Any]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as pool:
+        futures = {
+            pool.submit(
+                _run_member,
+                member,
+                prepared[member.member_id],
+                task=str(task).strip(),
+                cwd=target_cwd,
+                timeout_seconds=timeout_seconds,
+                route_source=plan["route_source"],
+            ): member.member_id
+            for member in members
+        }
+        for future in concurrent.futures.as_completed(futures):
+            member_id = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                results.append(
+                    {
+                        "member_id": member_id,
+                        "status": "worker_error",
+                        "error": _redact_text(str(exc), _all_api_keys(members)),
+                    }
+                )
+    results.sort(key=lambda item: str(item.get("member_id") or ""))
+    succeeded = sum(1 for item in results if item.get("status") == "success")
+    return {
+        "schema": "mms.pi_committee.result.v1",
+        "mission_id": plan["mission_id"],
+        "status": "success" if succeeded == len(results) else ("partial" if succeeded else "failed"),
+        "elapsed_ms": int((time.monotonic() - started) * 1000),
+        "summary": {"members": len(results), "succeeded": succeeded, "failed": len(results) - succeeded},
+        "plan": plan,
+        "results": results,
+    }
+
+
+def _prepare_members(members: Sequence[MemberSpec], *, config_root: Path) -> dict[str, tuple[PreparedAttempt, ...]]:
+    prepared: dict[str, tuple[PreparedAttempt, ...]] = {}
+    with _scoped_mms_config_root(config_root):
+        for member in members:
+            attempts = tuple(_prepare_attempt(member, binding) for binding in member.candidate.route_chain)
+            prepared[member.member_id] = attempts
+    return prepared
+
+
+def _prepare_attempt(member: MemberSpec, binding: RouteBinding) -> PreparedAttempt:
+    import mms_pi_support
+
+    runtime: dict[str, Any] = {
+        "id": binding.provider_id,
+        "provider_id": binding.provider_id,
+        "name": binding.provider_id,
+        "api_key": binding.api_key,
+        "model": member.candidate.model,
+        "provider_profile": binding.provider_profile,
+        "_launch_prefetched_probe": {"models": [member.candidate.model]},
+    }
+    if binding.protocol == "anthropic_messages":
+        runtime["anthropic_base_url"] = binding.base_url
+    else:
+        runtime["openai_base_url"] = binding.base_url
+    try:
+        payload, provider_ref = mms_pi_support._pi_build_models_payload(runtime, member.candidate.model)
+    except RuntimeError as exc:
+        raise CommitteeError(f"Pi payload preparation failed for {member.candidate.model}: {exc}") from exc
+    payload = json.loads(json.dumps(payload))
+    provider = payload.get("providers", {}).get(provider_ref)
+    if not isinstance(provider, dict):
+        raise CommitteeError(f"Pi payload did not contain selected provider {provider_ref}")
+    configured_protocol = _pi_api_protocol(provider.get("api"))
+    if configured_protocol != binding.protocol:
+        raise CommitteeError(
+            f"Pi payload protocol drift for {member.candidate.model}: "
+            f"planned {binding.protocol}, configured {configured_protocol or 'unknown'}"
+        )
+    configured_url, configured_path = _request_target(str(provider.get("baseUrl") or ""), configured_protocol)
+    if configured_url != binding.request_url or configured_path != binding.request_path:
+        raise CommitteeError(
+            f"Pi payload request target drift for {member.candidate.model}: "
+            f"planned {binding.request_path}, configured {configured_path}"
+        )
+    env_name = _credential_env_name(member.member_id, binding.fallback_position)
+    provider["apiKey"] = f"${env_name}"
+    selected_model = _patch_wire_model(provider, member.candidate.model, binding.wire_model)
+    return PreparedAttempt(
+        binding=binding,
+        models_payload=payload,
+        provider_ref=provider_ref,
+        selected_model=selected_model,
+    )
+
+
+def _pi_api_protocol(api: Any) -> str:
+    return {
+        "anthropic-messages": "anthropic_messages",
+        "openai-responses": "openai_responses",
+        "openai-completions": "openai_chat_completions",
+    }.get(str(api or "").strip(), "")
+
+
+def _run_member(
+    member: MemberSpec,
+    attempts: Sequence[PreparedAttempt],
+    *,
+    task: str,
+    cwd: Path,
+    timeout_seconds: int,
+    route_source: str,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    errors: list[str] = []
+    attempt_records: list[dict[str, Any]] = []
+    all_keys = [attempt.binding.api_key for attempt in attempts]
+    for index, attempt in enumerate(attempts):
+        remaining = max(1, int(deadline - time.monotonic()))
+        result = _run_attempt(member, attempt, task=task, cwd=cwd, timeout_seconds=remaining)
+        route_fallback = index > 0
+        fallback_reason = "; ".join(errors) if route_fallback else ""
+        if attempt.binding.protocol_fallback_reason:
+            fallback_reason = "; ".join(
+                item for item in (fallback_reason, attempt.binding.protocol_fallback_reason) if item
+            )
+        evidence = _transport_evidence(
+            member,
+            attempt.binding,
+            route_source=route_source,
+            fallback_used=route_fallback or bool(attempt.binding.protocol_fallback_reason),
+            fallback_reason=fallback_reason,
+            usage=result.get("_usage", {}),
+        )
+        attempt_records.append(
+            {
+                "provider_id": attempt.binding.provider_id,
+                "status": result.get("status"),
+                "error": result.get("error", ""),
+                "cache_transport_evidence": evidence,
+            }
+        )
+        if result["status"] == "success":
+            result.pop("_usage", None)
+            result["fallback_used"] = evidence["fallback_used"]
+            result["fallback_reason"] = evidence["fallback_reason"]
+            result["cache_transport_evidence"] = evidence
+            result["attempts"] = attempt_records
+            return _redact_object(result, all_keys)
+        errors.append(f"{attempt.binding.provider_id}:{result.get('status')}")
+        if time.monotonic() >= deadline:
+            break
+    return _redact_object(
+        {
+            "member_id": member.member_id,
+            "model": member.candidate.model,
+            "family": member.candidate.family,
+            "lens": member.lens,
+            "status": "failed",
+            "error": "; ".join(errors) or "no route attempts were available",
+            "fallback_used": len(errors) > 1,
+            "fallback_reason": "; ".join(errors[:-1]),
+            "attempts": attempt_records,
+        },
+        all_keys,
+    )
+
+
+def _run_attempt(
+    member: MemberSpec,
+    attempt: PreparedAttempt,
+    *,
+    task: str,
+    cwd: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    root = Path(__file__).resolve().parent
+    wrapper = root / "scripts" / "pi-cli-wrapper.sh"
+    if not wrapper.is_file():
+        raise CommitteeError(f"repo-local Pi wrapper is missing: {wrapper}")
+    prompt = _worker_prompt(task, member)
+    with tempfile.TemporaryDirectory(prefix=f"mms-pi-{member.member_id}-") as temp_dir:
+        temp_root = Path(temp_dir)
+        agent_dir = temp_root / ".pi" / "agent"
+        session_dir = agent_dir / "sessions"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        _write_private_json(agent_dir / "models.json", attempt.models_payload)
+        _write_private_json(agent_dir / "settings.json", {})
+        env_name = _credential_env_name(member.member_id, attempt.binding.fallback_position)
+        env = _isolated_env(temp_root)
+        env.update(
+            {
+                "PI_CODING_AGENT_DIR": str(agent_dir),
+                "PI_CODING_AGENT_SESSION_DIR": str(session_dir),
+                "PI_TELEMETRY": "0",
+                "PI_SKIP_VERSION_CHECK": "1",
+                "MMS_PI_NPX_CACHE": str(root / ".ai" / "cache" / "pi-npx"),
+                env_name: attempt.binding.api_key,
+            }
+        )
+        cmd = [
+            str(wrapper),
+            "--provider",
+            attempt.provider_ref,
+            "--model",
+            attempt.selected_model,
+            "--mode",
+            "json",
+            "--no-session",
+            "--no-context-files",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--no-themes",
+            "--tools",
+            READ_ONLY_TOOLS,
+            "--thinking",
+            "off",
+            "-p",
+            prompt,
+        ]
+        try:
+            completed = subprocess.run(
+                cmd,
+                cwd=cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {"status": "timeout", "elapsed_ms": int((time.monotonic() - started) * 1000)}
+    message, parse_error = _parse_pi_stream(completed.stdout)
+    text = _message_text(message)
+    if completed.returncode != 0:
+        return {
+            "status": "launch_error",
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "error": str(message.get("errorMessage") or completed.stderr[-800:] or parse_error or "Pi exited non-zero"),
+        }
+    if str(message.get("stopReason") or "").strip().lower() == "error":
+        return {
+            "status": "request_error",
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "error": str(message.get("errorMessage") or "Pi request failed"),
+        }
+    if not text:
+        return {"status": "empty_response", "elapsed_ms": int((time.monotonic() - started) * 1000)}
+    parsed = _parse_response_object(text)
+    return {
+        "member_id": member.member_id,
+        "model": member.candidate.model,
+        "family": member.candidate.family,
+        "lens": member.lens,
+        "status": "success",
+        "elapsed_ms": int((time.monotonic() - started) * 1000),
+        "provider_id": attempt.binding.provider_id,
+        "protocol": attempt.binding.protocol,
+        "response": parsed if parsed is not None else {"raw_text": text},
+        "_usage": _normalize_usage(message.get("usage")),
+    }
+
+
+def _worker_prompt(task: str, member: MemberSpec) -> str:
+    return f"""You are an independent read-only committee member.
+
+Mission:
+{task}
+
+Your assigned lens: {member.lens}
+
+Rules:
+- Inspect only. Do not edit files, run shell commands, or invoke other agents.
+- Work independently; do not assume other committee opinions.
+- Separate inspected facts from inference.
+- Return one JSON object and no Markdown fence.
+
+Required JSON shape:
+{{
+  "verdict": "short conclusion",
+  "confidence": 0.0,
+  "findings": [{{"claim": "...", "evidence": ["path or fact"], "severity": "low|medium|high"}}],
+  "risks": ["..."],
+  "recommendation": "..."
+}}
+""".strip()
+
+
+def _build_route_chain(model: str, route_group: Mapping[str, Any], profile: Mapping[str, Any]) -> tuple[RouteBinding, ...]:
+    primary = route_group.get("primary")
+    if not isinstance(primary, Mapping):
+        raise CommitteeError("route primary is missing")
+    chain_rows: list[Mapping[str, Any]] = [primary]
+    chain_rows.extend(item for item in route_group.get("fallbacks") or [] if isinstance(item, Mapping))
+    bindings: list[RouteBinding] = []
+    for position, row in enumerate(chain_rows):
+        try:
+            binding = _route_binding(model, row, profile, fallback_position=position)
+            block_reason = _pi_binding_block_reason(model, binding)
+            if block_reason:
+                raise CommitteeError(f"Pi route is blocked: {block_reason}")
+            bindings.append(binding)
+        except CommitteeError:
+            if position == 0:
+                raise
+    return tuple(bindings)
+
+
+def _pi_binding_block_reason(model: str, binding: RouteBinding) -> str:
+    import mms_pi_support
+
+    if not mms_pi_support._pi_model_supported(model):
+        return "model is not a conversational Pi model"
+    runtime = {
+        "id": binding.provider_id,
+        "provider_id": binding.provider_id,
+        "model": model,
+        "_launch_prefetched_probe": {"models": [model, binding.wire_model]},
+    }
+    return str(mms_pi_support._pi_model_block_reason(runtime, model) or "").strip()
+
+
+def _route_binding(
+    model: str,
+    route: Mapping[str, Any],
+    profile_payload: Mapping[str, Any],
+    *,
+    fallback_position: int,
+) -> RouteBinding:
+    provider_id = str(route.get("provider_id") or "").strip()
+    api_key = str(route.get("api_key") or "").strip()
+    wire_model = str(route.get("model_id") or model).strip()
+    anthropic_url = str(route.get("anthropic_base_url") or "").strip()
+    openai_url = str(route.get("openai_base_url") or "").strip()
+    if not provider_id:
+        raise CommitteeError("route provider_id is missing")
+    if not api_key:
+        raise CommitteeError(f"route {provider_id} has no API key")
+    protocol, base_url, protocol_fallback_reason = _select_protocol(
+        model,
+        anthropic_url=anthropic_url,
+        openai_url=openai_url,
+    )
+    request_url, request_path = _request_target(base_url, protocol)
+    return RouteBinding(
+        model=model,
+        wire_model=wire_model,
+        provider_id=provider_id,
+        protocol=protocol,
+        base_url=base_url,
+        request_url=request_url,
+        request_path=request_path,
+        api_key=api_key,
+        provider_profile=_provider_profile_id(provider_id, route, profile_payload),
+        protocol_fallback_reason=protocol_fallback_reason,
+        fallback_position=fallback_position,
+    )
+
+
+def _select_protocol(model: str, *, anthropic_url: str, openai_url: str) -> tuple[str, str, str]:
+    normalized = model.strip().lower()
+    if normalized.startswith(_OPENAI_FAMILY_PREFIXES) and openai_url:
+        return "openai_responses", openai_url, ""
+    if anthropic_url:
+        return "anthropic_messages", anthropic_url, ""
+    if openai_url:
+        protocol = "openai_responses" if normalized.startswith(_OPENAI_FAMILY_PREFIXES) else "openai_chat_completions"
+        fallback_reason = ""
+        if protocol == "openai_chat_completions":
+            fallback_reason = "route has no Anthropic endpoint; using explicit OpenAI-compatible route"
+        return protocol, openai_url, fallback_reason
+    raise CommitteeError("route has neither Anthropic nor OpenAI base URL")
+
+
+def _request_target(base_url: str, protocol: str) -> tuple[str, str]:
+    parsed = urlsplit(base_url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise CommitteeError("route base URL must be an absolute http(s) URL")
+    path = parsed.path.rstrip("/")
+    if protocol == "anthropic_messages":
+        if path.endswith("/v1/messages"):
+            request_path = path
+        elif path.endswith("/v1"):
+            request_path = f"{path}/messages"
+        else:
+            request_path = f"{path}/v1/messages" if path else "/v1/messages"
+    else:
+        suffix = "/responses" if protocol == "openai_responses" else "/chat/completions"
+        if path.endswith(suffix):
+            request_path = path
+        elif path.endswith("/v1"):
+            request_path = f"{path}{suffix}"
+        else:
+            request_path = f"{path}/v1{suffix}" if path else f"/v1{suffix}"
+    return urlunsplit((parsed.scheme, parsed.netloc, request_path, "", "")), request_path
+
+
+def _provider_profile_id(provider_id: str, route: Mapping[str, Any], profile_payload: Mapping[str, Any]) -> str:
+    explicit = str(route.get("provider_profile") or route.get("profile") or "").strip()
+    if explicit:
+        return explicit
+    profiles = profile_payload.get("profiles") if isinstance(profile_payload.get("profiles"), Mapping) else {}
+    return provider_id if provider_id in profiles else ""
+
+
+def _model_capabilities(
+    model: str,
+    lineup: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    approved: Mapping[str, Any],
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    approved_row = _approved_model_row(approved, model)
+    if isinstance(approved_row.get("capabilities"), Mapping):
+        result.update(approved_row["capabilities"])
+    result.update({key: value for key, value in approved_row.items() if key not in {"capabilities", "sources"}})
+    policy_row = _mapping_at(policy, "models", model)
+    if isinstance(policy_row.get("capabilities"), Mapping):
+        result.update(policy_row["capabilities"])
+    lineup_primary = _mapping_at(lineup, "routes", model, "primary")
+    context = _positive_int(
+        result.get("context_window_tokens")
+        or result.get("official_context_window_tokens")
+        or result.get("provider_top_context_window_tokens")
+        or lineup_primary.get("max_context_tokens")
+        or lineup_primary.get("context_window_tokens")
+    )
+    if context:
+        result["context_window_tokens"] = context
+    result.setdefault("text", True)
+    return result
+
+
+def _merge_pi_capabilities(
+    model: str,
+    binding: RouteBinding,
+    configured: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Fill missing bundle facts with the same resolver used by the Pi payload."""
+    import mms_pi_support
+
+    runtime: dict[str, Any] = {
+        "id": binding.provider_id,
+        "provider_id": binding.provider_id,
+        "model": model,
+        "provider_profile": binding.provider_profile,
+        "_launch_prefetched_probe": {"models": [model, binding.wire_model]},
+    }
+    if binding.protocol == "anthropic_messages":
+        runtime["anthropic_base_url"] = binding.base_url
+    else:
+        runtime["openai_base_url"] = binding.base_url
+    try:
+        resolved = mms_pi_support._pi_model_capabilities(runtime, model)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return dict(configured)
+    if not isinstance(resolved, Mapping):
+        return dict(configured)
+
+    result = dict(configured)
+    adopted: set[str] = set()
+    for key, value in resolved.items():
+        if key == "sources":
+            continue
+        current = result.get(key)
+        missing = key not in result or current is None or current == ""
+        if isinstance(current, (int, float)) and not isinstance(current, bool) and current <= 0:
+            missing = True
+        if missing:
+            result[key] = value
+            adopted.add(str(key))
+    configured_sources = result.get("sources") if isinstance(result.get("sources"), Mapping) else {}
+    resolved_sources = resolved.get("sources") if isinstance(resolved.get("sources"), Mapping) else {}
+    if configured_sources or resolved_sources:
+        sources = dict(configured_sources)
+        for key in adopted:
+            if key in resolved_sources:
+                sources[key] = resolved_sources[key]
+        result["sources"] = sources
+    return result
+
+
+def _approved_model_row(approved: Mapping[str, Any], model: str) -> dict[str, Any]:
+    rows = approved.get("models")
+    if isinstance(rows, Mapping):
+        row = rows.get(model)
+        return dict(row) if isinstance(row, Mapping) else {}
+    if not isinstance(rows, list):
+        return {}
+    normalized = model.strip().lower()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        identities = (
+            row.get("alias"),
+            row.get("model"),
+            row.get("model_name"),
+            row.get("model_id"),
+            row.get("canonical_model_id"),
+        )
+        if any(str(value or "").strip().lower() == normalized for value in identities):
+            return dict(row)
+    return {}
+
+
+def _policy_visibility(model: str, policy: Mapping[str, Any]) -> tuple[bool, str]:
+    row = _mapping_at(policy, "models", model)
+    if row.get("visible") is False:
+        return False, "policy visible=false"
+    capabilities = row.get("capabilities") if isinstance(row.get("capabilities"), Mapping) else {}
+    if capabilities.get("text") is False:
+        return False, "policy capabilities.text=false"
+    hidden_in = {str(item).strip().lower() for item in row.get("hide_in") or []}
+    if hidden_in.intersection({"pi-committee", "pi_committee"}):
+        return False, "policy hide_in includes pi-committee"
+    project = _mapping_at(policy, "projects", "pi-committee") or _mapping_at(policy, "projects", "pi_committee")
+    allowed = {str(item).strip() for item in project.get("allowed_models") or []}
+    hidden = {str(item).strip() for item in (project.get("hidden_models") or []) + (project.get("disabled_models") or [])}
+    if model in hidden:
+        return False, "pi-committee project policy denies model"
+    if project.get("default_visible") is False and model not in allowed:
+        return False, "pi-committee project policy does not allow model"
+    return True, ""
+
+
+def _select_diverse(candidates: Sequence[ModelCandidate], *, count: int, min_families: int) -> list[ModelCandidate]:
+    ranked = sorted(candidates, key=_candidate_sort_key)
+    if len(ranked) < count:
+        return ranked
+    family_best: dict[str, ModelCandidate] = {}
+    for candidate in ranked:
+        family_best.setdefault(candidate.family, candidate)
+    diversity_target = min(count, max(1, min_families), len(family_best))
+    representatives = sorted(family_best.values(), key=_candidate_sort_key)[:diversity_target]
+    selected = list(representatives)
+    selected_models = {item.model for item in selected}
+    for candidate in ranked:
+        if len(selected) >= count:
+            break
+        if candidate.model not in selected_models:
+            selected.append(candidate)
+            selected_models.add(candidate.model)
+    return selected
+
+
+def _select_frontier(
+    candidates: Sequence[ModelCandidate],
+    *,
+    families: Sequence[str],
+    additional_models: Sequence[str],
+    count: int | None,
+) -> list[ModelCandidate]:
+    target_families = _dedupe(_canonical_family(family) for family in families)
+    if not target_families:
+        raise CommitteeError("frontier profile requires at least one target family")
+    by_family: dict[str, list[ModelCandidate]] = {}
+    by_model = {candidate.model: candidate for candidate in candidates}
+    for candidate in candidates:
+        by_family.setdefault(candidate.family, []).append(candidate)
+    missing_families = [family for family in target_families if not by_family.get(family)]
+    if missing_families:
+        raise CommitteeError("frontier families are unavailable: " + ", ".join(missing_families))
+
+    selected = [
+        sorted(by_family[family], key=_frontier_model_sort_key)[0]
+        for family in target_families
+    ]
+    extra_names = _dedupe(additional_models)
+    missing_models = [model for model in extra_names if model not in by_model]
+    if missing_models:
+        raise CommitteeError("additional models are unavailable: " + ", ".join(missing_models))
+    selected_models = {candidate.model for candidate in selected}
+    for model in extra_names:
+        if model not in selected_models:
+            selected.append(by_model[model])
+            selected_models.add(model)
+
+    effective_count = count if count is not None else len(selected)
+    if effective_count <= len(selected):
+        return selected[:effective_count]
+    for candidate in sorted(candidates, key=_candidate_sort_key):
+        if len(selected) >= effective_count:
+            break
+        if candidate.model not in selected_models:
+            selected.append(candidate)
+            selected_models.add(candidate.model)
+    return selected
+
+
+def _frontier_model_sort_key(candidate: ModelCandidate) -> tuple[Any, ...]:
+    lower = candidate.model.strip().lower()
+    version = _model_version_sort_key(lower)
+    variant_rank = 5
+    channel_rank = 1
+    if candidate.family == "Kimi":
+        if lower == "kimi-for-coding":
+            channel_rank = 0
+        elif lower == "kimi-for-code":
+            channel_rank = 1
+        else:
+            channel_rank = 2
+    elif candidate.family == "Gemini":
+        if re.fullmatch(r"gemini-\d+(?:\.\d+)?-flash-agent\(high\)", lower):
+            channel_rank = 0
+        elif "agent(high)" in lower:
+            channel_rank = 1
+        else:
+            channel_rank = 2
+    elif candidate.family == "Qwen":
+        variant_rank = 0 if "max" in lower else (1 if "plus" in lower else (2 if "flash" in lower else 3))
+    elif candidate.family == "DeepSeek":
+        variant_rank = 0 if "flash" in lower else (1 if "pro" in lower else 2)
+    elif candidate.family == "GPT":
+        variant_rank = 0 if lower.startswith("gpt-") else (1 if lower.startswith("codex-") else 2)
+    tier_rank = {"primary": 0, "preferred": 0, "secondary": 1, "fallback": 2}.get(candidate.tier, 1)
+    family_rank = (channel_rank, version, variant_rank) if candidate.family in {"Kimi", "Gemini"} else (version, variant_rank, channel_rank)
+    return (
+        *family_rank,
+        0 if candidate.favorite else 1,
+        tier_rank,
+        -candidate.context_window_tokens,
+        -len(candidate.route_chain),
+        lower,
+    )
+
+
+def _model_version_sort_key(model: str) -> tuple[int, int, int, int]:
+    match = re.search(r"\d+(?:\.\d+){0,3}", model)
+    parts = [int(part) for part in match.group(0).split(".")] if match else []
+    parts = (parts + [0, 0, 0, 0])[:4]
+    return -parts[0], -parts[1], -parts[2], -parts[3]
+
+
+def _canonical_family(value: str) -> str:
+    text = str(value or "").strip()
+    known = {family.lower(): family for family in DEFAULT_FRONTIER_FAMILIES}
+    known.update({"claude": "Claude", "mimo": "MiMo", "stepfun": "StepFun", "other": "Other"})
+    return known.get(text.lower(), text)
+
+
+def _candidate_sort_key(candidate: ModelCandidate) -> tuple[Any, ...]:
+    tier_rank = {"primary": 0, "preferred": 0, "secondary": 1, "fallback": 2}.get(candidate.tier, 1)
+    return (
+        0 if candidate.favorite else 1,
+        tier_rank,
+        0 if _capability_enabled(candidate.capabilities, "reasoning") else 1,
+        -candidate.context_window_tokens,
+        candidate.family.lower(),
+        candidate.model.lower(),
+    )
+
+
+def _infer_family(model: str) -> str:
+    normalized = model.lower()
+    families = (
+        ("Claude", ("claude",)),
+        ("GPT", ("gpt", "codex", "o1", "o3", "o4")),
+        ("Gemini", ("gemini",)),
+        ("DeepSeek", ("deepseek",)),
+        ("Qwen", ("qwen",)),
+        ("Kimi", ("kimi", "k2.6")),
+        ("MiMo", ("mimo",)),
+        ("MiniMax", ("minimax",)),
+        ("GLM", ("glm",)),
+        ("StepFun", ("stepfun", "step-")),
+    )
+    for family, keywords in families:
+        if any(keyword in normalized for keyword in keywords):
+            return family
+    return "Other"
+
+
+def _transport_evidence(
+    member: MemberSpec,
+    binding: RouteBinding,
+    *,
+    route_source: str,
+    fallback_used: bool,
+    fallback_reason: str,
+    usage: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema": "cache_transport_evidence.v1",
+        "model": member.candidate.model,
+        "provider_id": binding.provider_id,
+        "protocol": binding.protocol,
+        "request_url": _redact_url(binding.request_url),
+        "request_path": binding.request_path,
+        "route_source": route_source,
+        "provider_profile": binding.provider_profile,
+        "fallback_used": fallback_used,
+        "fallback_reason": fallback_reason,
+        "usage": dict(usage),
+    }
+
+
+def _normalize_usage(raw: Any) -> dict[str, int]:
+    usage = raw if isinstance(raw, Mapping) else {}
+    prompt_details = usage.get("prompt_tokens_details") if isinstance(usage.get("prompt_tokens_details"), Mapping) else {}
+    return {
+        "input_tokens": _positive_int(usage.get("input") or usage.get("input_tokens") or usage.get("prompt_tokens")),
+        "output_tokens": _positive_int(usage.get("output") or usage.get("output_tokens") or usage.get("completion_tokens")),
+        "cache_read_input_tokens": _positive_int(usage.get("cacheRead") or usage.get("cache_read_input_tokens") or usage.get("cache_read_tokens")),
+        "cache_creation_input_tokens": _positive_int(usage.get("cacheWrite") or usage.get("cache_creation_input_tokens")),
+        "cached_tokens": _positive_int(usage.get("cached_tokens") or prompt_details.get("cached_tokens")),
+    }
+
+
+def _parse_pi_stream(stdout: str) -> tuple[dict[str, Any], str]:
+    last_message: dict[str, Any] = {}
+    turn_end: dict[str, Any] = {}
+    parse_error = ""
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            parse_error = str(exc)
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type") or "").strip()
+        message = event.get("message")
+        if event_type == "message_end" and isinstance(message, dict) and message.get("role") == "assistant":
+            last_message = message
+        elif event_type == "turn_end" and isinstance(message, dict):
+            turn_end = message
+    return turn_end or last_message, parse_error
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    chunks = []
+    for item in message.get("content") or []:
+        if isinstance(item, Mapping) and item.get("type") == "text" and item.get("text"):
+            chunks.append(str(item["text"]))
+    return "".join(chunks).strip()
+
+
+def _parse_response_object(text: str) -> dict[str, Any] | None:
+    candidate = text.strip()
+    if candidate.startswith("```"):
+        candidate = re.sub(r"^```(?:json)?\s*", "", candidate, flags=re.IGNORECASE)
+        candidate = re.sub(r"\s*```$", "", candidate)
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError:
+        start = candidate.find("{")
+        end = candidate.rfind("}")
+        if start < 0 or end <= start:
+            return None
+        try:
+            payload = json.loads(candidate[start : end + 1])
+        except json.JSONDecodeError:
+            return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _isolated_env(temp_root: Path) -> dict[str, str]:
+    allowed = {
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "SHELL",
+        "TERM",
+        "TMPDIR",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "NODE_EXTRA_CA_CERTS",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    }
+    env = {key: value for key, value in os.environ.items() if key in allowed and value}
+    env.update(
+        {
+            "HOME": str(temp_root),
+            "XDG_CONFIG_HOME": str(temp_root / ".config"),
+            "XDG_CACHE_HOME": str(temp_root / ".cache"),
+            "XDG_DATA_HOME": str(temp_root / ".local" / "share"),
+            "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+        }
+    )
+    return env
+
+
+@contextlib.contextmanager
+def _scoped_mms_config_root(config_root: Path) -> Iterable[None]:
+    keys = ("MMS_CONFIG_ROOT", "MMS_CONFIG_DIR")
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        for key in keys:
+            os.environ[key] = str(config_root)
+        _clear_mms_resolution_caches()
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        _clear_mms_resolution_caches()
+
+
+def _clear_mms_resolution_caches() -> None:
+    try:
+        import mms_capability_resolver
+        import mms_provider_profiles
+
+        mms_provider_profiles.load_provider_profiles.cache_clear()
+        mms_capability_resolver.clear_capability_cache()
+    except (AttributeError, ImportError):
+        pass
+
+
+def _write_private_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
+def _patch_wire_model(provider: dict[str, Any], logical_model: str, wire_model: str) -> str:
+    models = provider.get("models") if isinstance(provider.get("models"), list) else []
+    if not models:
+        raise CommitteeError("Pi provider payload has no models")
+    target = None
+    for row in models:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("id") or "") == logical_model or str(row.get("name") or "") == logical_model:
+            target = row
+            break
+    if target is None:
+        target = models[0] if isinstance(models[0], dict) else None
+    if target is None:
+        raise CommitteeError("Pi provider payload has no usable model entry")
+    target["id"] = wire_model
+    target["name"] = logical_model
+    return wire_model
+
+
+def _credential_env_name(member_id: str, fallback_position: int) -> str:
+    suffix = re.sub(r"[^A-Za-z0-9]", "_", member_id).upper()
+    return f"MMS_PI_COMMITTEE_KEY_{suffix}_{fallback_position}"
+
+
+def _redact_object(value: Any, secrets: Sequence[str]) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _redact_object(item, secrets) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_object(item, secrets) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_object(item, secrets) for item in value]
+    if isinstance(value, str):
+        return _redact_text(value, secrets)
+    return value
+
+
+def _redact_text(value: str, secrets: Sequence[str]) -> str:
+    text = value
+    for secret in sorted({item for item in secrets if item}, key=len, reverse=True):
+        text = text.replace(secret, "<redacted>")
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub("<redacted>", text)
+    return text
+
+
+def _redact_url(value: str) -> str:
+    parsed = urlsplit(value)
+    hostname = parsed.hostname or ""
+    if parsed.port:
+        hostname = f"{hostname}:{parsed.port}"
+    return urlunsplit((parsed.scheme, hostname, parsed.path, "", ""))
+
+
+def _all_api_keys(members: Sequence[MemberSpec]) -> list[str]:
+    return [binding.api_key for member in members for binding in member.candidate.route_chain]
+
+
+def _mapping_at(payload: Mapping[str, Any], *path: str) -> dict[str, Any]:
+    current: Any = payload
+    for part in path:
+        if not isinstance(current, Mapping):
+            return {}
+        current = current.get(part)
+    return dict(current) if isinstance(current, Mapping) else {}
+
+
+def _capability_enabled(capabilities: Mapping[str, Any], name: str) -> bool:
+    key = str(name or "").strip().lower()
+    aliases = {
+        "vision": ("vision", "supports_vision"),
+        "thinking": ("thinking", "supports_thinking"),
+        "reasoning": ("reasoning", "supports_reasoning"),
+        "tool_use": ("tool_use", "tools", "supports_tools"),
+        "text": ("text",),
+    }
+    keys = aliases.get(key, (key,))
+    return any(capabilities.get(candidate) is True for candidate in keys)
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        number = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, number)
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        item = str(value or "").strip()
+        if item and item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
+
+
+__all__ = [
+    "CommitteeError",
+    "DEFAULT_LENSES",
+    "ModelCandidate",
+    "RouteBinding",
+    "build_candidates",
+    "load_catalog",
+    "plan_committee",
+    "run_committee",
+    "select_members",
+]

--- a/mms_pi_committee.py
+++ b/mms_pi_committee.py
@@ -12,22 +12,32 @@ import contextlib
 import json
 import os
 import re
-import subprocess
 import tempfile
 import time
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 from urllib.parse import urlsplit, urlunsplit
 
 import mms_consumer_bundle
+import mms_pi_watchdog
 
 
 DEFAULT_MEMBER_COUNT = 4
 DEFAULT_MIN_FAMILIES = 3
 DEFAULT_MAX_CONCURRENCY = 4
-DEFAULT_TIMEOUT_SECONDS = 180
+DEFAULT_TIMEOUT_SECONDS = 900
+DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS = 300
+DEFAULT_MAX_BUNDLE_AGE_DAYS = 30
+DEFAULT_IDLE_TIMEOUT_SECONDS = 300
+DEFAULT_MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+DEFAULT_MAX_REPEATED_EVENTS = 32
+DEFAULT_COMMITTEE_TIMEOUT_SECONDS = 0
+DEFAULT_COMMITTEE_TIMEOUT_GRACE_SECONDS = 60
+DEFAULT_QUORUM_SUCCESSES = 0
+DEFAULT_QUORUM_GRACE_SECONDS = 30
 DEFAULT_SELECTION_PROFILE = "frontier"
 DEFAULT_FRONTIER_FAMILIES = (
     "MiniMax",
@@ -48,6 +58,9 @@ DEFAULT_LENSES = (
 )
 READ_ONLY_TOOLS = "read,grep,find,ls"
 _OPENAI_FAMILY_PREFIXES = ("gpt-", "o1", "o3", "o4", "codex-")
+_KIMI_PRIMARY_PROVIDER_KEYWORDS = ("tokyo",)
+_KIMI_FALLBACK_PROVIDER_KEYWORDS = ("tencent",)
+_KIMI_DIRECT_PROVIDER_KEYWORDS = ("direct-kimi", "direct_kimi")
 _SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]{8,}\b"),
     re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b"),
@@ -102,9 +115,15 @@ class MemberSpec:
     member_id: str
     lens: str
     candidate: ModelCandidate
+    domain: str = ""
+    role_id: str = ""
+    role_card: str = field(default="", repr=False)
+    role_card_source: str = ""
+    role_card_sha256: str = ""
+    required_domain: bool = False
 
     def public(self) -> dict[str, Any]:
-        return {
+        payload = {
             "member_id": self.member_id,
             "lens": self.lens,
             "model": self.candidate.model,
@@ -112,6 +131,17 @@ class MemberSpec:
             "context_window_tokens": self.candidate.context_window_tokens,
             "route_chain": [binding.public() for binding in self.candidate.route_chain],
         }
+        if self.domain:
+            payload["domain"] = self.domain
+        if self.role_id:
+            payload["role_id"] = self.role_id
+        if self.role_card_source:
+            payload["role_card_source"] = self.role_card_source
+        if self.role_card_sha256:
+            payload["role_card_sha256"] = self.role_card_sha256
+        if self.domain:
+            payload["required_domain"] = self.required_domain
+        return payload
 
 
 @dataclass(frozen=True)
@@ -122,7 +152,76 @@ class PreparedAttempt:
     selected_model: str
 
 
-def load_catalog(config_root: str | os.PathLike[str]) -> dict[str, Any]:
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _bundle_timestamp(manifest: Mapping[str, Any]) -> datetime | None:
+    raw = str(manifest.get("generated_at") or "").strip()
+    if raw:
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            parsed = None
+        if parsed is not None:
+            return parsed.replace(tzinfo=parsed.tzinfo or timezone.utc).astimezone(timezone.utc)
+    revision = str(manifest.get("bundle_revision") or "").strip()
+    match = re.search(r"(?:^|_)bundle_(\d{14})(?:_|$)", f"_{revision}")
+    if not match:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _bundle_freshness(bundle: Mapping[str, Any], *, max_bundle_age_days: int) -> dict[str, Any]:
+    manifest = bundle.get("manifest") if isinstance(bundle.get("manifest"), Mapping) else {}
+    revision = str(manifest.get("bundle_revision") or "").strip()
+    generated_at = _bundle_timestamp(manifest)
+    payload: dict[str, Any] = {
+        "status": "unknown",
+        "bundle_revision": revision,
+        "generated_at": "",
+        "age_seconds": 0,
+        "age_days": 0.0,
+        "max_age_days": max_bundle_age_days,
+    }
+    if generated_at is None:
+        return payload
+    age_seconds = max(0, int((_utc_now() - generated_at).total_seconds()))
+    payload.update(
+        {
+            "status": (
+                "freshness_disabled"
+                if max_bundle_age_days == 0
+                else ("stale" if age_seconds > max_bundle_age_days * 86400 else "fresh")
+            ),
+            "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
+            "age_seconds": age_seconds,
+            "age_days": round(age_seconds / 86400, 3),
+        }
+    )
+    return payload
+
+
+def public_bundle_metadata(bundle: Mapping[str, Any]) -> dict[str, Any]:
+    freshness = bundle.get("freshness") if isinstance(bundle.get("freshness"), Mapping) else {}
+    return {
+        "config_root": str(bundle.get("config_root") or ""),
+        "manifest_path": str(bundle.get("manifest_path") or ""),
+        "revision": str(freshness.get("bundle_revision") or ""),
+        "freshness": dict(freshness),
+    }
+
+
+def load_catalog(
+    config_root: str | os.PathLike[str],
+    *,
+    max_bundle_age_days: int = DEFAULT_MAX_BUNDLE_AGE_DAYS,
+) -> dict[str, Any]:
+    if max_bundle_age_days < 0:
+        raise CommitteeError("max bundle age must be zero (disabled) or greater")
     root = Path(config_root).expanduser()
     try:
         bundle = mms_consumer_bundle.load_verified_consumer_bundle(
@@ -137,6 +236,14 @@ def load_catalog(config_root: str | os.PathLike[str]) -> dict[str, Any]:
     router = payloads.get("router") if isinstance(payloads.get("router"), dict) else {}
     if not isinstance(router.get("routes"), dict) or not router["routes"]:
         raise CommitteeError("verified latest-approved Router has no model routes")
+    freshness = _bundle_freshness(bundle, max_bundle_age_days=max_bundle_age_days)
+    bundle["freshness"] = freshness
+    if freshness["status"] == "stale":
+        raise CommitteeError(
+            "latest-approved bundle is stale: "
+            f"{freshness['bundle_revision']} is {freshness['age_days']:.1f} days old "
+            f"(limit {max_bundle_age_days} days); select a current explicit config root"
+        )
     return bundle
 
 
@@ -188,6 +295,19 @@ def build_candidates(
             )
         )
     return candidates, excluded
+
+
+def load_candidates(
+    config_root: str | os.PathLike[str],
+    *,
+    required_capabilities: Sequence[str] = ("text",),
+    max_bundle_age_days: int = DEFAULT_MAX_BUNDLE_AGE_DAYS,
+) -> tuple[dict[str, Any], list[ModelCandidate], dict[str, str]]:
+    bundle = load_catalog(config_root, max_bundle_age_days=max_bundle_age_days)
+    bundle_root = Path(str(bundle.get("config_root") or config_root)).expanduser()
+    with _scoped_mms_config_root(bundle_root):
+        candidates, excluded = build_candidates(bundle, required_capabilities=required_capabilities)
+    return bundle, candidates, excluded
 
 
 def select_members(
@@ -251,16 +371,18 @@ def plan_committee(
     required_capabilities: Sequence[str] = ("text",),
     lenses: Sequence[str] = DEFAULT_LENSES,
     mission_id: str | None = None,
+    max_bundle_age_days: int = DEFAULT_MAX_BUNDLE_AGE_DAYS,
 ) -> tuple[dict[str, Any], list[MemberSpec], dict[str, Any]]:
     task_text = str(task or "").strip()
     if not task_text:
         raise CommitteeError("task must not be empty")
     if explicit_models and additional_models:
         raise CommitteeError("--model cannot be combined with additional models")
-    bundle = load_catalog(config_root)
-    bundle_root = Path(str(bundle.get("config_root") or config_root)).expanduser()
-    with _scoped_mms_config_root(bundle_root):
-        candidates, excluded = build_candidates(bundle, required_capabilities=required_capabilities)
+    bundle, candidates, excluded = load_candidates(
+        config_root,
+        required_capabilities=required_capabilities,
+        max_bundle_age_days=max_bundle_age_days,
+    )
     members = select_members(
         candidates,
         count=count,
@@ -282,6 +404,7 @@ def plan_committee(
         "task": task_text,
         "route_source": f"mms:latest-approved:{manifest.get('bundle_revision') or ''}",
         "component_revisions": dict(bundle.get("component_revisions") or {}),
+        "bundle": public_bundle_metadata(bundle),
         "selection": {
             "requested_count": effective_count,
             "profile": effective_profile,
@@ -324,11 +447,16 @@ def run_committee(
     lenses: Sequence[str] = DEFAULT_LENSES,
     max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
     timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    kimi_attempt_timeout_seconds: int = DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
+    max_bundle_age_days: int = DEFAULT_MAX_BUNDLE_AGE_DAYS,
+    idle_timeout_seconds: int = DEFAULT_IDLE_TIMEOUT_SECONDS,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    max_repeated_events: int = DEFAULT_MAX_REPEATED_EVENTS,
+    committee_timeout_seconds: int = DEFAULT_COMMITTEE_TIMEOUT_SECONDS,
+    quorum_successes: int = DEFAULT_QUORUM_SUCCESSES,
+    quorum_grace_seconds: int = DEFAULT_QUORUM_GRACE_SECONDS,
     dry_run: bool = False,
 ) -> dict[str, Any]:
-    target_cwd = Path(cwd).expanduser().resolve()
-    if not target_cwd.is_dir():
-        raise CommitteeError(f"worker cwd is not a directory: {target_cwd}")
     plan, members, _bundle = plan_committee(
         config_root=config_root,
         task=task,
@@ -340,58 +468,181 @@ def run_committee(
         additional_models=additional_models,
         required_capabilities=required_capabilities,
         lenses=lenses,
+        max_bundle_age_days=max_bundle_age_days,
     )
-    if dry_run:
-        return {
-            "schema": "mms.pi_committee.result.v1",
-            "mission_id": plan["mission_id"],
-            "status": "dry_run",
-            "plan": plan,
-            "results": [],
-        }
+    return run_preplanned_committee(
+        config_root=config_root,
+        plan=plan,
+        members=members,
+        cwd=cwd,
+        max_concurrency=max_concurrency,
+        timeout_seconds=timeout_seconds,
+        kimi_attempt_timeout_seconds=kimi_attempt_timeout_seconds,
+        idle_timeout_seconds=idle_timeout_seconds,
+        max_output_bytes=max_output_bytes,
+        max_repeated_events=max_repeated_events,
+        committee_timeout_seconds=committee_timeout_seconds,
+        quorum_successes=quorum_successes,
+        quorum_grace_seconds=quorum_grace_seconds,
+        dry_run=dry_run,
+    )
+
+
+def run_preplanned_committee(
+    *,
+    config_root: str | os.PathLike[str],
+    plan: Mapping[str, Any],
+    members: Sequence[MemberSpec],
+    cwd: str | os.PathLike[str],
+    max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+    kimi_attempt_timeout_seconds: int = DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
+    idle_timeout_seconds: int = DEFAULT_IDLE_TIMEOUT_SECONDS,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    max_repeated_events: int = DEFAULT_MAX_REPEATED_EVENTS,
+    committee_timeout_seconds: int = DEFAULT_COMMITTEE_TIMEOUT_SECONDS,
+    quorum_successes: int = DEFAULT_QUORUM_SUCCESSES,
+    quorum_grace_seconds: int = DEFAULT_QUORUM_GRACE_SECONDS,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    target_cwd = Path(cwd).expanduser().resolve()
+    if not target_cwd.is_dir():
+        raise CommitteeError(f"worker cwd is not a directory: {target_cwd}")
+    if not members:
+        raise CommitteeError("preplanned committee must contain at least one member")
+    member_ids = [str(member.member_id).strip() for member in members]
+    if any(not member_id for member_id in member_ids) or len(set(member_ids)) != len(member_ids):
+        raise CommitteeError("preplanned committee member ids must be non-empty and unique")
+    effective_plan = dict(plan)
+    task = str(effective_plan.get("task") or "").strip()
+    if not task:
+        raise CommitteeError("preplanned committee task must not be empty")
+    if not str(effective_plan.get("mission_id") or "").strip():
+        raise CommitteeError("preplanned committee mission id must not be empty")
+    if not str(effective_plan.get("route_source") or "").strip():
+        raise CommitteeError("preplanned committee route source must not be empty")
+    effective_plan["members"] = [member.public() for member in members]
     if max_concurrency < 1:
         raise CommitteeError("max concurrency must be at least 1")
     if timeout_seconds < 1:
         raise CommitteeError("timeout must be at least 1 second")
+    if kimi_attempt_timeout_seconds < 0:
+        raise CommitteeError("Kimi attempt timeout must be zero (disabled) or greater")
+    if idle_timeout_seconds < 1:
+        raise CommitteeError("idle timeout must be at least 1 second")
+    if max_output_bytes < 1:
+        raise CommitteeError("max output bytes must be at least 1")
+    if max_repeated_events < 2:
+        raise CommitteeError("max repeated events must be at least 2")
+    if committee_timeout_seconds < 0:
+        raise CommitteeError("committee timeout must be zero (auto) or greater")
+    if quorum_successes < 0 or quorum_successes > len(members):
+        raise CommitteeError("quorum successes must be zero or no greater than member count")
+    if quorum_grace_seconds < 0:
+        raise CommitteeError("quorum grace must not be negative")
+
+    worker_count = min(max_concurrency, len(members))
+    wave_count = (len(members) + worker_count - 1) // worker_count
+    effective_committee_timeout = committee_timeout_seconds or (
+        timeout_seconds * wave_count + DEFAULT_COMMITTEE_TIMEOUT_GRACE_SECONDS
+    )
+    watchdog_config = {
+        "member_wall_timeout_seconds": timeout_seconds,
+        "kimi_attempt_timeout_seconds": kimi_attempt_timeout_seconds,
+        "idle_timeout_seconds": idle_timeout_seconds,
+        "max_output_bytes": max_output_bytes,
+        "max_repeated_events": max_repeated_events,
+        "committee_timeout_seconds": effective_committee_timeout,
+        "committee_timeout_mode": "explicit" if committee_timeout_seconds else "auto_by_concurrency_waves",
+        "quorum_successes": quorum_successes,
+        "quorum_grace_seconds": quorum_grace_seconds,
+    }
+    effective_plan["watchdog"] = watchdog_config
+    if dry_run:
+        return {
+            "schema": "mms.pi_committee.result.v1",
+            "mission_id": effective_plan["mission_id"],
+            "status": "dry_run",
+            "watchdog": {**watchdog_config, "committee_stop_reason": "not_started"},
+            "plan": effective_plan,
+            "results": [],
+        }
 
     prepared = _prepare_members(members, config_root=Path(config_root).expanduser())
-    worker_count = min(max_concurrency, len(members))
     started = time.monotonic()
     results: list[dict[str, Any]] = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count) as pool:
-        futures = {
+    cancellation = mms_pi_watchdog.CancellationController()
+    committee_deadline = started + effective_committee_timeout
+    quorum_deadline: float | None = None
+    succeeded = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=worker_count, thread_name_prefix="pi-committee") as pool:
+        future_to_member = {
             pool.submit(
                 _run_member,
                 member,
                 prepared[member.member_id],
-                task=str(task).strip(),
+                task=task,
                 cwd=target_cwd,
                 timeout_seconds=timeout_seconds,
-                route_source=plan["route_source"],
-            ): member.member_id
+                kimi_attempt_timeout_seconds=kimi_attempt_timeout_seconds,
+                idle_timeout_seconds=idle_timeout_seconds,
+                max_output_bytes=max_output_bytes,
+                max_repeated_events=max_repeated_events,
+                cancellation=cancellation,
+                route_source=effective_plan["route_source"],
+            ): member
             for member in members
         }
-        for future in concurrent.futures.as_completed(futures):
-            member_id = futures[future]
-            try:
-                results.append(future.result())
-            except Exception as exc:
-                results.append(
-                    {
-                        "member_id": member_id,
-                        "status": "worker_error",
-                        "error": _redact_text(str(exc), _all_api_keys(members)),
-                    }
-                )
+        pending = set(future_to_member)
+        while pending:
+            now = time.monotonic()
+            if not cancellation.is_cancelled():
+                if now >= committee_deadline:
+                    cancellation.cancel("committee_timeout")
+                elif quorum_deadline is not None and now >= quorum_deadline:
+                    cancellation.cancel("quorum_reached")
+            if cancellation.is_cancelled():
+                for future in pending:
+                    future.cancel()
+            next_deadline = committee_deadline
+            if quorum_deadline is not None:
+                next_deadline = min(next_deadline, quorum_deadline)
+            wait_seconds = min(0.1, max(0.001, next_deadline - time.monotonic()))
+            done, pending = concurrent.futures.wait(
+                pending,
+                timeout=wait_seconds,
+                return_when=concurrent.futures.FIRST_COMPLETED,
+            )
+            for future in done:
+                member = future_to_member[future]
+                if future.cancelled():
+                    result = _cancelled_member_result(member, cancellation.reason or "cancelled")
+                else:
+                    try:
+                        result = future.result()
+                    except Exception as exc:
+                        result = {
+                            **_member_identity(member),
+                            "status": "worker_error",
+                            "terminal_reason": "worker_error",
+                            "error": _redact_text(str(exc), _all_api_keys(members)),
+                        }
+                results.append(result)
+                if result.get("status") == "success":
+                    succeeded += 1
+                    if quorum_successes and succeeded >= quorum_successes and quorum_deadline is None:
+                        quorum_deadline = time.monotonic() + quorum_grace_seconds
     results.sort(key=lambda item: str(item.get("member_id") or ""))
     succeeded = sum(1 for item in results if item.get("status") == "success")
+    stop_reason = cancellation.reason or "completed"
     return {
         "schema": "mms.pi_committee.result.v1",
-        "mission_id": plan["mission_id"],
+        "mission_id": effective_plan["mission_id"],
         "status": "success" if succeeded == len(results) else ("partial" if succeeded else "failed"),
         "elapsed_ms": int((time.monotonic() - started) * 1000),
         "summary": {"members": len(results), "succeeded": succeeded, "failed": len(results) - succeeded},
-        "plan": plan,
+        "watchdog": {**watchdog_config, "committee_stop_reason": stop_reason},
+        "plan": effective_plan,
         "results": results,
     }
 
@@ -467,16 +718,48 @@ def _run_member(
     task: str,
     cwd: Path,
     timeout_seconds: int,
+    idle_timeout_seconds: int,
+    max_output_bytes: int,
+    max_repeated_events: int,
+    cancellation: mms_pi_watchdog.CancellationController,
     route_source: str,
+    kimi_attempt_timeout_seconds: int = DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + timeout_seconds
     errors: list[str] = []
     attempt_records: list[dict[str, Any]] = []
+    fallback_used = False
+    fallback_skipped_reason = ""
+    last_terminal_reason = "no_route_attempts"
     all_keys = [attempt.binding.api_key for attempt in attempts]
     for index, attempt in enumerate(attempts):
-        remaining = max(1, int(deadline - time.monotonic()))
-        result = _run_attempt(member, attempt, task=task, cwd=cwd, timeout_seconds=remaining)
+        if cancellation.is_cancelled():
+            return _redact_object(_cancelled_member_result(member, cancellation.reason), all_keys)
+        remaining_float = deadline - time.monotonic()
+        if remaining_float < 1:
+            fallback_skipped_reason = "no_budget_remaining" if index > 0 else ""
+            attempt_records.extend(_skipped_attempt_records(attempts[index:], "no_budget_remaining"))
+            break
+        remaining = int(remaining_float)
+        attempt_timeout = _attempt_timeout_seconds(
+            member,
+            remaining_seconds=remaining,
+            attempts_left=len(attempts) - index,
+            kimi_attempt_timeout_seconds=kimi_attempt_timeout_seconds,
+        )
         route_fallback = index > 0
+        fallback_used = fallback_used or route_fallback or bool(attempt.binding.protocol_fallback_reason)
+        result = _run_attempt(
+            member,
+            attempt,
+            task=task,
+            cwd=cwd,
+            timeout_seconds=attempt_timeout,
+            idle_timeout_seconds=idle_timeout_seconds,
+            max_output_bytes=max_output_bytes,
+            max_repeated_events=max_repeated_events,
+            cancellation=cancellation,
+        )
         fallback_reason = "; ".join(errors) if route_fallback else ""
         if attempt.binding.protocol_fallback_reason:
             fallback_reason = "; ".join(
@@ -493,11 +776,17 @@ def _run_member(
         attempt_records.append(
             {
                 "provider_id": attempt.binding.provider_id,
+                "fallback_position": attempt.binding.fallback_position,
+                "started": True,
+                "budget_seconds": attempt_timeout,
                 "status": result.get("status"),
+                "terminal_reason": result.get("terminal_reason", result.get("status")),
                 "error": result.get("error", ""),
+                "watchdog": result.get("watchdog", {}),
                 "cache_transport_evidence": evidence,
             }
         )
+        last_terminal_reason = str(result.get("terminal_reason") or result.get("status") or "unknown")
         if result["status"] == "success":
             result.pop("_usage", None)
             result["fallback_used"] = evidence["fallback_used"]
@@ -506,22 +795,59 @@ def _run_member(
             result["attempts"] = attempt_records
             return _redact_object(result, all_keys)
         errors.append(f"{attempt.binding.provider_id}:{result.get('status')}")
+        if cancellation.is_cancelled():
+            break
         if time.monotonic() >= deadline:
+            if index + 1 < len(attempts):
+                fallback_skipped_reason = "no_budget_remaining"
+                attempt_records.extend(_skipped_attempt_records(attempts[index + 1 :], "no_budget_remaining"))
             break
     return _redact_object(
         {
-            "member_id": member.member_id,
-            "model": member.candidate.model,
-            "family": member.candidate.family,
-            "lens": member.lens,
+            **_member_identity(member),
             "status": "failed",
+            "terminal_reason": last_terminal_reason,
             "error": "; ".join(errors) or "no route attempts were available",
-            "fallback_used": len(errors) > 1,
-            "fallback_reason": "; ".join(errors[:-1]),
+            "fallback_used": fallback_used,
+            "fallback_reason": "; ".join(errors[:-1]) if fallback_used else "",
+            "fallback_skipped_reason": fallback_skipped_reason,
             "attempts": attempt_records,
         },
         all_keys,
     )
+
+
+def _attempt_timeout_seconds(
+    member: MemberSpec,
+    *,
+    remaining_seconds: int,
+    attempts_left: int,
+    kimi_attempt_timeout_seconds: int,
+) -> int:
+    remaining = max(1, int(remaining_seconds))
+    if member.candidate.family != "Kimi" or kimi_attempt_timeout_seconds == 0:
+        return remaining
+    fair_share = max(1, remaining // max(1, attempts_left))
+    return max(1, min(remaining, kimi_attempt_timeout_seconds, fair_share))
+
+
+def _skipped_attempt_records(
+    attempts: Sequence[PreparedAttempt],
+    terminal_reason: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "provider_id": attempt.binding.provider_id,
+            "fallback_position": attempt.binding.fallback_position,
+            "started": False,
+            "budget_seconds": 0,
+            "status": "skipped",
+            "terminal_reason": terminal_reason,
+            "error": "",
+            "watchdog": {},
+        }
+        for attempt in attempts
+    ]
 
 
 def _run_attempt(
@@ -531,6 +857,10 @@ def _run_attempt(
     task: str,
     cwd: Path,
     timeout_seconds: int,
+    idle_timeout_seconds: int,
+    max_output_bytes: int,
+    max_repeated_events: int,
+    cancellation: mms_pi_watchdog.CancellationController,
 ) -> dict[str, Any]:
     started = time.monotonic()
     root = Path(__file__).resolve().parent
@@ -545,6 +875,10 @@ def _run_attempt(
         session_dir.mkdir(parents=True, exist_ok=True)
         _write_private_json(agent_dir / "models.json", attempt.models_payload)
         _write_private_json(agent_dir / "settings.json", {})
+        role_prompt_path: Path | None = None
+        if member.role_card:
+            role_prompt_path = temp_root / "court-role.md"
+            _write_private_text(role_prompt_path, _role_system_prompt(member))
         env_name = _credential_env_name(member.member_id, attempt.binding.fallback_position)
         env = _isolated_env(temp_root)
         env.update(
@@ -575,59 +909,96 @@ def _run_attempt(
             READ_ONLY_TOOLS,
             "--thinking",
             "off",
-            "-p",
-            prompt,
         ]
-        try:
-            completed = subprocess.run(
-                cmd,
-                cwd=cwd,
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                check=False,
-            )
-        except subprocess.TimeoutExpired:
-            return {"status": "timeout", "elapsed_ms": int((time.monotonic() - started) * 1000)}
-    message, parse_error = _parse_pi_stream(completed.stdout)
+        if role_prompt_path is not None:
+            cmd.extend(["--append-system-prompt", str(role_prompt_path)])
+        cmd.extend(["-p", prompt])
+        outcome = mms_pi_watchdog.run_process(
+            cmd,
+            cwd=cwd,
+            env=env,
+            policy=mms_pi_watchdog.WatchdogPolicy(
+                wall_timeout_seconds=timeout_seconds,
+                idle_timeout_seconds=min(idle_timeout_seconds, timeout_seconds),
+                max_output_bytes=max_output_bytes,
+                max_repeated_events=max_repeated_events,
+            ),
+            cancellation=cancellation,
+        )
+    watchdog = outcome.public()
+    if outcome.terminal_reason != "completed":
+        return {
+            "status": outcome.terminal_reason,
+            "terminal_reason": outcome.terminal_reason,
+            "elapsed_ms": outcome.elapsed_ms,
+            "error": outcome.stderr[-800:] if outcome.terminal_reason == "launch_error" else "",
+            "watchdog": watchdog,
+        }
+    message, parse_error = _parse_pi_stream(outcome.stdout)
     text = _message_text(message)
-    if completed.returncode != 0:
+    if outcome.returncode != 0:
         return {
             "status": "launch_error",
+            "terminal_reason": "launch_error",
             "elapsed_ms": int((time.monotonic() - started) * 1000),
-            "error": str(message.get("errorMessage") or completed.stderr[-800:] or parse_error or "Pi exited non-zero"),
+            "error": str(message.get("errorMessage") or outcome.stderr[-800:] or parse_error or "Pi exited non-zero"),
+            "watchdog": watchdog,
         }
     if str(message.get("stopReason") or "").strip().lower() == "error":
         return {
             "status": "request_error",
+            "terminal_reason": "request_error",
             "elapsed_ms": int((time.monotonic() - started) * 1000),
             "error": str(message.get("errorMessage") or "Pi request failed"),
+            "watchdog": watchdog,
         }
     if not text:
-        return {"status": "empty_response", "elapsed_ms": int((time.monotonic() - started) * 1000)}
+        return {
+            "status": "empty_response",
+            "terminal_reason": "empty_response",
+            "elapsed_ms": int((time.monotonic() - started) * 1000),
+            "watchdog": watchdog,
+        }
     parsed = _parse_response_object(text)
     return {
-        "member_id": member.member_id,
-        "model": member.candidate.model,
-        "family": member.candidate.family,
-        "lens": member.lens,
+        **_member_identity(member),
         "status": "success",
+        "terminal_reason": "completed",
         "elapsed_ms": int((time.monotonic() - started) * 1000),
         "provider_id": attempt.binding.provider_id,
         "protocol": attempt.binding.protocol,
         "response": parsed if parsed is not None else {"raw_text": text},
+        "watchdog": watchdog,
         "_usage": _normalize_usage(message.get("usage")),
     }
 
 
+def _cancelled_member_result(member: MemberSpec, reason: str) -> dict[str, Any]:
+    terminal_reason = str(reason or "cancelled").strip() or "cancelled"
+    return {
+        **_member_identity(member),
+        "status": "failed",
+        "terminal_reason": terminal_reason,
+        "error": terminal_reason,
+        "fallback_used": False,
+        "fallback_reason": "",
+        "attempts": [],
+    }
+
+
 def _worker_prompt(task: str, member: MemberSpec) -> str:
+    assignments = [f"Your assigned lens: {member.lens}"]
+    if member.domain:
+        assignments.append(f"Your assigned domain: {member.domain}")
+    if member.role_id:
+        assignments.append(f"Your assigned role: {member.role_id}")
+    assignment_text = "\n".join(assignments)
     return f"""You are an independent read-only committee member.
 
 Mission:
 {task}
 
-Your assigned lens: {member.lens}
+{assignment_text}
 
 Rules:
 - Inspect only. Do not edit files, run shell commands, or invoke other agents.
@@ -641,8 +1012,40 @@ Required JSON shape:
   "confidence": 0.0,
   "findings": [{{"claim": "...", "evidence": ["path or fact"], "severity": "low|medium|high"}}],
   "risks": ["..."],
-  "recommendation": "..."
+  "recommendation": "...",
+  "role_payload": {{}}
 }}
+""".strip()
+
+
+def _member_identity(member: MemberSpec) -> dict[str, Any]:
+    identity = {
+        "member_id": member.member_id,
+        "model": member.candidate.model,
+        "family": member.candidate.family,
+        "lens": member.lens,
+    }
+    if member.domain:
+        identity["domain"] = member.domain
+        identity["required_domain"] = member.required_domain
+    if member.role_id:
+        identity["role_id"] = member.role_id
+    if member.role_card_sha256:
+        identity["role_card_sha256"] = member.role_card_sha256
+    return identity
+
+
+def _role_system_prompt(member: MemberSpec) -> str:
+    return f"""Canonical role card ({member.role_id}):
+
+{member.role_card.strip()}
+
+Pi Court adapter contract:
+- Apply the role card's method, gates, and evidence discipline only within the assigned domain and mission.
+- Remain an independent read-only court seat. Do not edit files, run shell commands, or invoke other agents.
+- The committee JSON envelope requested by the user prompt has precedence over any role-specific output shape.
+- Put useful role-specific fields under top-level role_payload; keep verdict, confidence, findings, risks, and recommendation populated.
+- Do not claim domain expertise, testing, or evidence that was not actually inspected.
 """.strip()
 
 
@@ -652,6 +1055,7 @@ def _build_route_chain(model: str, route_group: Mapping[str, Any], profile: Mapp
         raise CommitteeError("route primary is missing")
     chain_rows: list[Mapping[str, Any]] = [primary]
     chain_rows.extend(item for item in route_group.get("fallbacks") or [] if isinstance(item, Mapping))
+    chain_rows = _order_route_rows(model, chain_rows)
     bindings: list[RouteBinding] = []
     for position, row in enumerate(chain_rows):
         try:
@@ -664,6 +1068,30 @@ def _build_route_chain(model: str, route_group: Mapping[str, Any], profile: Mapp
             if position == 0:
                 raise
     return tuple(bindings)
+
+
+def _order_route_rows(model: str, rows: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    if _infer_family(model) != "Kimi":
+        return list(rows)
+    return [
+        row
+        for _index, row in sorted(enumerate(rows), key=lambda item: (_kimi_provider_rank(item[1]), item[0]))
+    ]
+
+
+def _kimi_provider_rank(row: Mapping[str, Any]) -> int:
+    provider_id = str(row.get("provider_id") or "").strip().lower()
+    profile = str(row.get("provider_profile") or row.get("profile") or "").strip().lower()
+    identity = f"{provider_id} {profile}"
+    if any(keyword in identity for keyword in _KIMI_PRIMARY_PROVIDER_KEYWORDS):
+        return 0
+    if any(keyword in identity for keyword in _KIMI_FALLBACK_PROVIDER_KEYWORDS):
+        return 1
+    if any(keyword in identity for keyword in _KIMI_DIRECT_PROVIDER_KEYWORDS):
+        return 3
+    if "kimi" in identity and "direct" in identity:
+        return 3
+    return 2
 
 
 def _pi_binding_block_reason(model: str, binding: RouteBinding) -> str:
@@ -954,11 +1382,13 @@ def _frontier_model_sort_key(candidate: ModelCandidate) -> tuple[Any, ...]:
     channel_rank = 1
     if candidate.family == "Kimi":
         if lower == "kimi-for-coding":
-            channel_rank = 0
-        elif lower == "kimi-for-code":
             channel_rank = 1
-        else:
+        elif lower == "kimi-for-code":
             channel_rank = 2
+        elif "code" in lower or "coding" in lower:
+            channel_rank = 0
+        else:
+            channel_rank = 3
     elif candidate.family == "Gemini":
         if re.fullmatch(r"gemini-\d+(?:\.\d+)?-flash-agent\(high\)", lower):
             channel_rank = 0
@@ -973,7 +1403,10 @@ def _frontier_model_sort_key(candidate: ModelCandidate) -> tuple[Any, ...]:
     elif candidate.family == "GPT":
         variant_rank = 0 if lower.startswith("gpt-") else (1 if lower.startswith("codex-") else 2)
     tier_rank = {"primary": 0, "preferred": 0, "secondary": 1, "fallback": 2}.get(candidate.tier, 1)
-    family_rank = (channel_rank, version, variant_rank) if candidate.family in {"Kimi", "Gemini"} else (version, variant_rank, channel_rank)
+    if candidate.family == "Gemini":
+        family_rank = (channel_rank, version, variant_rank)
+    else:
+        family_rank = (version, channel_rank, variant_rank) if candidate.family == "Kimi" else (version, variant_rank, channel_rank)
     return (
         *family_rank,
         0 if candidate.favorite else 1,
@@ -1012,13 +1445,15 @@ def _candidate_sort_key(candidate: ModelCandidate) -> tuple[Any, ...]:
 
 def _infer_family(model: str) -> str:
     normalized = model.lower()
+    if re.fullmatch(r"k\d+(?:\.\d+)*(?:-[a-z0-9-]+)?", normalized):
+        return "Kimi"
     families = (
         ("Claude", ("claude",)),
         ("GPT", ("gpt", "codex", "o1", "o3", "o4")),
         ("Gemini", ("gemini",)),
         ("DeepSeek", ("deepseek",)),
         ("Qwen", ("qwen",)),
-        ("Kimi", ("kimi", "k2.6")),
+        ("Kimi", ("kimi",)),
         ("MiMo", ("mimo",)),
         ("MiniMax", ("minimax",)),
         ("GLM", ("glm",)),
@@ -1186,6 +1621,12 @@ def _write_private_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.chmod(0o600)
 
 
+def _write_private_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value.rstrip() + "\n", encoding="utf-8")
+    path.chmod(0o600)
+
+
 def _patch_wire_model(provider: dict[str, Any], logical_model: str, wire_model: str) -> str:
     models = provider.get("models") if isinstance(provider.get("models"), list) else []
     if not models:
@@ -1287,12 +1728,17 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 __all__ = [
     "CommitteeError",
+    "DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS",
     "DEFAULT_LENSES",
+    "DEFAULT_MAX_BUNDLE_AGE_DAYS",
     "ModelCandidate",
     "RouteBinding",
     "build_candidates",
+    "load_candidates",
     "load_catalog",
     "plan_committee",
+    "public_bundle_metadata",
     "run_committee",
+    "run_preplanned_committee",
     "select_members",
 ]

--- a/mms_pi_parent.py
+++ b/mms_pi_parent.py
@@ -1,0 +1,363 @@
+"""Parent-facing adapter for the opt-in Pi committee runtime.
+
+The adapter is deterministic: it preserves member responses, flattens evidence,
+and defines a synthesis contract. Semantic consensus remains the responsibility
+of the current Codex or Claude parent; this module never launches a synthesizer.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import mms_pi_committee
+
+
+RESULT_SCHEMA = "mms.pi_committee.result.v1"
+PARENT_PACKET_SCHEMA = "mms.pi_committee.parent_packet.v1"
+
+
+class ParentPacketError(ValueError):
+    """Raised when a committee result cannot become a safe parent packet."""
+
+
+def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
+    """Build a lossless, synthesis-ready packet from a committee result."""
+    if not isinstance(result, Mapping) or result.get("schema") != RESULT_SCHEMA:
+        raise ParentPacketError(f"expected {RESULT_SCHEMA}")
+    if not isinstance(result.get("plan"), Mapping):
+        raise ParentPacketError("committee result plan must be an object")
+    plan = _mapping(result.get("plan"))
+    result_status = str(result.get("status") or "unknown").strip().lower()
+    raw_planned_rows = plan.get("members")
+    if not isinstance(raw_planned_rows, list) or not all(isinstance(item, Mapping) for item in raw_planned_rows):
+        raise ParentPacketError("committee result plan.members must be an array of objects")
+    planned_rows = list(raw_planned_rows)
+    planned_by_id = {
+        str(item.get("member_id") or "").strip(): item
+        for item in planned_rows
+        if str(item.get("member_id") or "").strip()
+    }
+    raw_result_rows = result.get("results")
+    if not isinstance(raw_result_rows, list) or not all(isinstance(item, Mapping) for item in raw_result_rows):
+        raise ParentPacketError("committee result results must be an array of objects")
+    result_rows = list(raw_result_rows)
+
+    opinions: list[dict[str, Any]] = []
+    evidence_index: list[dict[str, Any]] = []
+    route_health: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    status_counts: Counter[str] = Counter()
+    family_counts: Counter[str] = Counter()
+    returned_ids: set[str] = set()
+    structured_count = 0
+    raw_count = 0
+    fallback_count = 0
+
+    for row_index, row in enumerate(result_rows, start=1):
+        member_id = str(row.get("member_id") or f"unidentified-{row_index:02d}").strip()
+        returned_ids.add(member_id)
+        planned = _mapping(planned_by_id.get(member_id))
+        status = str(row.get("status") or "unknown").strip().lower()
+        model = str(row.get("model") or planned.get("model") or "").strip()
+        family = str(row.get("family") or planned.get("family") or "Other").strip() or "Other"
+        lens = str(row.get("lens") or planned.get("lens") or "").strip()
+        response = _response_object(row.get("response"))
+        response_format = _response_format(response)
+        if response_format == "structured_json":
+            structured_count += 1
+        elif response_format == "raw_text":
+            raw_count += 1
+        if bool(row.get("fallback_used")):
+            fallback_count += 1
+
+        normalized_findings = _normalize_findings(
+            response.get("findings"),
+            member_id=member_id,
+            model=model,
+            evidence_index=evidence_index,
+        )
+        opinion = {
+            "member_id": member_id,
+            "model": model,
+            "family": family,
+            "lens": lens,
+            "status": status,
+            "response_format": response_format,
+            "verdict": str(response.get("verdict") or "").strip(),
+            "confidence": _confidence(response.get("confidence")),
+            "findings": normalized_findings,
+            "risks": _string_list(response.get("risks")),
+            "recommendation": str(response.get("recommendation") or "").strip(),
+            "response": copy.deepcopy(response),
+            "fallback_used": bool(row.get("fallback_used")),
+            "fallback_reason": str(row.get("fallback_reason") or "").strip(),
+        }
+        if row.get("error"):
+            opinion["error"] = str(row.get("error"))
+        opinions.append(opinion)
+        status_counts[status] += 1
+        family_counts[family] += 1
+
+        health = _route_health(row, planned=planned, member_id=member_id, model=model, status=status)
+        route_health.append(health)
+        if status != "success":
+            failures.append(
+                {
+                    "member_id": member_id,
+                    "model": model,
+                    "status": status,
+                    "error": str(row.get("error") or "").strip(),
+                    "attempts": copy.deepcopy(health["attempts"]),
+                }
+            )
+
+    if result_status != "dry_run":
+        for member_id, planned in planned_by_id.items():
+            if member_id in returned_ids:
+                continue
+            model = str(planned.get("model") or "").strip()
+            failures.append(
+                {
+                    "member_id": member_id,
+                    "model": model,
+                    "status": "missing_result",
+                    "error": "planned member returned no result",
+                    "attempts": [],
+                }
+            )
+            status_counts["missing_result"] += 1
+    succeeded = status_counts.get("success", 0)
+    ready_for_synthesis = result_status != "dry_run" and succeeded > 0
+    mission_id = str(result.get("mission_id") or plan.get("mission_id") or "").strip()
+    return {
+        "schema": PARENT_PACKET_SCHEMA,
+        "status": result_status,
+        "ready_for_synthesis": ready_for_synthesis,
+        "mission": {
+            "mission_id": mission_id,
+            "task": str(plan.get("task") or "").strip(),
+            "route_source": str(plan.get("route_source") or "").strip(),
+            "elapsed_ms": _non_negative_int(result.get("elapsed_ms")),
+            "selection": copy.deepcopy(_mapping(plan.get("selection"))),
+        },
+        "committee_plan": copy.deepcopy(plan),
+        "committee_health": {
+            "planned_members": len(planned_rows),
+            "returned_members": len(result_rows),
+            "succeeded": succeeded,
+            "failed_or_missing": len(failures),
+            "structured_responses": structured_count,
+            "raw_responses": raw_count,
+            "fallback_members": fallback_count,
+            "status_counts": dict(sorted(status_counts.items())),
+            "family_counts": dict(sorted(family_counts.items())),
+        },
+        "opinions": opinions,
+        "evidence_index": evidence_index,
+        "route_health": route_health,
+        "failures": failures,
+        "synthesis_contract": _synthesis_contract(),
+        "source_result_schema": RESULT_SCHEMA,
+    }
+
+
+def run_parent_committee(
+    *,
+    config_root: str | Path,
+    task: str,
+    cwd: str | Path,
+    count: int | None = None,
+    min_families: int = mms_pi_committee.DEFAULT_MIN_FAMILIES,
+    explicit_models: Sequence[str] = (),
+    selection_profile: str = mms_pi_committee.DEFAULT_SELECTION_PROFILE,
+    frontier_families: Sequence[str] = mms_pi_committee.DEFAULT_FRONTIER_FAMILIES,
+    additional_models: Sequence[str] = (),
+    required_capabilities: Sequence[str] = ("text",),
+    lenses: Sequence[str] = mms_pi_committee.DEFAULT_LENSES,
+    max_concurrency: int = mms_pi_committee.DEFAULT_MAX_CONCURRENCY,
+    timeout_seconds: int = mms_pi_committee.DEFAULT_TIMEOUT_SECONDS,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run the existing committee runtime and return a parent packet."""
+    result = mms_pi_committee.run_committee(
+        config_root=config_root,
+        task=task,
+        cwd=cwd,
+        count=count,
+        min_families=min_families,
+        explicit_models=explicit_models,
+        selection_profile=selection_profile,
+        frontier_families=frontier_families,
+        additional_models=additional_models,
+        required_capabilities=required_capabilities,
+        lenses=lenses,
+        max_concurrency=max_concurrency,
+        timeout_seconds=timeout_seconds,
+        dry_run=dry_run,
+    )
+    return build_parent_packet(result)
+
+
+def _normalize_findings(
+    raw: Any,
+    *,
+    member_id: str,
+    model: str,
+    evidence_index: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    rows = raw if isinstance(raw, list) else []
+    for finding_index, item in enumerate(rows, start=1):
+        row = item if isinstance(item, Mapping) else {"claim": str(item)}
+        claim = str(row.get("claim") or row.get("finding") or "").strip()
+        evidence = _string_list(row.get("evidence"))
+        severity = str(row.get("severity") or "").strip().lower()
+        evidence_id = f"{member_id}-finding-{finding_index:02d}"
+        normalized = {
+            "evidence_id": evidence_id,
+            "claim": claim,
+            "evidence": evidence,
+            "severity": severity,
+            "original": copy.deepcopy(dict(row)),
+        }
+        findings.append(normalized)
+        evidence_index.append(
+            {
+                "evidence_id": evidence_id,
+                "member_id": member_id,
+                "model": model,
+                "claim": claim,
+                "evidence": evidence,
+                "severity": severity,
+            }
+        )
+    return findings
+
+
+def _route_health(
+    row: Mapping[str, Any],
+    *,
+    planned: Mapping[str, Any],
+    member_id: str,
+    model: str,
+    status: str,
+) -> dict[str, Any]:
+    attempts = []
+    for attempt in row.get("attempts") or []:
+        if not isinstance(attempt, Mapping):
+            continue
+        evidence = _mapping(attempt.get("cache_transport_evidence"))
+        attempts.append(
+            {
+                "provider_id": str(attempt.get("provider_id") or evidence.get("provider_id") or "").strip(),
+                "status": str(attempt.get("status") or "unknown").strip().lower(),
+                "error": str(attempt.get("error") or "").strip(),
+                "protocol": str(evidence.get("protocol") or "").strip(),
+                "request_path": str(evidence.get("request_path") or "").strip(),
+                "fallback_used": bool(evidence.get("fallback_used")),
+            }
+        )
+    if not attempts and isinstance(row.get("cache_transport_evidence"), Mapping):
+        evidence = _mapping(row.get("cache_transport_evidence"))
+        attempts.append(
+            {
+                "provider_id": str(row.get("provider_id") or evidence.get("provider_id") or "").strip(),
+                "status": status,
+                "error": str(row.get("error") or "").strip(),
+                "protocol": str(evidence.get("protocol") or row.get("protocol") or "").strip(),
+                "request_path": str(evidence.get("request_path") or "").strip(),
+                "fallback_used": bool(evidence.get("fallback_used")),
+            }
+        )
+    return {
+        "member_id": member_id,
+        "model": model,
+        "status": status,
+        "planned_routes": len(planned.get("route_chain") or []),
+        "fallback_used": bool(row.get("fallback_used")),
+        "attempts": attempts,
+    }
+
+
+def _synthesis_contract() -> dict[str, Any]:
+    return {
+        "owner": "current_parent",
+        "semantic_grouping": "parent_reasoning_required",
+        "required_sections": [
+            "committee_health",
+            "consensus",
+            "dissent",
+            "unique_findings",
+            "risks",
+            "recommendation",
+            "confidence",
+        ],
+        "rules": [
+            "Inspect every opinion, including raw_text and failed members.",
+            "Call a claim consensus only when at least two independent members support it.",
+            "Cite member_id and evidence_id for synthesized claims.",
+            "Keep factual evidence separate from parent inference.",
+            "Preserve minority dissent; do not reduce the committee to majority voting.",
+            "Lower confidence when failures, raw responses, or unsupported claims materially affect coverage.",
+        ],
+        "output_shape": {
+            "committee_health": "short health summary",
+            "consensus": [{"claim": "...", "supported_by": ["member-01"], "evidence_ids": []}],
+            "dissent": [{"topic": "...", "positions": [{"member_id": "member-01", "position": "..."}]}],
+            "unique_findings": [{"claim": "...", "member_id": "member-01", "evidence_ids": []}],
+            "risks": ["..."],
+            "recommendation": "parent decision",
+            "confidence": 0.0,
+        },
+    }
+
+
+def _response_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return copy.deepcopy(dict(value))
+    if value is None:
+        return {}
+    return {"raw_text": str(value)}
+
+
+def _response_format(response: Mapping[str, Any]) -> str:
+    if response.get("raw_text") is not None:
+        return "raw_text"
+    return "structured_json" if response else "none"
+
+
+def _confidence(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(1.0, number))
+
+
+def _string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    rows = value if isinstance(value, list) else [value]
+    return [str(item).strip() for item in rows if str(item).strip()]
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _non_negative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = [
+    "PARENT_PACKET_SCHEMA",
+    "ParentPacketError",
+    "build_parent_packet",
+    "run_parent_committee",
+]

--- a/mms_pi_parent.py
+++ b/mms_pi_parent.py
@@ -8,6 +8,7 @@ of the current Codex or Claude parent; this module never launches a synthesizer.
 from __future__ import annotations
 
 import copy
+import math
 from collections import Counter
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -17,6 +18,8 @@ import mms_pi_committee
 
 RESULT_SCHEMA = "mms.pi_committee.result.v1"
 PARENT_PACKET_SCHEMA = "mms.pi_committee.parent_packet.v1"
+MIN_SYNTHESIS_COVERAGE_RATIO = 0.5
+MIN_SYNTHESIS_SUCCESSES = 2
 
 
 class ParentPacketError(ValueError):
@@ -70,7 +73,8 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
             structured_count += 1
         elif response_format == "raw_text":
             raw_count += 1
-        if bool(row.get("fallback_used")):
+        fallback_used = _fallback_was_used(row)
+        if fallback_used:
             fallback_count += 1
 
         normalized_findings = _normalize_findings(
@@ -92,9 +96,18 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
             "risks": _string_list(response.get("risks")),
             "recommendation": str(response.get("recommendation") or "").strip(),
             "response": copy.deepcopy(response),
-            "fallback_used": bool(row.get("fallback_used")),
+            "fallback_used": fallback_used,
             "fallback_reason": str(row.get("fallback_reason") or "").strip(),
+            "fallback_skipped_reason": str(row.get("fallback_skipped_reason") or "").strip(),
+            "terminal_reason": str(row.get("terminal_reason") or "").strip(),
+            "watchdog": copy.deepcopy(_mapping(row.get("watchdog"))),
         }
+        for field in ("domain", "role_id", "role_card_source", "role_card_sha256"):
+            value = str(row.get(field) or planned.get(field) or "").strip()
+            if value:
+                opinion[field] = value
+        if opinion.get("domain"):
+            opinion["required_domain"] = bool(row.get("required_domain", planned.get("required_domain", False)))
         if row.get("error"):
             opinion["error"] = str(row.get("error"))
         opinions.append(opinion)
@@ -110,6 +123,8 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
                     "model": model,
                     "status": status,
                     "error": str(row.get("error") or "").strip(),
+                    "terminal_reason": str(row.get("terminal_reason") or "").strip(),
+                    "fallback_skipped_reason": str(row.get("fallback_skipped_reason") or "").strip(),
                     "attempts": copy.deepcopy(health["attempts"]),
                 }
             )
@@ -130,18 +145,35 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
             )
             status_counts["missing_result"] += 1
     succeeded = status_counts.get("success", 0)
-    ready_for_synthesis = result_status != "dry_run" and succeeded > 0
+    planned_count = len(planned_rows)
+    required_successes = _required_synthesis_successes(planned_count)
+    coverage_ratio = succeeded / planned_count if planned_count else 0.0
+    coverage_met = planned_count > 0 and succeeded >= required_successes
+    ready_for_synthesis = result_status != "dry_run" and coverage_met
+    readiness_reason = (
+        "dry_run"
+        if result_status == "dry_run"
+        else ("sufficient_coverage" if coverage_met else "insufficient_coverage")
+    )
     mission_id = str(result.get("mission_id") or plan.get("mission_id") or "").strip()
     return {
         "schema": PARENT_PACKET_SCHEMA,
         "status": result_status,
         "ready_for_synthesis": ready_for_synthesis,
+        "synthesis_readiness": {
+            "reason": readiness_reason,
+            "coverage_met": coverage_met,
+            "coverage_ratio": round(coverage_ratio, 6),
+            "required_coverage_ratio": MIN_SYNTHESIS_COVERAGE_RATIO,
+            "required_successes": required_successes,
+        },
         "mission": {
             "mission_id": mission_id,
             "task": str(plan.get("task") or "").strip(),
             "route_source": str(plan.get("route_source") or "").strip(),
             "elapsed_ms": _non_negative_int(result.get("elapsed_ms")),
             "selection": copy.deepcopy(_mapping(plan.get("selection"))),
+            "watchdog": copy.deepcopy(_mapping(result.get("watchdog"))),
         },
         "committee_plan": copy.deepcopy(plan),
         "committee_health": {
@@ -152,6 +184,9 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
             "structured_responses": structured_count,
             "raw_responses": raw_count,
             "fallback_members": fallback_count,
+            "coverage_ratio": round(coverage_ratio, 6),
+            "required_successes_for_synthesis": required_successes,
+            "synthesis_coverage_met": coverage_met,
             "status_counts": dict(sorted(status_counts.items())),
             "family_counts": dict(sorted(family_counts.items())),
         },
@@ -159,7 +194,7 @@ def build_parent_packet(result: Mapping[str, Any]) -> dict[str, Any]:
         "evidence_index": evidence_index,
         "route_health": route_health,
         "failures": failures,
-        "synthesis_contract": _synthesis_contract(),
+        "synthesis_contract": synthesis_contract(),
         "source_result_schema": RESULT_SCHEMA,
     }
 
@@ -179,6 +214,14 @@ def run_parent_committee(
     lenses: Sequence[str] = mms_pi_committee.DEFAULT_LENSES,
     max_concurrency: int = mms_pi_committee.DEFAULT_MAX_CONCURRENCY,
     timeout_seconds: int = mms_pi_committee.DEFAULT_TIMEOUT_SECONDS,
+    kimi_attempt_timeout_seconds: int = mms_pi_committee.DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
+    max_bundle_age_days: int = mms_pi_committee.DEFAULT_MAX_BUNDLE_AGE_DAYS,
+    idle_timeout_seconds: int = mms_pi_committee.DEFAULT_IDLE_TIMEOUT_SECONDS,
+    max_output_bytes: int = mms_pi_committee.DEFAULT_MAX_OUTPUT_BYTES,
+    max_repeated_events: int = mms_pi_committee.DEFAULT_MAX_REPEATED_EVENTS,
+    committee_timeout_seconds: int = mms_pi_committee.DEFAULT_COMMITTEE_TIMEOUT_SECONDS,
+    quorum_successes: int = mms_pi_committee.DEFAULT_QUORUM_SUCCESSES,
+    quorum_grace_seconds: int = mms_pi_committee.DEFAULT_QUORUM_GRACE_SECONDS,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Run the existing committee runtime and return a parent packet."""
@@ -196,6 +239,14 @@ def run_parent_committee(
         lenses=lenses,
         max_concurrency=max_concurrency,
         timeout_seconds=timeout_seconds,
+        kimi_attempt_timeout_seconds=kimi_attempt_timeout_seconds,
+        max_bundle_age_days=max_bundle_age_days,
+        idle_timeout_seconds=idle_timeout_seconds,
+        max_output_bytes=max_output_bytes,
+        max_repeated_events=max_repeated_events,
+        committee_timeout_seconds=committee_timeout_seconds,
+        quorum_successes=quorum_successes,
+        quorum_grace_seconds=quorum_grace_seconds,
         dry_run=dry_run,
     )
     return build_parent_packet(result)
@@ -253,8 +304,13 @@ def _route_health(
         attempts.append(
             {
                 "provider_id": str(attempt.get("provider_id") or evidence.get("provider_id") or "").strip(),
+                "fallback_position": _non_negative_int(attempt.get("fallback_position")),
+                "started": bool(attempt.get("started", str(attempt.get("status") or "").lower() != "skipped")),
+                "budget_seconds": _non_negative_int(attempt.get("budget_seconds")),
                 "status": str(attempt.get("status") or "unknown").strip().lower(),
+                "terminal_reason": str(attempt.get("terminal_reason") or "").strip(),
                 "error": str(attempt.get("error") or "").strip(),
+                "watchdog": copy.deepcopy(_mapping(attempt.get("watchdog"))),
                 "protocol": str(evidence.get("protocol") or "").strip(),
                 "request_path": str(evidence.get("request_path") or "").strip(),
                 "fallback_used": bool(evidence.get("fallback_used")),
@@ -265,8 +321,13 @@ def _route_health(
         attempts.append(
             {
                 "provider_id": str(row.get("provider_id") or evidence.get("provider_id") or "").strip(),
+                "fallback_position": 0,
+                "started": True,
+                "budget_seconds": 0,
                 "status": status,
+                "terminal_reason": str(row.get("terminal_reason") or "").strip(),
                 "error": str(row.get("error") or "").strip(),
+                "watchdog": copy.deepcopy(_mapping(row.get("watchdog"))),
                 "protocol": str(evidence.get("protocol") or row.get("protocol") or "").strip(),
                 "request_path": str(evidence.get("request_path") or "").strip(),
                 "fallback_used": bool(evidence.get("fallback_used")),
@@ -276,13 +337,50 @@ def _route_health(
         "member_id": member_id,
         "model": model,
         "status": status,
+        "terminal_reason": str(row.get("terminal_reason") or "").strip(),
+        "watchdog": copy.deepcopy(_mapping(row.get("watchdog"))),
         "planned_routes": len(planned.get("route_chain") or []),
-        "fallback_used": bool(row.get("fallback_used")),
+        "fallback_used": _fallback_was_used(row),
+        "fallback_skipped_reason": str(row.get("fallback_skipped_reason") or "").strip(),
         "attempts": attempts,
     }
 
 
-def _synthesis_contract() -> dict[str, Any]:
+def _fallback_was_used(row: Mapping[str, Any]) -> bool:
+    raw_attempts = row.get("attempts")
+    if not isinstance(raw_attempts, list) or not raw_attempts:
+        return bool(row.get("fallback_used"))
+    has_explicit_start_state = any(
+        isinstance(attempt, Mapping) and ("started" in attempt or str(attempt.get("status") or "").lower() == "skipped")
+        for attempt in raw_attempts
+    )
+    if not has_explicit_start_state:
+        return bool(row.get("fallback_used"))
+    for index, attempt in enumerate(raw_attempts):
+        if not isinstance(attempt, Mapping):
+            continue
+        status = str(attempt.get("status") or "").strip().lower()
+        started = bool(attempt.get("started", status != "skipped")) and status != "skipped"
+        if not started:
+            continue
+        evidence = _mapping(attempt.get("cache_transport_evidence"))
+        if index > 0 or bool(evidence.get("fallback_used")):
+            return True
+    return False
+
+
+def _required_synthesis_successes(planned_members: int) -> int:
+    if planned_members <= 0:
+        return 1
+    if planned_members == 1:
+        return 1
+    return min(
+        planned_members,
+        max(MIN_SYNTHESIS_SUCCESSES, math.ceil(planned_members * MIN_SYNTHESIS_COVERAGE_RATIO)),
+    )
+
+
+def synthesis_contract() -> dict[str, Any]:
     return {
         "owner": "current_parent",
         "semantic_grouping": "parent_reasoning_required",
@@ -296,6 +394,7 @@ def _synthesis_contract() -> dict[str, Any]:
             "confidence",
         ],
         "rules": [
+            "Do not synthesize when ready_for_synthesis is false; report insufficient coverage instead.",
             "Inspect every opinion, including raw_text and failed members.",
             "Call a claim consensus only when at least two independent members support it.",
             "Cite member_id and evidence_id for synthesized claims.",
@@ -313,6 +412,11 @@ def _synthesis_contract() -> dict[str, Any]:
             "confidence": 0.0,
         },
     }
+
+
+def _synthesis_contract() -> dict[str, Any]:
+    """Backward-compatible private alias for older local callers."""
+    return synthesis_contract()
 
 
 def _response_object(value: Any) -> dict[str, Any]:
@@ -360,4 +464,5 @@ __all__ = [
     "ParentPacketError",
     "build_parent_packet",
     "run_parent_committee",
+    "synthesis_contract",
 ]

--- a/mms_pi_watchdog.py
+++ b/mms_pi_watchdog.py
@@ -1,0 +1,306 @@
+"""Streaming process watchdog for isolated Pi committee workers."""
+
+from __future__ import annotations
+
+import os
+import queue
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+STREAM_QUEUE_MAX_CHUNKS = 64
+
+
+@dataclass(frozen=True)
+class WatchdogPolicy:
+    wall_timeout_seconds: float
+    idle_timeout_seconds: float
+    max_output_bytes: int
+    max_repeated_events: int
+    terminate_grace_seconds: float = 3.0
+    poll_interval_seconds: float = 0.05
+
+    def validate(self) -> None:
+        if self.wall_timeout_seconds <= 0:
+            raise ValueError("wall timeout must be greater than zero")
+        if self.idle_timeout_seconds <= 0:
+            raise ValueError("idle timeout must be greater than zero")
+        if self.max_output_bytes < 1:
+            raise ValueError("max output bytes must be at least 1")
+        if self.max_repeated_events < 2:
+            raise ValueError("max repeated events must be at least 2")
+        if self.terminate_grace_seconds < 0:
+            raise ValueError("terminate grace must not be negative")
+        if self.poll_interval_seconds <= 0:
+            raise ValueError("poll interval must be greater than zero")
+
+    def public(self) -> dict[str, int | float]:
+        return {
+            "wall_timeout_seconds": self.wall_timeout_seconds,
+            "idle_timeout_seconds": self.idle_timeout_seconds,
+            "max_output_bytes": self.max_output_bytes,
+            "max_repeated_events": self.max_repeated_events,
+            "terminate_grace_seconds": self.terminate_grace_seconds,
+        }
+
+
+class CancellationController:
+    """Thread-safe cooperative cancellation shared by committee workers."""
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._lock = threading.Lock()
+        self._reason = ""
+
+    def cancel(self, reason: str) -> bool:
+        normalized = str(reason or "cancelled").strip() or "cancelled"
+        with self._lock:
+            if self._event.is_set():
+                return False
+            self._reason = normalized
+            self._event.set()
+            return True
+
+    @property
+    def reason(self) -> str:
+        with self._lock:
+            return self._reason
+
+    def is_cancelled(self) -> bool:
+        return self._event.is_set()
+
+
+@dataclass(frozen=True)
+class ProcessOutcome:
+    terminal_reason: str
+    returncode: int | None
+    stdout: str
+    stderr: str
+    elapsed_ms: int
+    stdout_bytes: int
+    stderr_bytes: int
+    peak_repeated_events: int
+    terminated: bool
+    forced_kill: bool
+
+    def public(self) -> dict[str, int | bool | str | None]:
+        return {
+            "terminal_reason": self.terminal_reason,
+            "returncode": self.returncode,
+            "elapsed_ms": self.elapsed_ms,
+            "stdout_bytes": self.stdout_bytes,
+            "stderr_bytes": self.stderr_bytes,
+            "peak_repeated_events": self.peak_repeated_events,
+            "terminated": self.terminated,
+            "forced_kill": self.forced_kill,
+        }
+
+
+def run_process(
+    command: Sequence[str],
+    *,
+    cwd: str | os.PathLike[str],
+    env: Mapping[str, str],
+    policy: WatchdogPolicy,
+    cancellation: CancellationController | None = None,
+) -> ProcessOutcome:
+    """Run a command with streaming bounded capture and group termination."""
+    policy.validate()
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(
+            list(command),
+            cwd=Path(cwd),
+            env=dict(env),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            start_new_session=(os.name == "posix"),
+        )
+    except OSError as exc:
+        return ProcessOutcome(
+            terminal_reason="launch_error",
+            returncode=None,
+            stdout="",
+            stderr=str(exc),
+            elapsed_ms=int((time.monotonic() - started) * 1000),
+            stdout_bytes=0,
+            stderr_bytes=0,
+            peak_repeated_events=0,
+            terminated=False,
+            forced_kill=False,
+        )
+
+    chunks: queue.Queue[tuple[str, bytes | None]] = queue.Queue(maxsize=STREAM_QUEUE_MAX_CHUNKS)
+    readers = [
+        threading.Thread(target=_read_stream, args=("stdout", process.stdout, chunks), daemon=True),
+        threading.Thread(target=_read_stream, args=("stderr", process.stderr, chunks), daemon=True),
+    ]
+    for reader in readers:
+        reader.start()
+
+    captured = {"stdout": bytearray(), "stderr": bytearray()}
+    line_buffers = {"stdout": bytearray(), "stderr": bytearray()}
+    total_bytes = {"stdout": 0, "stderr": 0}
+    repeat_state: dict[str, tuple[bytes, int]] = {"stdout": (b"", 0), "stderr": (b"", 0)}
+    peak_repeated = 0
+    eof_streams: set[str] = set()
+    last_activity = started
+    terminal_reason = "completed"
+    terminated = False
+    forced_kill = False
+
+    while True:
+        now = time.monotonic()
+        if process.poll() is None:
+            if cancellation is not None and cancellation.is_cancelled():
+                terminal_reason = cancellation.reason or "cancelled"
+            elif now - started >= policy.wall_timeout_seconds:
+                terminal_reason = "wall_timeout"
+            elif now - last_activity >= policy.idle_timeout_seconds:
+                terminal_reason = "idle_timeout"
+            if terminal_reason != "completed":
+                terminated, forced_kill = _terminate_process_group(process, policy.terminate_grace_seconds)
+
+        wait_for = min(policy.poll_interval_seconds, max(0.001, policy.idle_timeout_seconds))
+        try:
+            stream_name, chunk = chunks.get(timeout=wait_for)
+        except queue.Empty:
+            if process.poll() is not None and len(eof_streams) == 2:
+                break
+            continue
+
+        if chunk is None:
+            eof_streams.add(stream_name)
+        else:
+            last_activity = time.monotonic()
+            total_bytes[stream_name] += len(chunk)
+            captured[stream_name].extend(chunk)
+            if len(captured[stream_name]) > policy.max_output_bytes:
+                del captured[stream_name][: len(captured[stream_name]) - policy.max_output_bytes]
+            line_buffers[stream_name].extend(chunk)
+            repeat_state[stream_name], stream_peak, largest_event = _consume_lines(
+                line_buffers[stream_name], repeat_state[stream_name]
+            )
+            peak_repeated = max(peak_repeated, stream_peak)
+            if process.poll() is None and max(largest_event, len(line_buffers[stream_name])) > policy.max_output_bytes:
+                terminal_reason = "output_limit"
+                terminated, forced_kill = _terminate_process_group(process, policy.terminate_grace_seconds)
+            elif process.poll() is None and peak_repeated >= policy.max_repeated_events:
+                terminal_reason = "repetition_limit"
+                terminated, forced_kill = _terminate_process_group(process, policy.terminate_grace_seconds)
+
+        if process.poll() is not None and len(eof_streams) == 2:
+            break
+
+    for reader in readers:
+        reader.join(timeout=0.2)
+    returncode = process.poll()
+    return ProcessOutcome(
+        terminal_reason=terminal_reason,
+        returncode=returncode,
+        stdout=bytes(captured["stdout"]).decode("utf-8", errors="replace"),
+        stderr=bytes(captured["stderr"]).decode("utf-8", errors="replace"),
+        elapsed_ms=int((time.monotonic() - started) * 1000),
+        stdout_bytes=total_bytes["stdout"],
+        stderr_bytes=total_bytes["stderr"],
+        peak_repeated_events=peak_repeated,
+        terminated=terminated,
+        forced_kill=forced_kill,
+    )
+
+
+def _read_stream(name: str, stream, chunks: queue.Queue[tuple[str, bytes | None]]) -> None:
+    if stream is None:
+        chunks.put((name, None))
+        return
+    try:
+        while True:
+            chunk = stream.read(65536)
+            if not chunk:
+                break
+            chunks.put((name, chunk))
+    finally:
+        chunks.put((name, None))
+
+
+def _consume_lines(buffer: bytearray, state: tuple[bytes, int]) -> tuple[tuple[bytes, int], int, int]:
+    last_line, repeated = state
+    peak = repeated
+    largest_event = 0
+    while True:
+        newline = buffer.find(b"\n")
+        if newline < 0:
+            break
+        line = bytes(buffer[:newline]).strip()
+        del buffer[: newline + 1]
+        if not line:
+            continue
+        largest_event = max(largest_event, len(line))
+        if line == last_line:
+            repeated += 1
+        else:
+            last_line = line
+            repeated = 1
+        peak = max(peak, repeated)
+    return (last_line, repeated), peak, largest_event
+
+
+def _terminate_process_group(process: subprocess.Popen[bytes], grace_seconds: float) -> tuple[bool, bool]:
+    if process.poll() is not None:
+        return False, False
+    terminated = True
+    if os.name == "posix":
+        process_group_id = process.pid
+        try:
+            os.killpg(process_group_id, signal.SIGTERM)
+        except ProcessLookupError:
+            return terminated, False
+        except OSError:
+            process.terminate()
+            try:
+                process.wait(timeout=max(1.0, grace_seconds))
+                return terminated, False
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=max(1.0, grace_seconds))
+                return terminated, True
+        deadline = time.monotonic() + grace_seconds
+        while time.monotonic() < deadline:
+            process.poll()
+            if not _process_group_exists(process_group_id):
+                return terminated, False
+            time.sleep(0.01)
+        if _process_group_exists(process_group_id):
+            try:
+                os.killpg(process_group_id, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait(timeout=max(1.0, grace_seconds))
+            return terminated, True
+        return terminated, False
+    else:
+        process.terminate()
+    try:
+        process.wait(timeout=grace_seconds)
+        return terminated, False
+    except subprocess.TimeoutExpired:
+        pass
+    process.kill()
+    process.wait(timeout=max(1.0, grace_seconds))
+    return terminated, True
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/scripts/pi-cli-wrapper.sh
+++ b/scripts/pi-cli-wrapper.sh
@@ -2,12 +2,65 @@
 set -eu
 
 export NPM_CONFIG_UPDATE_NOTIFIER=false
+
+if [ -n "${MMS_PI_EXECUTABLE:-}" ]; then
+  exec "$MMS_PI_EXECUTABLE" "$@"
+fi
+
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 ROOT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 CACHE_DIR=${MMS_PI_NPX_CACHE:-"$ROOT_DIR/.ai/cache/pi-npx"}
+LOCK_DIR="$CACHE_DIR/.mms-pi-npx-install.lock"
+LOCK_TIMEOUT=${MMS_PI_NPX_INSTALL_LOCK_TIMEOUT:-300}
+LOCK_HELD=0
 
 mkdir -p "$CACHE_DIR"
 export NPM_CONFIG_CACHE="$CACHE_DIR"
 export npm_config_cache="$CACHE_DIR"
+
+cached_pi_exists() {
+  [ -n "$(find "$CACHE_DIR/_npx" -path "*/node_modules/.bin/pi" -type f -print -quit 2>/dev/null || true)" ]
+}
+
+release_lock() {
+  if [ "$LOCK_HELD" = "1" ] && [ -f "$LOCK_DIR/pid" ]; then
+    lock_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+    if [ "$lock_pid" = "$$" ]; then
+      rm -rf "$LOCK_DIR"
+    fi
+  fi
+  LOCK_HELD=0
+}
+
+acquire_lock() {
+  start_time=$(date +%s)
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    if [ -f "$LOCK_DIR/pid" ]; then
+      lock_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+      if [ -n "$lock_pid" ] && ! kill -0 "$lock_pid" 2>/dev/null; then
+        rm -rf "$LOCK_DIR"
+        continue
+      fi
+    fi
+    now=$(date +%s)
+    if [ $((now - start_time)) -ge "$LOCK_TIMEOUT" ]; then
+      echo "MMS Pi npx install lock timeout after ${LOCK_TIMEOUT}s: $LOCK_DIR" >&2
+      exit 124
+    fi
+    sleep 1
+  done
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+  LOCK_HELD=1
+  trap release_lock EXIT INT TERM HUP
+}
+
+if ! cached_pi_exists; then
+  acquire_lock
+  if ! cached_pi_exists; then
+    npx -y --cache "$CACHE_DIR" @earendil-works/pi-coding-agent --version >/dev/null
+  fi
+  release_lock
+  trap - EXIT INT TERM HUP
+fi
 
 exec npx -y --cache "$CACHE_DIR" @earendil-works/pi-coding-agent "$@"

--- a/scripts/pi_committee.py
+++ b/scripts/pi_committee.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""CLI for the opt-in dynamic Pi committee sidecar."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import mms_pi_committee
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run isolated, runtime-bound Pi committee members without OpenCode or global config writes."
+    )
+    parser.add_argument("--config-root", required=True, help="Explicit MMS config root containing a verified latest-approved bundle.")
+    task = parser.add_mutually_exclusive_group(required=True)
+    task.add_argument("--task", help="Committee mission text.")
+    task.add_argument("--task-file", help="UTF-8 file containing the committee mission.")
+    parser.add_argument("--cwd", default=".", help="Read-only inspection working directory for Pi workers.")
+    parser.add_argument("--count", type=int, help="Member count; defaults to all frontier families, 4 for balanced, or all explicit models.")
+    parser.add_argument("--min-families", type=int, default=mms_pi_committee.DEFAULT_MIN_FAMILIES)
+    parser.add_argument(
+        "--selection-profile",
+        choices=("frontier", "balanced"),
+        default=mms_pi_committee.DEFAULT_SELECTION_PROFILE,
+        help="frontier chooses one current champion per target family; balanced uses generic diversity ranking.",
+    )
+    parser.add_argument("--family", action="append", default=[], help="Replace the default frontier family list; repeat in desired order.")
+    parser.add_argument("--add-family", action="append", default=[], help="Append a temporary frontier family for this mission.")
+    parser.add_argument("--add-model", action="append", default=[], help="Append an exact temporary model after frontier champions.")
+    parser.add_argument("--model", action="append", default=[], help="Fully override the lineup with exact logical models; repeat to preserve order.")
+    parser.add_argument("--require", action="append", default=["text"], dest="required_capabilities")
+    parser.add_argument("--lens", action="append", default=[], help="Optional lens list; repeat for multiple members.")
+    parser.add_argument("--max-concurrency", type=int, default=mms_pi_committee.DEFAULT_MAX_CONCURRENCY)
+    parser.add_argument("--timeout", type=int, default=mms_pi_committee.DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--dry-run", action="store_true", help="Verify bundle and emit the dynamic plan without launching Pi.")
+    parser.add_argument("--output", help="Optional result JSON path. Parent directories are created locally.")
+    return parser
+
+
+def _task_text(args: argparse.Namespace) -> str:
+    if args.task is not None:
+        return args.task
+    return Path(args.task_file).expanduser().read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    lenses = tuple(args.lens) if args.lens else mms_pi_committee.DEFAULT_LENSES
+    frontier_families = tuple(args.family or mms_pi_committee.DEFAULT_FRONTIER_FAMILIES) + tuple(args.add_family)
+    try:
+        result = mms_pi_committee.run_committee(
+            config_root=args.config_root,
+            task=_task_text(args),
+            cwd=args.cwd,
+            count=args.count,
+            min_families=args.min_families,
+            explicit_models=args.model,
+            selection_profile=args.selection_profile,
+            frontier_families=frontier_families,
+            additional_models=args.add_model,
+            required_capabilities=args.required_capabilities,
+            lenses=lenses,
+            max_concurrency=args.max_concurrency,
+            timeout_seconds=args.timeout,
+            dry_run=args.dry_run,
+        )
+    except (mms_pi_committee.CommitteeError, OSError, ValueError) as exc:
+        print(json.dumps({"schema": "mms.pi_committee.error.v1", "status": "error", "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+    rendered = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        output = Path(args.output).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    return 0 if result.get("status") in {"success", "dry_run"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi_committee.py
+++ b/scripts/pi_committee.py
@@ -39,7 +39,40 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require", action="append", default=["text"], dest="required_capabilities")
     parser.add_argument("--lens", action="append", default=[], help="Optional lens list; repeat for multiple members.")
     parser.add_argument("--max-concurrency", type=int, default=mms_pi_committee.DEFAULT_MAX_CONCURRENCY)
-    parser.add_argument("--timeout", type=int, default=mms_pi_committee.DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=mms_pi_committee.DEFAULT_TIMEOUT_SECONDS,
+        help="Per-member wall budget in seconds; shared by route attempts.",
+    )
+    parser.add_argument(
+        "--kimi-attempt-timeout",
+        type=int,
+        default=mms_pi_committee.DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
+        help="Maximum seconds for one Kimi route attempt; 0 lets one route use the whole member budget.",
+    )
+    parser.add_argument(
+        "--max-bundle-age-days",
+        type=int,
+        default=mms_pi_committee.DEFAULT_MAX_BUNDLE_AGE_DAYS,
+        help="Fail closed when a timestamped latest-approved bundle is older; 0 disables freshness enforcement.",
+    )
+    parser.add_argument("--idle-timeout", type=int, default=mms_pi_committee.DEFAULT_IDLE_TIMEOUT_SECONDS)
+    parser.add_argument("--max-output-bytes", type=int, default=mms_pi_committee.DEFAULT_MAX_OUTPUT_BYTES)
+    parser.add_argument("--max-repeated-events", type=int, default=mms_pi_committee.DEFAULT_MAX_REPEATED_EVENTS)
+    parser.add_argument(
+        "--committee-timeout",
+        type=int,
+        default=mms_pi_committee.DEFAULT_COMMITTEE_TIMEOUT_SECONDS,
+        help="Whole-committee budget; 0 auto-sizes by member wall budget and concurrency waves.",
+    )
+    parser.add_argument(
+        "--quorum-successes",
+        type=int,
+        default=mms_pi_committee.DEFAULT_QUORUM_SUCCESSES,
+        help="Cancel remaining workers after this many successes plus grace; 0 disables early stop.",
+    )
+    parser.add_argument("--quorum-grace", type=int, default=mms_pi_committee.DEFAULT_QUORUM_GRACE_SECONDS)
     parser.add_argument("--dry-run", action="store_true", help="Verify bundle and emit the dynamic plan without launching Pi.")
     parser.add_argument("--output", help="Optional result JSON path. Parent directories are created locally.")
     return parser
@@ -70,6 +103,14 @@ def main(argv: list[str] | None = None) -> int:
             lenses=lenses,
             max_concurrency=args.max_concurrency,
             timeout_seconds=args.timeout,
+            kimi_attempt_timeout_seconds=args.kimi_attempt_timeout,
+            max_bundle_age_days=args.max_bundle_age_days,
+            idle_timeout_seconds=args.idle_timeout,
+            max_output_bytes=args.max_output_bytes,
+            max_repeated_events=args.max_repeated_events,
+            committee_timeout_seconds=args.committee_timeout,
+            quorum_successes=args.quorum_successes,
+            quorum_grace_seconds=args.quorum_grace,
             dry_run=args.dry_run,
         )
     except (mms_pi_committee.CommitteeError, OSError, ValueError) as exc:

--- a/scripts/pi_committee_parent.py
+++ b/scripts/pi_committee_parent.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Run Pi committee work or convert a saved result into a parent packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import mms_pi_committee
+import mms_pi_parent
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Dispatch the isolated Pi committee and emit a lossless packet for the current Codex/Claude parent."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--result", help="Existing mms.pi_committee.result.v1 JSON; never launches Pi.")
+    source.add_argument("--task", help="Committee mission text.")
+    source.add_argument("--task-file", help="UTF-8 file containing the committee mission.")
+    parser.add_argument("--config-root", help="Explicit MMS config root; required for task execution.")
+    parser.add_argument("--cwd", default=".", help="Read-only inspection working directory for Pi workers.")
+    parser.add_argument("--count", type=int)
+    parser.add_argument("--min-families", type=int, default=mms_pi_committee.DEFAULT_MIN_FAMILIES)
+    parser.add_argument(
+        "--selection-profile",
+        choices=("frontier", "balanced"),
+        default=mms_pi_committee.DEFAULT_SELECTION_PROFILE,
+    )
+    parser.add_argument("--family", action="append", default=[], help="Replace default frontier families; repeat in order.")
+    parser.add_argument("--add-family", action="append", default=[], help="Append a temporary frontier family.")
+    parser.add_argument("--add-model", action="append", default=[], help="Append an exact temporary model.")
+    parser.add_argument("--model", action="append", default=[], help="Fully override the lineup with exact models.")
+    parser.add_argument("--require", action="append", default=["text"], dest="required_capabilities")
+    parser.add_argument("--lens", action="append", default=[])
+    parser.add_argument("--max-concurrency", type=int, default=mms_pi_committee.DEFAULT_MAX_CONCURRENCY)
+    parser.add_argument("--timeout", type=int, default=mms_pi_committee.DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--dry-run", action="store_true", help="Plan only; no Pi provider calls.")
+    parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
+    parser.add_argument("--output", help="Optional parent packet JSON path.")
+    return parser
+
+
+def _load_result(path: str) -> dict:
+    payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise mms_pi_parent.ParentPacketError("committee result JSON must be an object")
+    return payload
+
+
+def _task_text(args: argparse.Namespace) -> str:
+    if args.task is not None:
+        return args.task
+    return Path(args.task_file).expanduser().read_text(encoding="utf-8")
+
+
+def _build_packet(args: argparse.Namespace) -> dict:
+    if args.result:
+        return mms_pi_parent.build_parent_packet(_load_result(args.result))
+    if not str(args.config_root or "").strip():
+        raise mms_pi_parent.ParentPacketError("--config-root is required when dispatching a task")
+    lenses = tuple(args.lens) if args.lens else mms_pi_committee.DEFAULT_LENSES
+    frontier_families = tuple(args.family or mms_pi_committee.DEFAULT_FRONTIER_FAMILIES) + tuple(args.add_family)
+    return mms_pi_parent.run_parent_committee(
+        config_root=args.config_root,
+        task=_task_text(args),
+        cwd=args.cwd,
+        count=args.count,
+        min_families=args.min_families,
+        explicit_models=args.model,
+        selection_profile=args.selection_profile,
+        frontier_families=frontier_families,
+        additional_models=args.add_model,
+        required_capabilities=args.required_capabilities,
+        lenses=lenses,
+        max_concurrency=args.max_concurrency,
+        timeout_seconds=args.timeout,
+        dry_run=args.dry_run,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        packet = _build_packet(args)
+    except (json.JSONDecodeError, mms_pi_committee.CommitteeError, mms_pi_parent.ParentPacketError, OSError, ValueError) as exc:
+        error = {"schema": "mms.pi_committee.parent_error.v1", "status": "error", "error": str(exc)}
+        print(json.dumps(error, ensure_ascii=False), file=sys.stderr)
+        return 2
+    indent = None if args.compact else 2
+    rendered = json.dumps(packet, ensure_ascii=False, indent=indent) + "\n"
+    if args.output:
+        output = Path(args.output).expanduser()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered, encoding="utf-8")
+    sys.stdout.write(rendered)
+    return 0 if packet.get("status") in {"success", "partial", "dry_run"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pi_committee_parent.py
+++ b/scripts/pi_committee_parent.py
@@ -41,6 +41,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--lens", action="append", default=[])
     parser.add_argument("--max-concurrency", type=int, default=mms_pi_committee.DEFAULT_MAX_CONCURRENCY)
     parser.add_argument("--timeout", type=int, default=mms_pi_committee.DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--kimi-attempt-timeout",
+        type=int,
+        default=mms_pi_committee.DEFAULT_KIMI_ATTEMPT_TIMEOUT_SECONDS,
+        help="Maximum seconds for one Kimi route attempt; 0 disables the per-route cap.",
+    )
+    parser.add_argument(
+        "--max-bundle-age-days",
+        type=int,
+        default=mms_pi_committee.DEFAULT_MAX_BUNDLE_AGE_DAYS,
+        help="Reject older timestamped bundles; 0 disables freshness enforcement.",
+    )
+    parser.add_argument("--idle-timeout", type=int, default=mms_pi_committee.DEFAULT_IDLE_TIMEOUT_SECONDS)
+    parser.add_argument("--max-output-bytes", type=int, default=mms_pi_committee.DEFAULT_MAX_OUTPUT_BYTES)
+    parser.add_argument("--max-repeated-events", type=int, default=mms_pi_committee.DEFAULT_MAX_REPEATED_EVENTS)
+    parser.add_argument(
+        "--committee-timeout",
+        type=int,
+        default=mms_pi_committee.DEFAULT_COMMITTEE_TIMEOUT_SECONDS,
+        help="Whole-committee budget; 0 auto-sizes by concurrency waves.",
+    )
+    parser.add_argument("--quorum-successes", type=int, default=mms_pi_committee.DEFAULT_QUORUM_SUCCESSES)
+    parser.add_argument("--quorum-grace", type=int, default=mms_pi_committee.DEFAULT_QUORUM_GRACE_SECONDS)
     parser.add_argument("--dry-run", action="store_true", help="Plan only; no Pi provider calls.")
     parser.add_argument("--compact", action="store_true", help="Emit compact JSON.")
     parser.add_argument("--output", help="Optional parent packet JSON path.")
@@ -81,6 +104,14 @@ def _build_packet(args: argparse.Namespace) -> dict:
         lenses=lenses,
         max_concurrency=args.max_concurrency,
         timeout_seconds=args.timeout,
+        kimi_attempt_timeout_seconds=args.kimi_attempt_timeout,
+        max_bundle_age_days=args.max_bundle_age_days,
+        idle_timeout_seconds=args.idle_timeout,
+        max_output_bytes=args.max_output_bytes,
+        max_repeated_events=args.max_repeated_events,
+        committee_timeout_seconds=args.committee_timeout,
+        quorum_successes=args.quorum_successes,
+        quorum_grace_seconds=args.quorum_grace,
         dry_run=args.dry_run,
     )
 

--- a/tests/test_pi_committee.py
+++ b/tests/test_pi_committee.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import mms_pi_committee
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+MODELS = {
+    "MiniMax-M3": {
+        "provider_id": "minimax-test-provider",
+        "anthropic_base_url": "https://minimax.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-minimax-test-secret-123456",
+        "model_id": "MiniMax-M3",
+    },
+    "MiniMax-M2.7": {
+        "provider_id": "minimax-test-provider",
+        "anthropic_base_url": "https://minimax.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-minimax-test-secret-123456",
+        "model_id": "MiniMax-M2.7",
+    },
+    "gpt-5.5": {
+        "provider_id": "gpt-frontier-test-provider",
+        "anthropic_base_url": "",
+        "openai_base_url": "https://gpt.example.test/v1",
+        "api_key": "sk-gpt-frontier-test-secret-123456",
+        "model_id": "gpt-5.5",
+    },
+    "gpt-5.4": {
+        "provider_id": "gpt-frontier-test-provider",
+        "anthropic_base_url": "",
+        "openai_base_url": "https://gpt.example.test/v1",
+        "api_key": "sk-gpt-frontier-test-secret-123456",
+        "model_id": "gpt-5.4",
+    },
+    "kimi-for-coding": {
+        "provider_id": "kimi-test-provider",
+        "anthropic_base_url": "https://kimi.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-kimi-test-secret-123456",
+        "model_id": "kimi-for-coding",
+    },
+    "kimi-k2.7-code": {
+        "provider_id": "kimi-test-provider",
+        "anthropic_base_url": "https://kimi.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-kimi-test-secret-123456",
+        "model_id": "kimi-k2.7-code",
+    },
+    "gemini-3-flash-agent(high)": {
+        "provider_id": "gemini-test-provider",
+        "anthropic_base_url": "https://gemini.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-gemini-test-secret-123456",
+        "model_id": "gemini-3-flash-agent(high)",
+    },
+    "gemini-3.1-pro-low": {
+        "provider_id": "gemini-test-provider",
+        "anthropic_base_url": "https://gemini.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-gemini-test-secret-123456",
+        "model_id": "gemini-3.1-pro-low",
+    },
+    "qwen3.7-max": {
+        "provider_id": "qwen-frontier-test-provider",
+        "anthropic_base_url": "https://qwen-frontier.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-qwen-frontier-test-secret-123456",
+        "model_id": "qwen3.7-max",
+    },
+    "qwen3.7-plus": {
+        "provider_id": "qwen-frontier-test-provider",
+        "anthropic_base_url": "https://qwen-frontier.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-qwen-frontier-test-secret-123456",
+        "model_id": "qwen3.7-plus",
+    },
+    "deepseek-v4-flash": {
+        "provider_id": "deepseek-test-provider",
+        "anthropic_base_url": "https://deepseek.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-deepseek-test-secret-123456",
+        "model_id": "deepseek-v4-flash",
+    },
+    "deepseek-v4-pro": {
+        "provider_id": "deepseek-test-provider",
+        "anthropic_base_url": "https://deepseek.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-deepseek-test-secret-123456",
+        "model_id": "deepseek-v4-pro",
+    },
+    "glm-5.2": {
+        "provider_id": "glm-frontier-test-provider",
+        "anthropic_base_url": "https://glm-frontier.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-glm-frontier-test-secret-123456",
+        "model_id": "glm-5.2",
+    },
+    "glm-5.1": {
+        "provider_id": "glm-frontier-test-provider",
+        "anthropic_base_url": "https://glm-frontier.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-glm-frontier-test-secret-123456",
+        "model_id": "glm-5.1",
+    },
+    "mimo-v2.5": {
+        "provider_id": "mimo-test-provider",
+        "anthropic_base_url": "https://mimo.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-mimo-test-secret-123456",
+        "model_id": "mimo-v2.5",
+    },
+    "claude-sonnet-test": {
+        "provider_id": "claude-test-provider",
+        "anthropic_base_url": "https://claude.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-claude-test-secret-123456",
+        "model_id": "claude-sonnet-wire",
+    },
+    "gpt-test": {
+        "provider_id": "gpt-test-provider",
+        "anthropic_base_url": "",
+        "openai_base_url": "https://openai.example.test/v1",
+        "api_key": "sk-gpt-test-secret-123456",
+        "model_id": "gpt-test-wire",
+    },
+    "glm-test": {
+        "provider_id": "glm-test-provider",
+        "anthropic_base_url": "",
+        "openai_base_url": "https://glm.example.test/v1",
+        "api_key": "sk-glm-test-secret-123456",
+        "model_id": "glm-test-wire",
+    },
+    "qwen-test": {
+        "provider_id": "qwen-test-provider",
+        "anthropic_base_url": "https://qwen.example.test/anthropic",
+        "openai_base_url": "https://qwen.example.test/v1",
+        "api_key": "sk-qwen-test-secret-123456",
+        "model_id": "qwen-test-wire",
+    },
+}
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_bundle(root: Path, *, hidden_models: tuple[str, ...] = ()) -> Path:
+    generated = root / "generated"
+    routes = {model: {"primary": dict(route), "fallbacks": []} for model, route in MODELS.items()}
+    lineup_routes = {
+        model: {"primary": {"provider_id": row["provider_id"], "model_id": row["model_id"], "max_context_tokens": 200_000}}
+        for model, row in MODELS.items()
+    }
+    policy_models = {
+        model: {
+            "visible": model not in hidden_models,
+            "favorite": model == "qwen-test",
+            "tier": "primary" if model == "qwen-test" else "secondary",
+            "capabilities": {"text": True, "reasoning": True, "tool_use": True},
+        }
+        for model in MODELS
+    }
+    approved_models = [
+        {
+            "alias": model,
+            "model": model,
+            "official_context_window_tokens": 200_000,
+            "supports_thinking": True,
+        }
+        for model in MODELS
+    ]
+    payloads = {
+        "router": ("model-routes.json", {"version": 1, "routes": routes}, "secret"),
+        "lineup": ("model-routes.lineup.json", {"version": 1, "routes": lineup_routes}, "non-secret"),
+        "profile": (
+            "provider-profiles.generated.json",
+            {"version": 1, "profiles": {row["provider_id"]: {} for row in MODELS.values()}},
+            "non-secret",
+        ),
+        "policy": ("model-policy.effective.json", {"version": 1, "models": policy_models}, "non-secret"),
+        "capabilities": (
+            "model-capabilities.approved.json",
+            {"version": 1, "models": approved_models},
+            "non-secret",
+        ),
+    }
+    files = {}
+    for name, (filename, payload, sensitivity) in payloads.items():
+        path = generated / filename
+        _write_json(path, payload)
+        files[name] = {
+            "canonical_path": f"generated/{filename}",
+            "legacy_alias_path": "",
+            "sha256": _sha256(path),
+            "sensitivity": sensitivity,
+        }
+    manifest = generated / "model-registry.latest-approved.json"
+    _write_json(
+        manifest,
+        {
+            "schema": "mms.model_registry.latest_approved.v1",
+            "bundle_revision": "bundle_pi_committee_test",
+            "model_registry_revision": "bundle_pi_committee_test",
+            "capability_revision": "cap_pi_committee_test",
+            "route_revision": "route_pi_committee_test",
+            "policy_revision": "policy_pi_committee_test",
+            "profile_revision": "profile_pi_committee_test",
+            "files": files,
+        },
+    )
+    return root
+
+
+def test_dry_run_selects_frontier_members_without_secrets(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    result = mms_pi_committee.run_committee(
+        config_root=root,
+        task="Inspect the runtime design",
+        cwd=tmp_path,
+        count=4,
+        min_families=3,
+        dry_run=True,
+    )
+
+    assert result["status"] == "dry_run"
+    assert result["plan"]["selection"]["profile"] == "frontier"
+    members = result["plan"]["members"]
+    assert [member["member_id"] for member in members] == ["member-01", "member-02", "member-03", "member-04"]
+    assert len({member["family"] for member in members}) >= 3
+    assert all(member["context_window_tokens"] == 200_000 for member in members)
+    assert result["plan"]["isolation"] == {
+        "global_config_writes": False,
+        "global_oauth_fallback": False,
+        "opencode_dependency": False,
+        "worker_tools": "read,grep,find,ls",
+    }
+    rendered = json.dumps(result)
+    assert "sk-claude-test-secret" not in rendered
+    assert "sk-qwen-test-secret" not in rendered
+
+
+def test_default_frontier_reproduces_current_seven_family_roster(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+
+    plan, _members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Select current family champions",
+    )
+
+    assert [item["model"] for item in plan["members"]] == [
+        "MiniMax-M3",
+        "gpt-5.5",
+        "kimi-for-coding",
+        "gemini-3-flash-agent(high)",
+        "qwen3.7-max",
+        "deepseek-v4-flash",
+        "glm-5.2",
+    ]
+    assert plan["selection"]["target_families"] == list(mms_pi_committee.DEFAULT_FRONTIER_FAMILIES)
+    assert plan["selection"]["requested_count"] == 7
+
+
+def test_frontier_can_add_temporary_family_and_model_without_named_agents(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+
+    plan, _members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Expand this mission",
+        frontier_families=(*mms_pi_committee.DEFAULT_FRONTIER_FAMILIES, "Claude"),
+        additional_models=("qwen3.7-plus",),
+    )
+
+    assert [item["member_id"] for item in plan["members"]] == [f"member-{index:02d}" for index in range(1, 10)]
+    assert plan["members"][-2]["model"] == "claude-sonnet-test"
+    assert plan["members"][-1]["model"] == "qwen3.7-plus"
+
+
+def test_balanced_profile_preserves_generic_diversity_mode(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+
+    plan, _members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Use generic diversity",
+        selection_profile="balanced",
+        count=4,
+        min_families=3,
+    )
+
+    assert plan["selection"]["profile"] == "balanced"
+    assert plan["selection"]["target_families"] == []
+    assert len({item["family"] for item in plan["members"]}) >= 3
+
+
+def test_explicit_models_bind_to_generic_members_in_requested_order(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    plan, _members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Compare two models",
+        count=2,
+        explicit_models=["glm-test", "claude-sonnet-test"],
+    )
+
+    assert [(item["member_id"], item["model"]) for item in plan["members"]] == [
+        ("member-01", "glm-test"),
+        ("member-02", "claude-sonnet-test"),
+    ]
+
+
+def test_invalid_bundle_hash_fails_closed(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    policy = root / "generated" / "model-policy.effective.json"
+    policy.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(mms_pi_committee.CommitteeError, match="hash mismatch"):
+        mms_pi_committee.plan_committee(config_root=root, task="must fail")
+
+
+def test_policy_hidden_model_is_not_selectable(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config", hidden_models=("glm-test",))
+
+    with pytest.raises(mms_pi_committee.CommitteeError, match="requested models are unavailable"):
+        mms_pi_committee.plan_committee(
+            config_root=root,
+            task="must fail",
+            count=1,
+            explicit_models=["glm-test"],
+        )
+
+
+def test_prepared_pi_payload_uses_env_reference_and_wire_model(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    _plan, members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Inspect",
+        count=1,
+        explicit_models=["claude-sonnet-test"],
+    )
+    prepared = mms_pi_committee._prepare_members(members, config_root=root)
+    attempt = prepared["member-01"][0]
+    provider = attempt.models_payload["providers"][attempt.provider_ref]
+
+    assert provider["apiKey"] == "$MMS_PI_COMMITTEE_KEY_MEMBER_01_0"
+    assert attempt.selected_model == "claude-sonnet-wire"
+    assert provider["models"][0]["id"] == "claude-sonnet-wire"
+    assert MODELS["claude-sonnet-test"]["api_key"] not in json.dumps(attempt.models_payload)
+
+
+def test_worker_launch_is_isolated_read_only_and_emits_transport_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+    captured: dict = {}
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-global-should-not-leak-123456")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-global-should-not-leak-abcdef")
+    monkeypatch.setenv("MMS_CONFIG_ROOT", "/sentinel/original-root")
+
+    def fake_run(cmd, *, cwd, env, capture_output, text, timeout, check):
+        captured.update({"cmd": cmd, "cwd": cwd, "env": env, "timeout": timeout})
+        models = json.loads((Path(env["PI_CODING_AGENT_DIR"]) / "models.json").read_text(encoding="utf-8"))
+        provider = next(iter(models["providers"].values()))
+        captured["api_key_ref"] = provider["apiKey"]
+        message = {
+            "type": "turn_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "stop",
+                "usage": {"input": 11, "output": 7, "cacheRead": 3},
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "verdict": "isolated",
+                                "confidence": 0.9,
+                                "findings": [],
+                                "risks": [],
+                                "recommendation": "keep the boundary",
+                            }
+                        ),
+                    }
+                ],
+            },
+        }
+        return SimpleNamespace(returncode=0, stdout=json.dumps(message) + "\n", stderr="")
+
+    monkeypatch.setattr(mms_pi_committee.subprocess, "run", fake_run)
+    result = mms_pi_committee.run_committee(
+        config_root=root,
+        task="Inspect isolation",
+        cwd=tmp_path,
+        count=1,
+        explicit_models=["claude-sonnet-test"],
+        max_concurrency=1,
+    )
+
+    assert result["status"] == "success"
+    assert "--no-session" in captured["cmd"]
+    assert "--no-context-files" in captured["cmd"]
+    assert "--no-extensions" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--tools") + 1] == "read,grep,find,ls"
+    assert captured["api_key_ref"] == "$MMS_PI_COMMITTEE_KEY_MEMBER_01_0"
+    assert "OPENAI_API_KEY" not in captured["env"]
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+    assert "MMS_CONFIG_ROOT" not in captured["env"]
+    assert os.environ["MMS_CONFIG_ROOT"] == "/sentinel/original-root"
+    assert captured["env"]["HOME"] != str(Path.home())
+    evidence = result["results"][0]["cache_transport_evidence"]
+    assert evidence["schema"] == "cache_transport_evidence.v1"
+    assert evidence["protocol"] == "anthropic_messages"
+    assert evidence["request_path"] == "/v1/messages"
+    assert evidence["usage"]["cache_read_input_tokens"] == 3
+    assert "sk-global-should-not-leak" not in json.dumps(result)
+
+
+def test_openai_chat_route_records_audited_fallback_reason(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    plan, _members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Inspect transport",
+        count=1,
+        explicit_models=["glm-test"],
+    )
+
+    route = plan["members"][0]["route_chain"][0]
+    assert route["protocol"] == "openai_chat_completions"
+    assert route["protocol_fallback_reason"]
+
+
+def test_url_redaction_removes_userinfo_query_and_fragment() -> None:
+    value = "https://user:secret@example.test/v1/messages?api_key=hidden#fragment"
+
+    assert mms_pi_committee._redact_url(value) == "https://example.test/v1/messages"
+
+
+def test_pi_blocked_fallback_route_is_removed_from_member_chain() -> None:
+    route_group = {
+        "primary": {
+            "provider_id": "newapi-tencent",
+            "anthropic_base_url": "https://primary.example.test",
+            "api_key": "sk-primary-test-secret-123456",
+            "model_id": "gemini-3-flash-agent(high)",
+        },
+        "fallbacks": [
+            {
+                "provider_id": "newapi-personal-tokyo",
+                "anthropic_base_url": "https://blocked.example.test",
+                "api_key": "sk-blocked-test-secret-123456",
+                "model_id": "gemini-3-flash-agent(high)",
+            }
+        ],
+    }
+
+    chain = mms_pi_committee._build_route_chain("gemini-3-flash-agent(high)", route_group, {})
+
+    assert [binding.provider_id for binding in chain] == ["newapi-tencent"]
+
+
+def test_cli_dry_run_is_json_only_and_does_not_launch_pi(tmp_path: Path) -> None:
+    root = _write_bundle(tmp_path / "config")
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "pi_committee.py"),
+            "--config-root",
+            str(root),
+            "--task",
+            "CLI dry run",
+            "--cwd",
+            str(tmp_path),
+            "--count",
+            "2",
+            "--dry-run",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["status"] == "dry_run"
+    assert [item["member_id"] for item in payload["plan"]["members"]] == ["member-01", "member-02"]

--- a/tests/test_pi_committee.py
+++ b/tests/test_pi_committee.py
@@ -5,12 +5,15 @@ import json
 import os
 import subprocess
 import sys
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
 import mms_pi_committee
+import mms_pi_watchdog
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -46,18 +49,32 @@ MODELS = {
         "model_id": "gpt-5.4",
     },
     "kimi-for-coding": {
-        "provider_id": "kimi-test-provider",
-        "anthropic_base_url": "https://kimi.example.test",
+        "provider_id": "direct-kimi-test-provider",
+        "anthropic_base_url": "https://direct-kimi.example.test",
         "openai_base_url": "",
         "api_key": "sk-kimi-test-secret-123456",
         "model_id": "kimi-for-coding",
     },
     "kimi-k2.7-code": {
-        "provider_id": "kimi-test-provider",
-        "anthropic_base_url": "https://kimi.example.test",
+        "provider_id": "direct-kimi-test-provider",
+        "anthropic_base_url": "https://direct-kimi.example.test",
         "openai_base_url": "",
         "api_key": "sk-kimi-test-secret-123456",
         "model_id": "kimi-k2.7-code",
+    },
+    "kimi-k2.8-code": {
+        "provider_id": "direct-kimi-test-provider",
+        "anthropic_base_url": "https://direct-kimi.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-kimi-test-secret-123456",
+        "model_id": "kimi-k2.8-code",
+    },
+    "k3": {
+        "provider_id": "direct-kimi-test-provider",
+        "anthropic_base_url": "https://direct-kimi.example.test",
+        "openai_base_url": "",
+        "api_key": "sk-kimi-test-secret-123456",
+        "model_id": "k3",
     },
     "gemini-3-flash-agent(high)": {
         "provider_id": "gemini-test-provider",
@@ -162,9 +179,36 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _write_bundle(root: Path, *, hidden_models: tuple[str, ...] = ()) -> Path:
+def _write_bundle(
+    root: Path,
+    *,
+    hidden_models: tuple[str, ...] = (),
+    bundle_revision: str = "bundle_pi_committee_test",
+    generated_at: str = "",
+) -> Path:
     generated = root / "generated"
     routes = {model: {"primary": dict(route), "fallbacks": []} for model, route in MODELS.items()}
+    for model in ("kimi-for-coding", "kimi-k2.7-code", "kimi-k2.8-code", "k3"):
+        if model in routes:
+            routes[model] = {
+                "primary": dict(MODELS[model]),
+                "fallbacks": [
+                    {
+                        "provider_id": "newapi-tokyo-test-provider",
+                        "anthropic_base_url": "https://tokyo-kimi.example.test",
+                        "openai_base_url": "",
+                        "api_key": "sk-kimi-tokyo-test-secret-123456",
+                        "model_id": model,
+                    },
+                    {
+                        "provider_id": "newapi-tencent-test-provider",
+                        "anthropic_base_url": "https://tencent-kimi.example.test",
+                        "openai_base_url": "",
+                        "api_key": "sk-kimi-tencent-test-secret-123456",
+                        "model_id": model,
+                    },
+                ],
+            }
     lineup_routes = {
         model: {"primary": {"provider_id": row["provider_id"], "model_id": row["model_id"], "max_context_tokens": 200_000}}
         for model, row in MODELS.items()
@@ -213,19 +257,19 @@ def _write_bundle(root: Path, *, hidden_models: tuple[str, ...] = ()) -> Path:
             "sensitivity": sensitivity,
         }
     manifest = generated / "model-registry.latest-approved.json"
-    _write_json(
-        manifest,
-        {
-            "schema": "mms.model_registry.latest_approved.v1",
-            "bundle_revision": "bundle_pi_committee_test",
-            "model_registry_revision": "bundle_pi_committee_test",
-            "capability_revision": "cap_pi_committee_test",
-            "route_revision": "route_pi_committee_test",
-            "policy_revision": "policy_pi_committee_test",
-            "profile_revision": "profile_pi_committee_test",
-            "files": files,
-        },
-    )
+    manifest_payload = {
+        "schema": "mms.model_registry.latest_approved.v1",
+        "bundle_revision": bundle_revision,
+        "model_registry_revision": bundle_revision,
+        "capability_revision": "cap_pi_committee_test",
+        "route_revision": "route_pi_committee_test",
+        "policy_revision": "policy_pi_committee_test",
+        "profile_revision": "profile_pi_committee_test",
+        "files": files,
+    }
+    if generated_at:
+        manifest_payload["generated_at"] = generated_at
+    _write_json(manifest, manifest_payload)
     return root
 
 
@@ -252,6 +296,13 @@ def test_dry_run_selects_frontier_members_without_secrets(tmp_path: Path) -> Non
         "opencode_dependency": False,
         "worker_tools": "read,grep,find,ls",
     }
+    assert result["watchdog"]["member_wall_timeout_seconds"] == 900
+    assert result["watchdog"]["kimi_attempt_timeout_seconds"] == 300
+    assert result["watchdog"]["idle_timeout_seconds"] == 300
+    assert result["watchdog"]["committee_timeout_seconds"] == 960
+    assert result["watchdog"]["quorum_successes"] == 0
+    assert result["plan"]["bundle"]["config_root"] == str(root)
+    assert result["plan"]["bundle"]["freshness"]["status"] == "unknown"
     rendered = json.dumps(result)
     assert "sk-claude-test-secret" not in rendered
     assert "sk-qwen-test-secret" not in rendered
@@ -268,11 +319,18 @@ def test_default_frontier_reproduces_current_seven_family_roster(tmp_path: Path)
     assert [item["model"] for item in plan["members"]] == [
         "MiniMax-M3",
         "gpt-5.5",
-        "kimi-for-coding",
+        "k3",
         "gemini-3-flash-agent(high)",
         "qwen3.7-max",
         "deepseek-v4-flash",
         "glm-5.2",
+    ]
+    kimi_member = plan["members"][2]
+    assert kimi_member["family"] == "Kimi"
+    assert [route["provider_id"] for route in kimi_member["route_chain"]] == [
+        "newapi-tokyo-test-provider",
+        "newapi-tencent-test-provider",
+        "direct-kimi-test-provider",
     ]
     assert plan["selection"]["target_families"] == list(mms_pi_committee.DEFAULT_FRONTIER_FAMILIES)
     assert plan["selection"]["requested_count"] == 7
@@ -333,6 +391,27 @@ def test_invalid_bundle_hash_fails_closed(tmp_path: Path) -> None:
         mms_pi_committee.plan_committee(config_root=root, task="must fail")
 
 
+@pytest.mark.parametrize("generated_at", ["", "2026-05-29T00:14:32Z"])
+def test_stale_timestamped_bundle_fails_closed_before_model_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    generated_at: str,
+) -> None:
+    root = _write_bundle(
+        tmp_path / "config",
+        bundle_revision="bundle_20260529001432_deadbeef",
+        generated_at=generated_at,
+    )
+    monkeypatch.setattr(
+        mms_pi_committee,
+        "_utc_now",
+        lambda: datetime(2026, 7, 17, 0, 0, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(mms_pi_committee.CommitteeError, match="latest-approved bundle is stale"):
+        mms_pi_committee.plan_committee(config_root=root, task="must fail before selecting kimi-k2.6")
+
+
 def test_policy_hidden_model_is_not_selectable(tmp_path: Path) -> None:
     root = _write_bundle(tmp_path / "config", hidden_models=("glm-test",))
 
@@ -373,8 +452,8 @@ def test_worker_launch_is_isolated_read_only_and_emits_transport_evidence(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-global-should-not-leak-abcdef")
     monkeypatch.setenv("MMS_CONFIG_ROOT", "/sentinel/original-root")
 
-    def fake_run(cmd, *, cwd, env, capture_output, text, timeout, check):
-        captured.update({"cmd": cmd, "cwd": cwd, "env": env, "timeout": timeout})
+    def fake_run(cmd, *, cwd, env, policy, cancellation):
+        captured.update({"cmd": cmd, "cwd": cwd, "env": env, "policy": policy})
         models = json.loads((Path(env["PI_CODING_AGENT_DIR"]) / "models.json").read_text(encoding="utf-8"))
         provider = next(iter(models["providers"].values()))
         captured["api_key_ref"] = provider["apiKey"]
@@ -400,9 +479,20 @@ def test_worker_launch_is_isolated_read_only_and_emits_transport_evidence(
                 ],
             },
         }
-        return SimpleNamespace(returncode=0, stdout=json.dumps(message) + "\n", stderr="")
+        return mms_pi_watchdog.ProcessOutcome(
+            terminal_reason="completed",
+            returncode=0,
+            stdout=json.dumps(message) + "\n",
+            stderr="",
+            elapsed_ms=25,
+            stdout_bytes=100,
+            stderr_bytes=0,
+            peak_repeated_events=1,
+            terminated=False,
+            forced_kill=False,
+        )
 
-    monkeypatch.setattr(mms_pi_committee.subprocess, "run", fake_run)
+    monkeypatch.setattr(mms_pi_committee.mms_pi_watchdog, "run_process", fake_run)
     result = mms_pi_committee.run_committee(
         config_root=root,
         task="Inspect isolation",
@@ -417,6 +507,8 @@ def test_worker_launch_is_isolated_read_only_and_emits_transport_evidence(
     assert "--no-context-files" in captured["cmd"]
     assert "--no-extensions" in captured["cmd"]
     assert captured["cmd"][captured["cmd"].index("--tools") + 1] == "read,grep,find,ls"
+    assert captured["policy"].wall_timeout_seconds == 899
+    assert captured["policy"].idle_timeout_seconds == 300
     assert captured["api_key_ref"] == "$MMS_PI_COMMITTEE_KEY_MEMBER_01_0"
     assert "OPENAI_API_KEY" not in captured["env"]
     assert "ANTHROPIC_API_KEY" not in captured["env"]
@@ -428,7 +520,276 @@ def test_worker_launch_is_isolated_read_only_and_emits_transport_evidence(
     assert evidence["protocol"] == "anthropic_messages"
     assert evidence["request_path"] == "/v1/messages"
     assert evidence["usage"]["cache_read_input_tokens"] == 3
+    assert result["results"][0]["watchdog"]["terminal_reason"] == "completed"
     assert "sk-global-should-not-leak" not in json.dumps(result)
+
+
+def test_role_card_is_appended_as_private_system_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+    _plan, members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Inspect",
+        count=1,
+        explicit_models=["glm-test"],
+    )
+    member = replace(
+        members[0],
+        member_id="testing-contract",
+        domain="testing",
+        role_id="qa",
+        role_card="# qa\n\nGATE\n- inspect contract paths",
+        role_card_source="agent-spec:roles/qa.min.md",
+        role_card_sha256="a" * 64,
+        required_domain=True,
+    )
+    attempt = mms_pi_committee._prepare_members((member,), config_root=root)[member.member_id][0]
+    captured = {}
+
+    def fake_run(cmd, *, cwd, env, policy, cancellation):
+        captured["cmd"] = cmd
+        prompt_path = Path(cmd[cmd.index("--append-system-prompt") + 1])
+        captured["role_prompt"] = prompt_path.read_text(encoding="utf-8")
+        message = {
+            "type": "turn_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "stop",
+                "usage": {},
+                "content": [{"type": "text", "text": '{"verdict":"ok","confidence":0.8,"findings":[],"risks":[],"recommendation":"continue","role_payload":{}}'}],
+            },
+        }
+        return mms_pi_watchdog.ProcessOutcome(
+            terminal_reason="completed",
+            returncode=0,
+            stdout=json.dumps(message) + "\n",
+            stderr="",
+            elapsed_ms=20,
+            stdout_bytes=100,
+            stderr_bytes=0,
+            peak_repeated_events=1,
+            terminated=False,
+            forced_kill=False,
+        )
+
+    monkeypatch.setattr(mms_pi_committee.mms_pi_watchdog, "run_process", fake_run)
+    result = mms_pi_committee._run_attempt(
+        member,
+        attempt,
+        task="Inspect contract",
+        cwd=tmp_path,
+        timeout_seconds=30,
+        idle_timeout_seconds=10,
+        max_output_bytes=1024,
+        max_repeated_events=8,
+        cancellation=mms_pi_watchdog.CancellationController(),
+    )
+
+    assert "--append-system-prompt" in captured["cmd"]
+    assert "Canonical role card (qa)" in captured["role_prompt"]
+    assert "committee JSON envelope" in captured["role_prompt"]
+    assert result["domain"] == "testing"
+    assert result["role_id"] == "qa"
+    assert result["required_domain"] is True
+
+
+def test_exhausted_member_budget_skips_fallback_without_counting_it(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+    _plan, members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Inspect",
+        count=1,
+        explicit_models=["kimi-for-coding"],
+    )
+    primary = mms_pi_committee._prepare_members(members, config_root=root)["member-01"][0]
+    fallback = mms_pi_committee._prepare_members(members, config_root=root)["member-01"][1]
+    clock = [0.0]
+    calls: list[str] = []
+
+    monkeypatch.setattr(mms_pi_committee.time, "monotonic", lambda: clock[0])
+
+    def fake_run_attempt(_member, attempt, **_kwargs):
+        calls.append(attempt.binding.provider_id)
+        clock[0] = 900.1
+        return {
+            "status": "wall_timeout",
+            "terminal_reason": "wall_timeout",
+            "watchdog": {"elapsed_ms": 899_082},
+        }
+
+    monkeypatch.setattr(mms_pi_committee, "_run_attempt", fake_run_attempt)
+    result = mms_pi_committee._run_member(
+        members[0],
+        (primary, fallback),
+        task="Heavy review",
+        cwd=tmp_path,
+        timeout_seconds=900,
+        idle_timeout_seconds=300,
+        max_output_bytes=2 * 1024 * 1024,
+        max_repeated_events=32,
+        cancellation=mms_pi_watchdog.CancellationController(),
+        route_source="test",
+        kimi_attempt_timeout_seconds=0,
+    )
+
+    assert calls == ["newapi-tokyo-test-provider"]
+    assert result["terminal_reason"] == "wall_timeout"
+    assert result["fallback_used"] is False
+    assert result["fallback_skipped_reason"] == "no_budget_remaining"
+    assert result["error"] == "newapi-tokyo-test-provider:wall_timeout"
+    assert result["attempts"][0]["started"] is True
+    assert result["attempts"][0]["budget_seconds"] == 900
+    assert result["attempts"][1] == {
+        "provider_id": "newapi-tencent-test-provider",
+        "fallback_position": 1,
+        "started": False,
+        "budget_seconds": 0,
+        "status": "skipped",
+        "terminal_reason": "no_budget_remaining",
+        "error": "",
+        "watchdog": {},
+    }
+
+
+def test_kimi_attempt_cap_preserves_tencent_fallback_after_tokyo_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+    _plan, members, _bundle = mms_pi_committee.plan_committee(
+        config_root=root,
+        task="Inspect",
+        count=1,
+        explicit_models=["k3"],
+    )
+    attempts = mms_pi_committee._prepare_members(members, config_root=root)["member-01"][:2]
+    clock = [0.0]
+    calls: list[tuple[str, int]] = []
+
+    monkeypatch.setattr(mms_pi_committee.time, "monotonic", lambda: clock[0])
+
+    def fake_run_attempt(member, attempt, *, timeout_seconds, **_kwargs):
+        calls.append((attempt.binding.provider_id, timeout_seconds))
+        if attempt.binding.provider_id == "newapi-tokyo-test-provider":
+            clock[0] += timeout_seconds + 0.1
+            return {
+                "status": "wall_timeout",
+                "terminal_reason": "wall_timeout",
+                "watchdog": {"elapsed_ms": timeout_seconds * 1000},
+            }
+        clock[0] += 1
+        return {
+            **mms_pi_committee._member_identity(member),
+            "status": "success",
+            "terminal_reason": "completed",
+            "watchdog": {"elapsed_ms": 1000},
+            "_usage": {},
+        }
+
+    monkeypatch.setattr(mms_pi_committee, "_run_attempt", fake_run_attempt)
+    result = mms_pi_committee._run_member(
+        members[0],
+        attempts,
+        task="Heavy review",
+        cwd=tmp_path,
+        timeout_seconds=900,
+        idle_timeout_seconds=300,
+        max_output_bytes=2 * 1024 * 1024,
+        max_repeated_events=32,
+        cancellation=mms_pi_watchdog.CancellationController(),
+        route_source="test",
+        kimi_attempt_timeout_seconds=300,
+    )
+
+    assert calls == [
+        ("newapi-tokyo-test-provider", 300),
+        ("newapi-tencent-test-provider", 300),
+    ]
+    assert result["status"] == "success"
+    assert result["fallback_used"] is True
+    assert result["fallback_reason"] == "newapi-tokyo-test-provider:wall_timeout"
+    assert [attempt["budget_seconds"] for attempt in result["attempts"]] == [300, 300]
+
+
+def test_committee_deadline_cancels_workers_and_preserves_all_member_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+
+    monkeypatch.setattr(
+        mms_pi_committee,
+        "_prepare_members",
+        lambda members, **_kwargs: {member.member_id: () for member in members},
+    )
+
+    def fake_member(member, _attempts, *, cancellation, **_kwargs):
+        while not cancellation.is_cancelled():
+            time.sleep(0.01)
+        return mms_pi_committee._cancelled_member_result(member, cancellation.reason)
+
+    monkeypatch.setattr(mms_pi_committee, "_run_member", fake_member)
+    result = mms_pi_committee.run_committee(
+        config_root=root,
+        task="Bound the whole committee",
+        cwd=tmp_path,
+        count=3,
+        max_concurrency=2,
+        committee_timeout_seconds=0.12,
+    )
+
+    assert result["status"] == "failed"
+    assert result["watchdog"]["committee_stop_reason"] == "committee_timeout"
+    assert len(result["results"]) == 3
+    assert {item["terminal_reason"] for item in result["results"]} == {"committee_timeout"}
+
+
+def test_quorum_is_opt_in_and_cancels_only_after_grace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = _write_bundle(tmp_path / "config")
+    monkeypatch.setattr(
+        mms_pi_committee,
+        "_prepare_members",
+        lambda members, **_kwargs: {member.member_id: () for member in members},
+    )
+
+    def fake_member(member, _attempts, *, cancellation, **_kwargs):
+        if member.member_id == "member-01":
+            return {
+                "member_id": member.member_id,
+                "model": member.candidate.model,
+                "family": member.candidate.family,
+                "lens": member.lens,
+                "status": "success",
+                "terminal_reason": "completed",
+                "response": {"raw_text": "enough"},
+                "attempts": [],
+            }
+        while not cancellation.is_cancelled():
+            time.sleep(0.01)
+        return mms_pi_committee._cancelled_member_result(member, cancellation.reason)
+
+    monkeypatch.setattr(mms_pi_committee, "_run_member", fake_member)
+    result = mms_pi_committee.run_committee(
+        config_root=root,
+        task="Use explicit quorum",
+        cwd=tmp_path,
+        count=3,
+        max_concurrency=3,
+        quorum_successes=1,
+        quorum_grace_seconds=0.05,
+    )
+
+    assert result["status"] == "partial"
+    assert result["watchdog"]["committee_stop_reason"] == "quorum_reached"
+    assert result["summary"] == {"members": 3, "succeeded": 1, "failed": 2}
 
 
 def test_openai_chat_route_records_audited_fallback_reason(tmp_path: Path) -> None:

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -1,5 +1,8 @@
 import json
+import os
 from pathlib import Path
+import subprocess
+import textwrap
 
 import pytest
 
@@ -65,6 +68,56 @@ def test_pi_gateway_root_and_sessions_honor_explicit_mms_config_root(monkeypatch
 
     assert mms_pi_support._pi_gateway_root() == str(preview_root / "pi-gateway")
     assert mms_pi_support._pi_session_dir() == str(preview_root / "pi-gateway" / "sessions")
+
+
+def test_pi_wrapper_serializes_cold_npx_prewarm(tmp_path):
+    wrapper = Path(__file__).resolve().parents[1] / "scripts" / "pi-cli-wrapper.sh"
+    bin_dir = tmp_path / "bin"
+    cache_dir = tmp_path / "pi-npx"
+    log_path = tmp_path / "npx.log"
+    bin_dir.mkdir()
+    fake_npx = bin_dir / "npx"
+    fake_npx.write_text(
+        textwrap.dedent(
+            """\
+            #!/bin/sh
+            set -eu
+            printf '%s\\n' "$*" >> "$FAKE_NPX_LOG"
+            case " $* " in
+              *" --version "*)
+                mkdir -p "$FAKE_PI_CACHE/_npx/hash/node_modules/.bin"
+                printf '#!/bin/sh\\nexit 0\\n' > "$FAKE_PI_CACHE/_npx/hash/node_modules/.bin/pi"
+                chmod +x "$FAKE_PI_CACHE/_npx/hash/node_modules/.bin/pi"
+                exit 0
+                ;;
+            esac
+            exit 0
+            """
+        ),
+        encoding="utf-8",
+    )
+    fake_npx.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+            "MMS_PI_NPX_CACHE": str(cache_dir),
+            "MMS_PI_NPX_INSTALL_LOCK_TIMEOUT": "10",
+            "FAKE_NPX_LOG": str(log_path),
+            "FAKE_PI_CACHE": str(cache_dir),
+        }
+    )
+
+    processes = [
+        subprocess.Popen([str(wrapper), "--probe", str(index)], env=env)
+        for index in range(4)
+    ]
+    for process in processes:
+        assert process.wait(timeout=15) == 0
+
+    calls = log_path.read_text(encoding="utf-8").splitlines()
+    assert sum("--version" in call for call in calls) == 1
+    assert sum("--probe" in call for call in calls) == 4
 
 
 def test_launch_pi_writes_openai_models_config_and_uses_wrapper(monkeypatch, tmp_path):

--- a/tests/test_pi_parent.py
+++ b/tests/test_pi_parent.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import mms_pi_parent
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _result_fixture() -> dict:
+    return {
+        "schema": "mms.pi_committee.result.v1",
+        "mission_id": "pi-parent-test",
+        "status": "partial",
+        "elapsed_ms": 1234,
+        "summary": {"members": 3, "succeeded": 2, "failed": 1},
+        "plan": {
+            "mission_id": "pi-parent-test",
+            "task": "Review the target",
+            "route_source": "mms:latest-approved:test",
+            "selection": {"profile": "frontier"},
+            "members": [
+                {
+                    "member_id": "member-01",
+                    "model": "gpt-test",
+                    "family": "GPT",
+                    "lens": "architecture",
+                    "route_chain": [{"provider_id": "gpt-provider"}],
+                },
+                {
+                    "member_id": "member-02",
+                    "model": "qwen-test",
+                    "family": "Qwen",
+                    "lens": "failure-risk",
+                    "route_chain": [{"provider_id": "qwen-provider"}],
+                },
+                {
+                    "member_id": "member-03",
+                    "model": "glm-test",
+                    "family": "GLM",
+                    "lens": "verification",
+                    "route_chain": [{"provider_id": "glm-provider"}],
+                },
+                {
+                    "member_id": "member-04",
+                    "model": "kimi-test",
+                    "family": "Kimi",
+                    "lens": "counterexample",
+                    "route_chain": [{"provider_id": "kimi-provider"}],
+                },
+            ],
+        },
+        "results": [
+            {
+                "member_id": "member-01",
+                "model": "gpt-test",
+                "family": "GPT",
+                "lens": "architecture",
+                "status": "success",
+                "response": {
+                    "verdict": "one issue",
+                    "confidence": 0.8,
+                    "findings": [
+                        {
+                            "claim": "state can drift",
+                            "evidence": ["src/state.py:10"],
+                            "severity": "high",
+                            "extra": "preserve me",
+                        }
+                    ],
+                    "risks": ["silent fallback"],
+                    "recommendation": "fail closed",
+                },
+                "fallback_used": False,
+                "attempts": [
+                    {
+                        "provider_id": "gpt-provider",
+                        "status": "success",
+                        "error": "",
+                        "cache_transport_evidence": {
+                            "protocol": "openai_responses",
+                            "request_path": "/v1/responses",
+                            "fallback_used": False,
+                        },
+                    }
+                ],
+            },
+            {
+                "member_id": "member-02",
+                "model": "qwen-test",
+                "family": "Qwen",
+                "lens": "failure-risk",
+                "status": "success",
+                "response": {"raw_text": "malformed but useful opinion"},
+                "fallback_used": True,
+                "fallback_reason": "primary failed",
+                "attempts": [],
+            },
+            {
+                "member_id": "member-03",
+                "model": "glm-test",
+                "family": "GLM",
+                "lens": "verification",
+                "status": "failed",
+                "error": "request_error",
+                "attempts": [{"provider_id": "glm-provider", "status": "request_error", "error": "upstream"}],
+            },
+        ],
+    }
+
+
+def test_build_parent_packet_is_lossless_and_synthesis_ready() -> None:
+    packet = mms_pi_parent.build_parent_packet(_result_fixture())
+
+    assert packet["schema"] == "mms.pi_committee.parent_packet.v1"
+    assert packet["status"] == "partial"
+    assert packet["ready_for_synthesis"] is True
+    assert packet["committee_health"] == {
+        "planned_members": 4,
+        "returned_members": 3,
+        "succeeded": 2,
+        "failed_or_missing": 2,
+        "structured_responses": 1,
+        "raw_responses": 1,
+        "fallback_members": 1,
+        "status_counts": {"failed": 1, "missing_result": 1, "success": 2},
+        "family_counts": {"GLM": 1, "GPT": 1, "Qwen": 1},
+    }
+    assert packet["opinions"][0]["response"]["findings"][0]["extra"] == "preserve me"
+    assert packet["opinions"][1]["response"] == {"raw_text": "malformed but useful opinion"}
+    assert packet["evidence_index"][0]["evidence_id"] == "member-01-finding-01"
+    assert {item["status"] for item in packet["failures"]} == {"failed", "missing_result"}
+    assert packet["synthesis_contract"]["owner"] == "current_parent"
+    assert packet["synthesis_contract"]["semantic_grouping"] == "parent_reasoning_required"
+
+
+def test_dry_run_packet_is_not_ready_for_synthesis() -> None:
+    result = _result_fixture()
+    result["status"] = "dry_run"
+    result["results"] = []
+
+    packet = mms_pi_parent.build_parent_packet(result)
+
+    assert packet["ready_for_synthesis"] is False
+    assert packet["committee_health"]["planned_members"] == 4
+    assert packet["committee_health"]["failed_or_missing"] == 0
+    assert packet["committee_health"]["status_counts"] == {}
+    assert [item["model"] for item in packet["committee_plan"]["members"]] == [
+        "gpt-test",
+        "qwen-test",
+        "glm-test",
+        "kimi-test",
+    ]
+
+
+def test_invalid_result_schema_fails_closed() -> None:
+    with pytest.raises(mms_pi_parent.ParentPacketError, match="expected mms.pi_committee.result.v1"):
+        mms_pi_parent.build_parent_packet({"schema": "wrong"})
+
+
+def test_invalid_result_shapes_fail_closed() -> None:
+    result = _result_fixture()
+    result["results"] = {"member-01": {}}
+
+    with pytest.raises(mms_pi_parent.ParentPacketError, match="results must be an array"):
+        mms_pi_parent.build_parent_packet(result)
+
+
+def test_run_parent_committee_delegates_to_existing_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+
+    def fake_run_committee(**kwargs):
+        captured.update(kwargs)
+        result = _result_fixture()
+        result["status"] = "success"
+        result["plan"]["members"] = result["plan"]["members"][:1]
+        result["results"] = result["results"][:1]
+        return result
+
+    monkeypatch.setattr("mms_pi_committee.run_committee", fake_run_committee)
+
+    packet = mms_pi_parent.run_parent_committee(
+        config_root="/explicit/root",
+        task="Inspect",
+        cwd="/target",
+        dry_run=True,
+    )
+
+    assert captured["config_root"] == "/explicit/root"
+    assert captured["task"] == "Inspect"
+    assert captured["dry_run"] is True
+    assert packet["opinions"][0]["member_id"] == "member-01"
+
+
+def test_parent_cli_converts_saved_result_without_config_or_provider_call(tmp_path: Path) -> None:
+    result_path = tmp_path / "result.json"
+    result_path.write_text(json.dumps(_result_fixture()), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "pi_committee_parent.py"),
+            "--result",
+            str(result_path),
+            "--compact",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    packet = json.loads(completed.stdout)
+    assert packet["schema"] == "mms.pi_committee.parent_packet.v1"
+    assert packet["mission"]["mission_id"] == "pi-parent-test"
+
+
+def test_parent_cli_requires_explicit_config_for_task() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "pi_committee_parent.py"), "--task", "Inspect"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "--config-root is required" in completed.stderr
+
+
+def test_bundled_skill_is_explicit_and_runner_locates_parent_cli() -> None:
+    skill = ROOT / "assets" / "session-assets" / "skills" / "pi-committee"
+    skill_text = (skill / "SKILL.md").read_text(encoding="utf-8")
+    metadata = (skill / "agents" / "openai.yaml").read_text(encoding="utf-8")
+
+    assert "$pi-committee" in skill_text
+    assert "current Codex or Claude" in skill_text
+    assert "Do not assume the MMS launcher auto-injected it" in skill_text
+    assert "allow_implicit_invocation: false" in metadata
+    completed = subprocess.run(
+        [sys.executable, str(skill / "scripts" / "run_pi_committee.py"), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "--result" in completed.stdout
+    assert "--config-root" in completed.stdout

--- a/tests/test_pi_parent.py
+++ b/tests/test_pi_parent.py
@@ -19,6 +19,11 @@ def _result_fixture() -> dict:
         "mission_id": "pi-parent-test",
         "status": "partial",
         "elapsed_ms": 1234,
+        "watchdog": {
+            "member_wall_timeout_seconds": 600,
+            "committee_timeout_seconds": 1260,
+            "committee_stop_reason": "completed",
+        },
         "summary": {"members": 3, "succeeded": 2, "failed": 1},
         "plan": {
             "mission_id": "pi-parent-test",
@@ -108,8 +113,17 @@ def _result_fixture() -> dict:
                 "family": "GLM",
                 "lens": "verification",
                 "status": "failed",
+                "terminal_reason": "request_error",
                 "error": "request_error",
-                "attempts": [{"provider_id": "glm-provider", "status": "request_error", "error": "upstream"}],
+                "attempts": [
+                    {
+                        "provider_id": "glm-provider",
+                        "status": "request_error",
+                        "terminal_reason": "request_error",
+                        "error": "upstream",
+                        "watchdog": {"elapsed_ms": 700},
+                    }
+                ],
             },
         ],
     }
@@ -129,15 +143,117 @@ def test_build_parent_packet_is_lossless_and_synthesis_ready() -> None:
         "structured_responses": 1,
         "raw_responses": 1,
         "fallback_members": 1,
+        "coverage_ratio": 0.5,
+        "required_successes_for_synthesis": 2,
+        "synthesis_coverage_met": True,
         "status_counts": {"failed": 1, "missing_result": 1, "success": 2},
         "family_counts": {"GLM": 1, "GPT": 1, "Qwen": 1},
     }
     assert packet["opinions"][0]["response"]["findings"][0]["extra"] == "preserve me"
     assert packet["opinions"][1]["response"] == {"raw_text": "malformed but useful opinion"}
+    assert packet["mission"]["watchdog"]["committee_timeout_seconds"] == 1260
+    assert packet["failures"][0]["terminal_reason"] == "request_error"
+    assert packet["route_health"][2]["attempts"][0]["watchdog"] == {"elapsed_ms": 700}
     assert packet["evidence_index"][0]["evidence_id"] == "member-01-finding-01"
     assert {item["status"] for item in packet["failures"]} == {"failed", "missing_result"}
     assert packet["synthesis_contract"]["owner"] == "current_parent"
     assert packet["synthesis_contract"]["semantic_grouping"] == "parent_reasoning_required"
+    assert packet["synthesis_readiness"] == {
+        "reason": "sufficient_coverage",
+        "coverage_met": True,
+        "coverage_ratio": 0.5,
+        "required_coverage_ratio": 0.5,
+        "required_successes": 2,
+    }
+
+
+def _coverage_result(planned_members: int, successes: int) -> dict:
+    result = _result_fixture()
+    result["status"] = "partial" if successes < planned_members else "success"
+    result["plan"]["members"] = [
+        {
+            "member_id": f"member-{index:02d}",
+            "model": f"model-{index}",
+            "family": f"Family-{index}",
+            "lens": "verification",
+            "route_chain": [{"provider_id": f"provider-{index}"}],
+        }
+        for index in range(1, planned_members + 1)
+    ]
+    result["results"] = [
+        {
+            "member_id": f"member-{index:02d}",
+            "model": f"model-{index}",
+            "family": f"Family-{index}",
+            "lens": "verification",
+            "status": "success",
+            "response": {"raw_text": "opinion"},
+            "fallback_used": False,
+            "attempts": [],
+        }
+        for index in range(1, successes + 1)
+    ]
+    return result
+
+
+def test_one_of_seven_is_not_ready_for_synthesis() -> None:
+    packet = mms_pi_parent.build_parent_packet(_coverage_result(7, 1))
+
+    assert packet["ready_for_synthesis"] is False
+    assert packet["synthesis_readiness"]["reason"] == "insufficient_coverage"
+    assert packet["synthesis_readiness"]["required_successes"] == 4
+    assert packet["committee_health"]["coverage_ratio"] == pytest.approx(1 / 7, abs=1e-6)
+
+
+def test_four_of_seven_meets_synthesis_coverage_floor() -> None:
+    packet = mms_pi_parent.build_parent_packet(_coverage_result(7, 4))
+
+    assert packet["ready_for_synthesis"] is True
+    assert packet["synthesis_readiness"]["reason"] == "sufficient_coverage"
+    assert packet["synthesis_readiness"]["required_successes"] == 4
+
+
+def test_skipped_fallback_is_not_counted_as_fallback_member() -> None:
+    result = _coverage_result(1, 0)
+    result["status"] = "failed"
+    result["results"] = [
+        {
+            "member_id": "member-01",
+            "model": "model-1",
+            "family": "Family-1",
+            "lens": "verification",
+            "status": "failed",
+            "terminal_reason": "wall_timeout",
+            "error": "direct-kimi:wall_timeout",
+            "fallback_used": True,
+            "fallback_skipped_reason": "no_budget_remaining",
+            "attempts": [
+                {
+                    "provider_id": "direct-kimi",
+                    "fallback_position": 0,
+                    "started": True,
+                    "budget_seconds": 900,
+                    "status": "wall_timeout",
+                    "terminal_reason": "wall_timeout",
+                },
+                {
+                    "provider_id": "newapi-tokyo",
+                    "fallback_position": 1,
+                    "started": False,
+                    "budget_seconds": 0,
+                    "status": "skipped",
+                    "terminal_reason": "no_budget_remaining",
+                },
+            ],
+        }
+    ]
+
+    packet = mms_pi_parent.build_parent_packet(result)
+
+    assert packet["committee_health"]["fallback_members"] == 0
+    assert packet["opinions"][0]["fallback_used"] is False
+    assert packet["route_health"][0]["fallback_skipped_reason"] == "no_budget_remaining"
+    assert packet["route_health"][0]["attempts"][1]["started"] is False
 
 
 def test_dry_run_packet_is_not_ready_for_synthesis() -> None:
@@ -254,3 +370,5 @@ def test_bundled_skill_is_explicit_and_runner_locates_parent_cli() -> None:
     assert completed.returncode == 0, completed.stderr
     assert "--result" in completed.stdout
     assert "--config-root" in completed.stdout
+    assert "--kimi-attempt-timeout" in completed.stdout
+    assert "--max-bundle-age-days" in completed.stdout

--- a/tests/test_pi_watchdog.py
+++ b/tests/test_pi_watchdog.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import sys
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import mms_pi_watchdog
+
+
+def _policy(**overrides) -> mms_pi_watchdog.WatchdogPolicy:
+    values = {
+        "wall_timeout_seconds": 1.0,
+        "idle_timeout_seconds": 0.4,
+        "max_output_bytes": 64 * 1024,
+        "max_repeated_events": 8,
+        "terminate_grace_seconds": 0.5,
+        "poll_interval_seconds": 0.01,
+    }
+    values.update(overrides)
+    return mms_pi_watchdog.WatchdogPolicy(**values)
+
+
+def _run(script: str, *, policy: mms_pi_watchdog.WatchdogPolicy, tmp_path: Path):
+    return mms_pi_watchdog.run_process(
+        [sys.executable, "-u", "-c", script],
+        cwd=tmp_path,
+        env={},
+        policy=policy,
+    )
+
+
+def test_slow_but_active_process_completes(tmp_path: Path) -> None:
+    outcome = _run(
+        "import time; print('started', flush=True); time.sleep(0.12); print('finished', flush=True)",
+        policy=_policy(idle_timeout_seconds=0.25),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "completed"
+    assert outcome.returncode == 0
+    assert outcome.stdout.splitlines() == ["started", "finished"]
+
+
+def test_idle_timeout_stops_silent_process(tmp_path: Path) -> None:
+    outcome = _run(
+        "import time; time.sleep(5)",
+        policy=_policy(idle_timeout_seconds=0.1),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "idle_timeout"
+    assert outcome.terminated is True
+    assert outcome.elapsed_ms < 1500
+
+
+def test_wall_timeout_stops_process_that_keeps_emitting_unique_output(tmp_path: Path) -> None:
+    outcome = _run(
+        "import time\nfor i in range(100):\n print(i, flush=True)\n time.sleep(0.02)",
+        policy=_policy(wall_timeout_seconds=0.18, idle_timeout_seconds=0.5),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "wall_timeout"
+    assert outcome.terminated is True
+
+
+def test_repeated_event_limit_stops_loop(tmp_path: Path) -> None:
+    outcome = _run(
+        "import time\nfor _ in range(20):\n print('same-event', flush=True)\n time.sleep(0.01)\ntime.sleep(5)",
+        policy=_policy(max_repeated_events=5),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "repetition_limit"
+    assert outcome.peak_repeated_events >= 5
+
+
+def test_output_limit_bounds_capture_and_stops_process(tmp_path: Path) -> None:
+    outcome = _run(
+        "import sys,time; sys.stdout.write('x' * 8192); sys.stdout.flush(); time.sleep(5)",
+        policy=_policy(max_output_bytes=1024),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "output_limit"
+    assert outcome.stdout_bytes > 1024
+    assert len(outcome.stdout.encode()) <= 1024
+
+
+def test_high_cumulative_framed_output_uses_bounded_tail_without_false_kill(tmp_path: Path) -> None:
+    outcome = _run(
+        "for i in range(80): print(f'{i:03d}-' + 'x' * 96, flush=True)",
+        policy=_policy(max_output_bytes=1024),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason == "completed"
+    assert outcome.stdout_bytes > 1024
+    assert len(outcome.stdout.encode()) <= 1024
+    assert "079-" in outcome.stdout
+
+
+def test_external_cancellation_stops_process(tmp_path: Path) -> None:
+    controller = mms_pi_watchdog.CancellationController()
+    timer = threading.Timer(0.1, lambda: controller.cancel("committee_timeout"))
+    timer.start()
+    try:
+        outcome = mms_pi_watchdog.run_process(
+            [sys.executable, "-u", "-c", "import time; time.sleep(5)"],
+            cwd=tmp_path,
+            env={},
+            policy=_policy(),
+            cancellation=controller,
+        )
+    finally:
+        timer.cancel()
+
+    assert outcome.terminal_reason == "committee_timeout"
+    assert outcome.terminated is True
+
+
+def test_timeout_signals_descendant_process_group(tmp_path: Path) -> None:
+    marker = tmp_path / "child-terminated.txt"
+    child = (
+        "import signal,time,pathlib; "
+        f"p=pathlib.Path({str(marker)!r}); "
+        "signal.signal(signal.SIGTERM, lambda *_: (p.write_text('terminated'), exit(0))); "
+        "print('child-ready', flush=True); time.sleep(5)"
+    )
+    parent = (
+        "import subprocess,sys,time; "
+        f"subprocess.Popen([sys.executable, '-u', '-c', {child!r}]); "
+        "time.sleep(5)"
+    )
+
+    outcome = _run(
+        parent,
+        policy=_policy(wall_timeout_seconds=0.4, idle_timeout_seconds=0.3),
+        tmp_path=tmp_path,
+    )
+    deadline = time.monotonic() + 1
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert outcome.terminal_reason in {"idle_timeout", "wall_timeout"}
+    assert marker.read_text() == "terminated"
+
+
+def test_stubborn_descendant_forces_group_kill(tmp_path: Path) -> None:
+    child = "import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); print('ready', flush=True); time.sleep(5)"
+    parent = (
+        "import subprocess,sys,time; "
+        f"subprocess.Popen([sys.executable, '-u', '-c', {child!r}]); "
+        "time.sleep(5)"
+    )
+
+    outcome = _run(
+        parent,
+        policy=_policy(
+            wall_timeout_seconds=0.35,
+            idle_timeout_seconds=0.25,
+            terminate_grace_seconds=0.1,
+        ),
+        tmp_path=tmp_path,
+    )
+
+    assert outcome.terminal_reason in {"idle_timeout", "wall_timeout"}
+    assert outcome.forced_kill is True
+
+
+def test_posix_group_signal_error_falls_back_to_force_kill(monkeypatch) -> None:
+    class FakeProcess:
+        pid = 12345
+
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+            self.waits = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def kill(self):
+            self.killed = True
+
+        def wait(self, timeout):
+            self.waits += 1
+            if self.waits == 1:
+                raise subprocess.TimeoutExpired("fake", timeout)
+            return -9
+
+    process = FakeProcess()
+    monkeypatch.setattr(mms_pi_watchdog.os, "killpg", lambda *_args: (_ for _ in ()).throw(OSError("no group")))
+
+    terminated, forced = mms_pi_watchdog._terminate_process_group(process, 0.01)
+
+    assert terminated is True
+    assert forced is True
+    assert process.terminated is True
+    assert process.killed is True


### PR DESCRIPTION
## Scope
- Restore the dynamic Pi committee runtime and parent adapter required by the shared `pi-committee` launcher.
- Add committee-only watchdog handling and serialized Pi npx prewarm.
- Deliberately exclude Pi Court, Pi Executor, real MMS config roots, and provider calls.

## Validation
- `python3 -m py_compile mms_pi_committee.py mms_pi_parent.py mms_pi_watchdog.py scripts/pi_committee.py scripts/pi_committee_parent.py`
- Targeted suite: `68 passed, 2 deselected`
- Fresh-user gate: `python3 scripts/regression_fresh_user_gate.py`
- Shared launcher `--help` reaches `pi_committee_parent.py` when `MMS_PI_COMMITTEE_ROOT` points to this worktree.

## Known baseline failures
Two existing `tests/test_pi_launcher.py` assertions fail unchanged on clean `dev` and are not modified here: one assumes the retired `~/.config/mms` export root; one omits the existing `supportsDeveloperRole: false` DeepSeek compatibility field.

## Bootstrap review boundary
This PR restores the committee runtime that would normally review it. The human explicitly authorized the integration; no live provider or committee call was made during validation.