### PR TITLE
chore(vendor): sync web-access snapshot to canonical 2.6.0-ctrixin.1

### DIFF
--- a/vendor/web-access/.claude-plugin/plugin.json
+++ b/vendor/web-access/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "web-access",
   "description": "Complete web browsing and automation skill for Claude Code - intelligent tool selection, CDP browser automation, and site experience accumulation",
-  "version": "2.5.3-mmf.1",
+  "version": "2.6.0-ctrixin.1",
   "author": {
     "name": "一泽 Eze"
   },
-  "homepage": "https://github.com/eze-is/web-access",
-  "repository": "https://github.com/eze-is/web-access",
+  "homepage": "https://github.com/CtriXin/web-access",
+  "repository": "https://github.com/CtriXin/web-access",
   "license": "MIT",
   "keywords": ["web", "browser", "cdp", "automation", "search"],
   "skills": ["./"]

--- a/vendor/web-access/.gitignore
+++ b/vendor/web-access/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.ai/
 *.log
 references/site-patterns/*.md
 config.env

--- a/vendor/web-access/README.md
+++ b/vendor/web-access/README.md
@@ -18,6 +18,22 @@
   </details>
 </div>
 
+> **CtriXin distribution**：本仓库 fork 自
+> [`eze-is/web-access`](https://github.com/eze-is/web-access)，保留原作者与 MIT
+> 归属，并加入 MMF host-home 隔离、真实输入安全和广告位 source-fidelity
+> 验收。上游关系、版本基线与同步策略见 [UPSTREAM.md](./UPSTREAM.md)。
+
+> **本机广告位审计扩展**：广告位 source-fidelity 任务使用 canonical 最新目录
+> `~/auto-skills/CtriXin-repo/chrome-extensions/ad-placement-inspector/`。运行
+> `scripts/check-ad-placement-inspector.mjs --url <url> --manifest <source-manifest> --evidence-dir <dir>`
+> 会同时核验真实 Chrome、extension manifest 版本/build hash、页面 handshake，并由 extension
+> 对目标 tab 逐广告位检查 source-bound manifest；只有 `allPass=true` 才通过，同时产出
+> JSON 和截图证据。
+>
+> **批量验收**：先创建一个 task-owned tab；随后每个 case 使用
+> `--target <targetId>` 复用该 tab。脚本会在同一 tab 内导航和验收，避免每条 case 新建 tab
+> 或触发额外的 CDP 授权提示；完成后只关闭这个 task-owned tab。
+
 <img width="879" height="376" alt="image" src="https://github.com/user-attachments/assets/a87fd816-a0b5-4264-b01c-9466eae90723" />
 
 <p align="center">
@@ -118,6 +134,8 @@ CDP 模式需要 **Node.js 22+** 和浏览器（Chrome / Edge）开启远程调�
    - Edge：`edge://inspect/#remote-debugging`
 2. 勾选 **Allow remote debugging for this browser instance**（可能需要重启浏览器）
 
+在 MMF/Codex 等隔离会话中，先设置 `WEB_ACCESS_HOST_HOME` 指向宿主用户目录。若 Chrome 已在固定端口开启远程调试但未生成 `DevToolsActivePort`，`check-deps.mjs` 会把 `9222`、`9229`、`9333` 的监听端口交给任务专属 proxy；proxy 只建立一条最终 WebSocket，并用 `Browser.getVersion` 验证 CDP 和浏览器身份。TCP 能连接本身不会被误判为可用 CDP，也不会额外触发一次 Chrome 授权弹窗。
+
 ### 浏览器偏好（config.env）
 
 skill 长期偏好保存在 `${CLAUDE_SKILL_DIR}/config.env`（首次运行自动从 `config.env.template` 创建，gitignored）：
@@ -138,7 +156,9 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs" --browser chrome
 **切换浏览器**（proxy 已连接旧的）：
 
 ```bash
-pkill -f cdp-proxy.mjs && node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
+ps -axo pid=,command= | rg '/web-access/scripts/cdp-proxy.mjs'
+# 核对脚本路径后，只 kill 上一步确认的精确 PID，再运行：
+node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 ```
 
 环境检查（Agent 运行时会自动完成前置检查，无需手动执行）：

--- a/vendor/web-access/SKILL.md
+++ b/vendor/web-access/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: web-access
 license: MIT
-github: https://github.com/eze-is/web-access
+github: https://github.com/CtriXin/web-access
 description:
   所有联网操作必须通过此 skill 处理，包括：搜索、网页抓取、登录后操作、网络交互等。
   触发场景：用户要求搜索信息、查看网页内容、访问需要登录的网站、操作网页界面、抓取社交媒体内容（小红书、微博、推特等）、读取动态渲染页面、以及任何需要真实浏览器环境的网络任务。
 metadata:
-  author: 一泽Eze
-  version: "2.5.3-mmf.1"
+  author: 一泽Eze; CtriXin distribution
+  version: "2.6.0-ctrixin.1"
 ---
 
 # web-access Skill
@@ -17,6 +17,8 @@ metadata:
 `web-access` is a browser backend. When an agent enters through Weber/Webber, Weber chooses whether to use this backend; when an agent explicitly loads `web-access`, it may proceed directly.
 
 For MMF, Codex, and other isolated sessions, export `WEB_ACCESS_HOST_HOME` (or `HOST_HOME` / `REAL_HOME`) as the host user's home directory before running the precheck. Browser discovery then reads the host `DevToolsActivePort`, while the agent never copies the host Chrome profile or cookie database. If the session HOME is isolated and no host-home handoff is available, `check-deps.mjs` hard-fails rather than guessing a Chrome profile or starting a browser.
+
+When a host Chrome has remote debugging enabled on a fixed port but does not expose `DevToolsActivePort`, the precheck may identify a standard local listener as a candidate. It must not open a separate probe connection: the task-owned CDP Proxy performs one `Browser.getVersion` round trip on its final connection, verifies the configured browser product, and keeps that authorized connection alive. A TCP listener or an HTTP response alone is never reported as usable CDP, and an already connected proxy is always reused before any discovery.
 
 ## 前置检查
 
@@ -35,7 +37,36 @@ node "${CLAUDE_SKILL_DIR}/scripts/check-deps.mjs"
 
 支持参数 `--browser <chrome|edge>` 表达本次临时覆盖（不写 config.env）。
 
-切换浏览器时，proxy 是长驻进程，需先 `pkill -f cdp-proxy.mjs` 再重跑 check-deps。
+切换浏览器时，proxy 是长驻进程。先用 `ps` 核对其精确 PID 和脚本路径，只停止该
+task-owned proxy，再重跑 check-deps；禁止使用全局 `pkill`。
+
+### 广告位验收前置
+
+广告位、广告 source fidelity、复制站广告验证必须使用 canonical 最新插件目录
+`${WEB_ACCESS_HOST_HOME:-$HOME}/auto-skills/CtriXin-repo/chrome-extensions/ad-placement-inspector/`，
+并在目标 URL 上运行：
+
+```bash
+node "${CLAUDE_SKILL_DIR}/scripts/check-ad-placement-inspector.mjs" \
+  --url "<local-or-production-url>" \
+  --manifest "<source-bound-ad-placement-manifest.json>" \
+  --evidence-dir "<artifact-root>/evidence/runtime"
+```
+
+批量广告位验收时，必须只创建一个 task-owned 后台 tab，再让每条 case 传同一个
+`--target <targetId>`。该命令会在这个 tab 内导航并执行验收，绝不能为每条 case 重复创建 tab
+或重启 Proxy；结束后只关闭这个 task-owned tab。`--target` 不得指向用户已有 tab。
+
+当 source-bound manifest 声明 `viewportClass: "mobile"` 时，检查器会通过 Proxy 的
+`/setViewport` 为这个 task-owned tab 应用 `390 x 844` 的 CDP emulation，再导航到目标页。
+该接口拒绝用户已有 tab，不会新增 Chrome 连接或触发逐 case 授权；Desktop tab 保持真实窗口视口。
+
+只有同时满足真实 Chrome CDP 已连接、extension service worker manifest 的 name/version/build hash
+匹配 canonical source、目标页面 content-script handshake 同 hash，并且 extension 在目标 tab 上执行
+`ADI_RUN_ACCEPTANCE` 后逐广告位 `placement_acceptance.acceptance.allPass=true` 才是
+pass。只证明插件安装不等于位置验收。未安装、未启用、版本/build 漂移、origin permission
+缺失或任一 placement mismatch 均必须停止；不得用普通 DOM 检查或 Playwright 独立
+profile 替代。
 
 **隔离环境硬规则：** 已有登录态的任务必须先通过 `check-deps.mjs` 连接宿主 Chrome。不得从隔离 HOME 启动个人 Chrome binary，也不得回退到 Playwright 独立 Profile；必须命令启动时使用 `mms-chrome-host`。
 

--- a/vendor/web-access/SNAPSHOT.md
+++ b/vendor/web-access/SNAPSHOT.md
@@ -1,0 +1,11 @@
+# Vendor snapshot — not a source
+
+This directory is a **tracked cross-machine release snapshot** of the canonical
+checkout at `/Users/xin/auto-skills/CtriXin-repo/web-access`
+(fork: `CtriXin/web-access`, upstream: `eze-is/web-access`).
+
+- Snapshot of canonical commit: `e2a9e1d` (distribution `2.6.0-ctrixin.1`)
+- Synced: 2026-07-29 by Kimi (bounded-review follow-up)
+- Rule: never edit files here directly. Change the canonical repo, push, then
+  re-sync this snapshot from the canonical tracked file set (`git ls-files`),
+  excluding the git-ignored `config.env` (template: `templates/config.env.template`).

--- a/vendor/web-access/UPSTREAM.md
+++ b/vendor/web-access/UPSTREAM.md
@@ -1,0 +1,16 @@
+# Upstream and distribution policy
+
+`CtriXin/web-access` is a maintained fork of
+[`eze-is/web-access`](https://github.com/eze-is/web-access).
+
+- Upstream baseline: `7af34af6a25940d917905f0e5f2a7ef056952971` (`v2.5.3`)
+- Distribution version: `2.6.0-ctrixin.1`
+- Canonical local checkout: `/Users/xin/auto-skills/CtriXin-repo/web-access`
+- Runtime, global Agent skill directories, and MMF session overlays are consumers
+  of this checkout; they must not become independent source copies.
+
+The fork preserves the original author and MIT attribution. CtriXin-specific
+changes cover MMF host-home browser discovery, fail-closed isolation, targeted
+proxy lifecycle, real input operations, and source-bound ad-placement
+attestation. Upstream updates should be fetched through the `upstream` remote,
+reviewed against these contracts, and merged into this fork explicitly.

--- a/vendor/web-access/references/cdp-api.md
+++ b/vendor/web-access/references/cdp-api.md
@@ -5,7 +5,7 @@
 - 地址：`http://localhost:3456`
 - 启动：`node ~/.claude/skills/web-access/scripts/cdp-proxy.mjs &`
 - 启动后持续运行，不建议主动停止（重启需 Chrome 重新授权）
-- 强制停止：`pkill -f cdp-proxy.mjs`
+- 停止：先用 `ps -axo pid=,command=` 核对脚本路径，再只 `kill <精确 PID>`。
 
 ## API 端点
 
@@ -95,6 +95,15 @@ curl -s -X POST "http://localhost:3456/insertText?target=ID" --data-binary '待�
 读取 CSS 视口和设备倍率，避免 canvas 坐标与截图像素混用。
 ```bash
 curl -s "http://localhost:3456/viewport?target=ID"
+```
+
+### POST /setViewport?target=ID
+为通过 `/new` 创建的 task-owned tab 下发 CDP 设备视口。拒绝用户已有 tab；不会建立新的 Chrome
+连接。Mobile source-bound 广告验收由检查器自动调用，通常不需要手工执行。
+```bash
+curl -s -X POST "http://localhost:3456/setViewport?target=ID" \
+  -H 'content-type: application/json' \
+  -d '{"width":390,"height":844,"deviceScaleFactor":1,"mobile":true}'
 ```
 
 ### POST /setFiles?target=ID

--- a/vendor/web-access/scripts/browser-discovery.mjs
+++ b/vendor/web-access/scripts/browser-discovery.mjs
@@ -17,6 +17,7 @@ import { fileURLToPath } from 'node:url';
 
 const SKILL_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CONFIG_PATH = path.join(SKILL_ROOT, 'config.env');
+const FALLBACK_PORTS = [9222, 9229, 9333];
 
 function isIsolatedHome(home) {
   return /\/(?:\.mmf|\.config\/mms|\.config\/mmf|gateway\/s|sessions)\//.test(home || '');
@@ -69,8 +70,7 @@ export function knownBrowsers() {
   }
 }
 
-// TCP 端口监听检测
-// 用 TCP connect 而非 WebSocket，避免触发浏览器的远程调试授权弹窗。
+// TCP 端口监听检测。仅用于快速排除未监听端口，不能证明它是 CDP。
 export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
   return new Promise((resolve) => {
     const socket = net.createConnection(port, host);
@@ -78,6 +78,18 @@ export function checkPort(port, host = '127.0.0.1', timeoutMs = 2000) {
     socket.once('connect', () => { clearTimeout(timer); socket.destroy(); resolve(true); });
     socket.once('error',   () => { clearTimeout(timer); resolve(false); });
   });
+}
+
+export function productMatchesBrowser(product, browserId) {
+  const value = String(product || '').toLowerCase();
+  switch (browserId) {
+    case 'chrome': return value.startsWith('chrome/');
+    case 'chromium': return value.startsWith('chromium/');
+    case 'edge': return value.startsWith('edg/');
+    // Browser.getVersion cannot reliably distinguish Chrome Canary from Chrome.
+    case 'chrome-canary': return false;
+    default: return false;
+  }
 }
 
 // 读 config.env 文件（不写入 process.env，分清来源）
@@ -99,7 +111,7 @@ function readConfig() {
   return cfg;
 }
 
-// 返回所有开了 toggle 且端口活的浏览器
+// DevToolsActivePort gives the target WebSocket path; the proxy performs the CDP handshake.
 async function detectAll() {
   const result = [];
   for (const browser of knownBrowsers()) {
@@ -127,10 +139,21 @@ export async function selectBrowser(override = null) {
   const detected = await detectAll();
   const configured = readConfig().WEB_ACCESS_BROWSER || null;
 
+  // Browser toggles in isolated sessions may not leave DevToolsActivePort in the host profile.
+  // Treat a fixed listener as a candidate; cdp-proxy verifies Browser.getVersion on its one real connection.
+  const matchingFallback = async (browserId) => {
+    const fallback = await findFallbackPort();
+    const browser = knownBrowsers().find((item) => item.id === browserId);
+    if (!fallback || !browser) return null;
+    return { ...browser, ...fallback };
+  };
+
   // 1. 命令行 override（最高优先，单次有效）
   if (override) {
     const match = detected.find(b => b.id === override);
     if (match) return { kind: 'ok', browser: match, source: 'override', detected, configured, override };
+    const fallback = await matchingFallback(override);
+    if (fallback) return { kind: 'ok', browser: fallback, source: 'fallback', detected, configured, override };
     return { kind: 'mismatch', source: 'override', detected, configured, override };
   }
 
@@ -138,6 +161,8 @@ export async function selectBrowser(override = null) {
   if (configured) {
     const match = detected.find(b => b.id === configured);
     if (match) return { kind: 'ok', browser: match, source: 'preference', detected, configured };
+    const fallback = await matchingFallback(configured);
+    if (fallback) return { kind: 'ok', browser: fallback, source: 'fallback', detected, configured };
     return { kind: 'mismatch', source: 'preference', detected, configured };
   }
 
@@ -148,12 +173,10 @@ export async function selectBrowser(override = null) {
   return { kind: 'ambiguous', detected, configured };
 }
 
-// 兜底：扫描常用固定端口
-// 适用场景：用户手动 --remote-debugging-port=9222 启动浏览器，
-// 此时 DevToolsActivePort 可能不在默认 user-data-dir。
+// 兜底：扫描常用固定端口。它只是连接候选，CDP proxy 会在同一条最终连接上验证。
 export async function findFallbackPort() {
-  for (const port of [9222, 9229, 9333]) {
-    if (await checkPort(port)) return port;
+  for (const port of FALLBACK_PORTS) {
+    if (await checkPort(port)) return { port, wsPath: null };
   }
   return null;
 }

--- a/vendor/web-access/scripts/cdp-proxy.mjs
+++ b/vendor/web-access/scripts/cdp-proxy.mjs
@@ -9,7 +9,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import net from 'node:net';
-import { selectBrowser, findFallbackPort, browserEnvironment } from './browser-discovery.mjs';
+import { selectBrowser, findFallbackPort, productMatchesBrowser, browserEnvironment } from './browser-discovery.mjs';
 
 // --- 解析命令行 --browser 参数（本次启动用哪个浏览器）---
 function parseBrowserArg() {
@@ -61,12 +61,16 @@ async function discoverChromePort() {
     if (pinnedBrowserId && pinnedBrowserId !== result.browser.id) {
       throw new Error(
         `本次连接的浏览器已经是 ${pinnedBrowserId}，不会自动切到 ${result.browser.id}。` +
-        `如果想换成 ${result.browser.id}，请先在终端运行 pkill -f cdp-proxy.mjs 重置。`
+        `如果想换成 ${result.browser.id}，请先核对并停止当前 web-access proxy 的精确 PID。`
       );
     }
     pinnedBrowserId = result.browser.id;
     connectedBrowser = { id: result.browser.id, label: result.browser.label, source: result.source };
-    const tag = result.source === 'override' ? '[--browser 指定]' : '[config.env 偏好]';
+    const tag = result.source === 'override'
+      ? '[--browser 指定]'
+      : result.source === 'fallback'
+        ? '[固定端口候选，连接后验证]'
+        : '[config.env 偏好]';
     console.log(`[CDP Proxy] 选用 ${result.browser.label} (端口 ${result.browser.port}${result.browser.wsPath ? '，带 wsPath' : ''}) ${tag}`);
     return { port: result.browser.port, wsPath: result.browser.wsPath };
   }
@@ -86,15 +90,15 @@ async function discoverChromePort() {
       `本次连接的浏览器是 ${pinnedBrowserId}，但现在没连上。Agent 处理顺序：` +
       `(1) 先用系统命令打开 ${pinnedBrowserId}（按平台选择），稍等后重试请求；` +
       `(2) 若仍失败，告知用户在地址栏访问 ${pinnedBrowserId}://inspect/#remote-debugging 重新勾选允许。` +
-      `若想换成其他浏览器，请先在终端运行 pkill -f cdp-proxy.mjs 重置。`
+      `若想换成其他浏览器，请先核对并停止当前 web-access proxy 的精确 PID。`
     );
   }
   // 仅在「从未成功连接 + 无偏好/override」时允许固定端口兜底（手动 --remote-debugging-port 启动场景）
   const fallbackPort = await findFallbackPort();
   if (fallbackPort !== null) {
-    connectedBrowser = { id: 'unknown', label: '未知（通过手动调试端口连接）', source: 'fallback' };
-    console.log(`[CDP Proxy] 通过手动调试端口连接: ${fallbackPort}`);
-    return { port: fallbackPort, wsPath: null };
+    connectedBrowser = { id: 'unknown', label: '未知（通过固定端口候选）', source: 'fallback' };
+    console.log(`[CDP Proxy] 使用固定端口候选: ${fallbackPort.port}`);
+    return { port: fallbackPort.port, wsPath: fallbackPort.wsPath };
   }
   return null;
 }
@@ -131,11 +135,32 @@ async function connect() {
   return connectingPromise = new Promise((resolve, reject) => {
     ws = new WS(wsUrl);
 
-    const onOpen = () => {
+    const onOpen = async () => {
       cleanup();
-      connectingPromise = null;
-      console.log(`[CDP Proxy] 已连接浏览器 (端口 ${chromePort})`);
-      resolve();
+      try {
+        // Keep a single browser connection: this is both the permission-bearing connection and the CDP proof.
+        const version = await sendCDP('Browser.getVersion');
+        const product = version.result?.product;
+        if (typeof product !== 'string') throw new Error('CDP Browser.getVersion 未返回浏览器产品信息');
+        if (
+          connectedBrowser?.source === 'fallback'
+          && connectedBrowser.id !== 'unknown'
+          && !productMatchesBrowser(product, connectedBrowser.id)
+        ) {
+          throw new Error(`固定端口返回 ${product}，与请求的 ${connectedBrowser.id} 不一致`);
+        }
+        connectedBrowser = { ...connectedBrowser, product };
+        connectingPromise = null;
+        console.log(`[CDP Proxy] 已连接浏览器 (端口 ${chromePort}, ${product})`);
+        resolve();
+      } catch (error) {
+        connectingPromise = null;
+        ws?.close();
+        ws = null;
+        chromePort = null;
+        chromeWsPath = null;
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
     };
     const onError = (e) => {
       cleanup();
@@ -342,6 +367,194 @@ const server = http.createServer(async (req, res) => {
       const resp = await sendCDP('Target.getTargets');
       const pages = resp.result.targetInfos.filter(t => t.type === 'page');
       res.end(JSON.stringify(pages, null, 2));
+    }
+
+    // GET /extension-status?name=...&version=... - 只读核验指定 extension
+    else if (pathname === '/extension-status') {
+      const expectedName = String(q.name || '').trim();
+      const expectedVersion = String(q.version || '').trim();
+      const expectedBuildHash = String(q.buildHash || '').trim();
+      if (!expectedName) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ status: 'blocked', error: 'name is required' }));
+        return;
+      }
+      const resp = await sendCDP('Target.getTargets');
+      const extensionTargets = resp.result.targetInfos.filter(t =>
+        ['service_worker', 'background_page'].includes(t.type)
+        && t.url.startsWith('chrome-extension://')
+      );
+      const observed = [];
+      for (const target of extensionTargets) {
+        try {
+          const sid = await ensureSession(target.targetId);
+          const evaluated = await sendCDP('Runtime.evaluate', {
+            expression: `JSON.stringify({
+              manifest: chrome.runtime.getManifest(),
+              attestation: globalThis.AdPlacementInspectorBuildAttestation || null
+            })`,
+            returnByValue: true,
+          }, sid);
+          const raw = evaluated.result?.result?.value;
+          const runtime = raw ? JSON.parse(raw) : null;
+          const manifest = runtime?.manifest;
+          if (!manifest) continue;
+          observed.push({
+            id: new URL(target.url).hostname,
+            name: manifest.name,
+            version: manifest.version,
+            buildHash: runtime?.attestation?.buildHash || null,
+            targetType: target.type,
+          });
+        } catch { /* inactive or protected extension target */ }
+      }
+      const matched = observed.find(item =>
+        item.name === expectedName
+        && (!expectedVersion || item.version === expectedVersion)
+        && (!expectedBuildHash || item.buildHash === expectedBuildHash)
+      );
+      res.end(JSON.stringify({
+        status: matched ? 'passed' : 'blocked',
+        expected: {
+          name: expectedName,
+          version: expectedVersion || null,
+          buildHash: expectedBuildHash || null,
+        },
+        matched: matched || null,
+        observedCount: observed.length,
+      }, null, 2));
+    }
+
+    // POST /extension-acceptance - 通过指定 extension service worker 对目标 tab 运行固定的广告位验收消息。
+    // body: { name, version, targetUrl, manifest }
+    else if (pathname === '/extension-acceptance') {
+      if (req.method !== 'POST') {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ status: 'blocked', error: 'POST is required' }));
+        return;
+      }
+      const body = JSON.parse(await readBody(req));
+      const expectedName = String(body.name || '').trim();
+      const expectedVersion = String(body.version || '').trim();
+      const expectedBuildHash = String(body.buildHash || '').trim();
+      const targetUrl = String(body.targetUrl || '').trim();
+      const manifest = body.manifest;
+      if (
+        !expectedName
+        || !targetUrl
+        || manifest?.schema !== 'ad-placement-inspector.manifest.v1'
+        || !Array.isArray(manifest?.placements)
+        || !manifest.placements.length
+      ) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({
+          status: 'blocked',
+          error: 'name, targetUrl and a non-empty ad-placement-inspector.manifest.v1 are required',
+        }));
+        return;
+      }
+      const targets = await sendCDP('Target.getTargets');
+      const extensionTargets = targets.result.targetInfos.filter(target =>
+        ['service_worker', 'background_page'].includes(target.type)
+        && target.url.startsWith('chrome-extension://')
+      );
+      let matchedTarget = null;
+      let matchedManifest = null;
+      for (const target of extensionTargets) {
+        try {
+          const sid = await ensureSession(target.targetId);
+          const evaluated = await sendCDP('Runtime.evaluate', {
+            expression: `JSON.stringify({
+              manifest: chrome.runtime.getManifest(),
+              attestation: globalThis.AdPlacementInspectorBuildAttestation || null
+            })`,
+            returnByValue: true,
+          }, sid);
+          const raw = evaluated.result?.result?.value;
+          const runtime = raw ? JSON.parse(raw) : null;
+          const extensionManifest = runtime?.manifest;
+          if (
+            extensionManifest?.name === expectedName
+            && (!expectedVersion || extensionManifest.version === expectedVersion)
+            && (!expectedBuildHash || runtime?.attestation?.buildHash === expectedBuildHash)
+          ) {
+            matchedTarget = target;
+            matchedManifest = {
+              ...extensionManifest,
+              buildHash: runtime?.attestation?.buildHash || null,
+            };
+            break;
+          }
+        } catch { /* inactive or protected extension target */ }
+      }
+      if (!matchedTarget) {
+        res.end(JSON.stringify({
+          status: 'blocked',
+          error: 'expected extension runtime was not found',
+        }));
+        return;
+      }
+      const sid = await ensureSession(matchedTarget.targetId);
+      const payload = JSON.stringify({ targetUrl, manifest });
+      const expression = `(async () => {
+        const input = ${payload};
+        const tabs = await chrome.tabs.query({});
+        const tab = tabs.find(item => item.url === input.targetUrl);
+        if (!tab?.id) return { status: 'blocked', error: 'target tab not found' };
+        const originPattern = new URL(input.targetUrl).origin + '/*';
+        const granted = await chrome.permissions.contains({ origins: [originPattern] });
+        if (!granted) return {
+          status: 'blocked',
+          error: 'extension origin permission is not granted',
+          originPattern,
+        };
+        try {
+          await chrome.tabs.sendMessage(tab.id, { type: 'ADI_GET_SNAPSHOT' });
+        } catch (error) {
+          return {
+            status: 'blocked',
+            error: 'declared content script is not reachable',
+            detail: String(error),
+            tabId: tab.id,
+            originPattern,
+          };
+        }
+        const acceptance = await chrome.tabs.sendMessage(tab.id, {
+          type: 'ADI_RUN_ACCEPTANCE',
+          manifest: input.manifest,
+        });
+        return {
+          status: acceptance?.allPass ? 'passed' : 'failed',
+          tabId: tab.id,
+          originPattern,
+          acceptance,
+        };
+      })()`;
+      const evaluated = await sendCDP('Runtime.evaluate', {
+        expression,
+        returnByValue: true,
+        awaitPromise: true,
+      }, sid);
+      if (evaluated.result?.exceptionDetails) {
+        res.statusCode = 500;
+        res.end(JSON.stringify({
+          status: 'blocked',
+          error: evaluated.result.exceptionDetails.text,
+        }));
+        return;
+      }
+      res.end(JSON.stringify({
+        ...(evaluated.result?.result?.value || {
+          status: 'blocked',
+          error: 'extension acceptance returned no value',
+        }),
+        extension: {
+          id: new URL(matchedTarget.url).hostname,
+          name: matchedManifest.name,
+          version: matchedManifest.version,
+          buildHash: matchedManifest.buildHash,
+        },
+      }, null, 2));
     }
 
     // POST /new (body=URL) - 创建新后台 tab
@@ -556,6 +769,40 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify(resp.result?.result?.value || {}));
     }
 
+    // POST /setViewport?target=xxx — 仅允许 task-owned tab 设置 CDP 设备视口。
+    else if (pathname === '/setViewport') {
+      if (req.method !== 'POST') {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'POST body 需要 viewport JSON' }));
+        return;
+      }
+      if (!q.target || !managedTabs.has(q.target)) {
+        res.statusCode = 403;
+        res.end(JSON.stringify({ error: '只允许对通过 /new 创建的 task-owned tab 设置 viewport' }));
+        return;
+      }
+      const body = JSON.parse(await readBody(req));
+      const width = Number(body.width);
+      const height = Number(body.height);
+      const deviceScaleFactor = body.deviceScaleFactor === undefined ? 1 : Number(body.deviceScaleFactor);
+      if (!Number.isInteger(width) || !Number.isInteger(height) || width < 1 || height < 1 || width > 3840 || height > 3840 || !Number.isFinite(deviceScaleFactor) || deviceScaleFactor < 0 || deviceScaleFactor > 4) {
+        res.statusCode = 400;
+        res.end(JSON.stringify({ error: 'viewport width/height 必须是 1-3840 的整数，deviceScaleFactor 必须在 0-4 之间' }));
+        return;
+      }
+      const sid = await ensureSession(q.target);
+      await sendCDP('Emulation.setDeviceMetricsOverride', {
+        width,
+        height,
+        deviceScaleFactor,
+        mobile: body.mobile === true,
+        screenWidth: width,
+        screenHeight: height,
+      }, sid);
+      touchTab(q.target);
+      res.end(JSON.stringify({ status: 'ok', targetId: q.target, width, height, deviceScaleFactor, mobile: body.mobile === true }));
+    }
+
     // POST /setFiles?target=xxx — 给 file input 设置本地文件（绕过文件对话框）
     // body: JSON { "selector": "input[type=file]", "files": ["/path/to/file1.png", "/path/to/file2.png"] }
     else if (pathname === '/setFiles') {
@@ -644,6 +891,8 @@ const server = http.createServer(async (req, res) => {
         endpoints: {
           '/health': 'GET - 健康检查',
           '/targets': 'GET - 列出所有页面 tab',
+          '/extension-status?name=...&version=...': 'GET - 核验指定 Chrome extension 的 service worker manifest',
+          '/extension-acceptance': 'POST JSON - 通过指定 extension 对目标 tab 运行广告位 manifest 验收',
           '/new': 'POST body=URL - 创建新后台 tab（自动等待加载）',
           '/close?target=': 'GET - 关闭 tab',
           '/navigate?target=': 'POST body=URL - 导航（自动等待加载）',
@@ -656,6 +905,7 @@ const server = http.createServer(async (req, res) => {
           '/key?target=': 'POST JSON {action?,key,code?,text?,modifiers?} - 真实 CDP 键盘事件',
           '/insertText?target=': 'POST body=文本 - 向已进入编辑态的元素输入文本',
           '/viewport?target=': 'GET - CSS 视口、devicePixelRatio 和 visualViewport',
+          '/setViewport?target=': 'POST JSON {width,height,deviceScaleFactor?,mobile?} - 仅 task-owned tab 的 CDP 设备视口',
           '/scroll?target=&y=&direction=': 'GET - 滚动页面',
           '/screenshot?target=&file=': 'GET - 截图',
         },

--- a/vendor/web-access/scripts/check-ad-placement-inspector.mjs
+++ b/vendor/web-access/scripts/check-ad-placement-inspector.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const hostHome = process.env.WEB_ACCESS_HOST_HOME
+  || process.env.HOST_HOME
+  || process.env.REAL_HOME
+  || os.homedir();
+const EXTENSION_ROOT = path.resolve(
+  process.env.AD_PLACEMENT_INSPECTOR_ROOT
+  || path.join(hostHome, 'auto-skills', 'CtriXin-repo', 'chrome-extensions', 'ad-placement-inspector'),
+);
+const PROXY = `http://127.0.0.1:${Number(process.env.CDP_PROXY_PORT || 3456)}`;
+const EXPECTED_SCHEMA = 'ad-placement-inspector.handshake.v2';
+
+function mobileViewportFor(manifest) {
+  if (manifest?.context?.viewportClass !== 'mobile') return null;
+  return { width: 390, height: 844, deviceScaleFactor: 1, mobile: true };
+}
+
+function parseArgs(argv) {
+  const out = { url: '', evidenceDir: '', manifest: '', keepTab: false, targetId: '' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--url') out.url = argv[++i] || '';
+    else if (argv[i] === '--evidence-dir') out.evidenceDir = argv[++i] || '';
+    else if (argv[i] === '--manifest') out.manifest = argv[++i] || '';
+    else if (argv[i] === '--target') out.targetId = argv[++i] || '';
+    else if (argv[i] === '--keep-tab') out.keepTab = true;
+  }
+  if (!out.url) throw new Error('--url is required');
+  return out;
+}
+
+async function jsonFetch(url, options = {}) {
+  const response = await fetch(url, { ...options, signal: AbortSignal.timeout(15000) });
+  const text = await response.text();
+  let payload;
+  try { payload = JSON.parse(text); } catch { payload = { raw: text }; }
+  if (!response.ok) throw new Error(`${response.status} ${JSON.stringify(payload)}`);
+  return payload;
+}
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const inspectedUrl = new URL(args.url);
+  inspectedUrl.searchParams.set('__adi_inspection', `${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const manifestPath = path.join(EXTENSION_ROOT, 'manifest.json');
+  const attestationPath = path.join(EXTENSION_ROOT, 'build-attestation.json');
+  if (!fs.existsSync(manifestPath)) throw new Error(`extension manifest missing: ${manifestPath}`);
+  if (!fs.existsSync(attestationPath)) throw new Error(`extension attestation missing: ${attestationPath}`);
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const attestation = JSON.parse(fs.readFileSync(attestationPath, 'utf8'));
+  if (
+    attestation.schema !== 'ad-placement-inspector.build-attestation.v1'
+    || attestation.version !== manifest.version
+    || !/^[a-f0-9]{64}$/i.test(attestation.buildHash || '')
+  ) {
+    throw new Error('canonical extension build attestation is invalid');
+  }
+  let acceptanceManifest = null;
+  if (args.manifest) {
+    const acceptancePath = path.resolve(args.manifest);
+    acceptanceManifest = JSON.parse(fs.readFileSync(acceptancePath, 'utf8'));
+    if (
+      acceptanceManifest.schema !== 'ad-placement-inspector.manifest.v1'
+      || !Array.isArray(acceptanceManifest.placements)
+      || !acceptanceManifest.placements.length
+      || !acceptanceManifest.source?.taskGuid
+      || acceptanceManifest.source?.revision === undefined
+      || !/^[a-f0-9]{64}$/i.test(acceptanceManifest.manifestHash || '')
+    ) {
+      throw new Error('acceptance manifest is invalid or not source-bound');
+    }
+  }
+  const health = await jsonFetch(`${PROXY}/health`);
+  if (health.status !== 'ok' || !health.connected) {
+    throw new Error('web-access CDP proxy is not connected to the real Chrome instance');
+  }
+
+  let targetId = args.targetId;
+  let createdTarget = false;
+  const mobileViewport = mobileViewportFor(acceptanceManifest);
+  if (targetId) {
+    const targets = await jsonFetch(`${PROXY}/targets`);
+    if (!targets.some(target => target.targetId === targetId && target.type === 'page')) {
+      throw new Error('--target must be an existing task-owned page target');
+    }
+    if (mobileViewport) {
+      await jsonFetch(`${PROXY}/setViewport?target=${encodeURIComponent(targetId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(mobileViewport),
+      });
+    }
+    // Reuse one task-owned tab across a batch to avoid per-case CDP prompts.
+    await jsonFetch(`${PROXY}/navigate?target=${encodeURIComponent(targetId)}`, {
+      method: 'POST',
+      body: inspectedUrl.href,
+    });
+  } else {
+    // Set mobile emulation before navigation so responsive layout is verified at first render.
+    const created = await jsonFetch(`${PROXY}/new`, {
+      method: 'POST',
+      body: mobileViewport ? 'about:blank' : inspectedUrl.href,
+    });
+    targetId = created.targetId;
+    createdTarget = true;
+    if (mobileViewport) {
+      await jsonFetch(`${PROXY}/setViewport?target=${encodeURIComponent(targetId)}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(mobileViewport),
+      });
+      await jsonFetch(`${PROXY}/navigate?target=${encodeURIComponent(targetId)}`, {
+        method: 'POST',
+        body: inspectedUrl.href,
+      });
+    }
+  }
+  let result;
+  try {
+    let pageHandshake = null;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      const expression = `JSON.stringify({
+        enabled: document.documentElement.dataset.adPlacementInspector || null,
+        schema: document.documentElement.dataset.adPlacementInspectorSchema || null,
+        version: document.documentElement.dataset.adPlacementInspectorVersion || null,
+        buildHash: document.documentElement.dataset.adPlacementInspectorBuildHash || null,
+        url: location.href
+      })`;
+      const evaluated = await jsonFetch(
+        `${PROXY}/eval?target=${encodeURIComponent(targetId)}`,
+        { method: 'POST', body: expression },
+      );
+      try { pageHandshake = JSON.parse(evaluated.value); } catch { pageHandshake = null; }
+      if (
+        pageHandshake?.enabled === 'enabled'
+        && pageHandshake?.schema === EXPECTED_SCHEMA
+        && pageHandshake?.version === manifest.version
+        && pageHandshake?.buildHash === attestation.buildHash
+      ) break;
+      await wait(250);
+    }
+    const extensionStatus = await jsonFetch(
+      `${PROXY}/extension-status?name=${encodeURIComponent(manifest.name)}`
+        + `&version=${encodeURIComponent(manifest.version)}`
+        + `&buildHash=${encodeURIComponent(attestation.buildHash)}`,
+    );
+    let placementAcceptance = null;
+    if (
+      acceptanceManifest
+      && pageHandshake?.url
+      && extensionStatus.status === 'passed'
+    ) {
+      const acceptanceRequest = {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: manifest.name,
+          version: manifest.version,
+          buildHash: attestation.buildHash,
+          targetUrl: pageHandshake.url,
+          manifest: acceptanceManifest,
+        }),
+      };
+      const maxAcceptanceAttempts = 20;
+      for (let attempt = 1; attempt <= maxAcceptanceAttempts; attempt++) {
+        placementAcceptance = await jsonFetch(
+          `${PROXY}/extension-acceptance`,
+          acceptanceRequest,
+        );
+        placementAcceptance.preflight = {
+          attempts: attempt,
+          maxAttempts: maxAcceptanceAttempts,
+          retryIntervalMs: 250,
+        };
+        if (
+          placementAcceptance.status === 'passed'
+          && placementAcceptance.acceptance?.allPass === true
+        ) break;
+        if (attempt < maxAcceptanceAttempts) await wait(250);
+      }
+    }
+    const handshakePassed = (
+      pageHandshake?.enabled === 'enabled'
+      && pageHandshake?.schema === EXPECTED_SCHEMA
+      && pageHandshake?.version === manifest.version
+      && pageHandshake?.buildHash === attestation.buildHash
+      && extensionStatus.status === 'passed'
+    );
+    const acceptancePassed = !acceptanceManifest || (
+      placementAcceptance?.status === 'passed'
+      && placementAcceptance?.acceptance?.allPass === true
+    );
+    const passed = handshakePassed && acceptancePassed;
+    result = {
+      schema_version: 'web-access.ad-placement-inspector-preflight.v1',
+      generated_at: new Date().toISOString(),
+      status: passed ? 'passed' : 'blocked',
+      real_chrome: {
+        connected: true,
+        browser: health.browser || null,
+        cdp_proxy_port: Number(process.env.CDP_PROXY_PORT || 3456),
+      },
+      expected_extension: {
+        root: EXTENSION_ROOT,
+        name: manifest.name,
+        version: manifest.version,
+        build_hash: attestation.buildHash,
+        handshake_schema: EXPECTED_SCHEMA,
+      },
+      extension_runtime: extensionStatus,
+      page_handshake: pageHandshake,
+      placement_acceptance: placementAcceptance,
+      acceptance_manifest: acceptanceManifest,
+      target: {
+        id: targetId,
+        requested_url: args.url,
+        inspected_url: inspectedUrl.href,
+        reused: !createdTarget,
+      },
+      blocker: passed ? null : (
+        !handshakePassed
+          ? '广告位检查器未安装/未启用，或真实 Chrome 加载的 version/build hash 与 canonical source 不一致。'
+            + '请在真实 Chrome 从 canonical 目录 reload 后重试。'
+          : '广告位与 source-bound manifest 不一致；逐项 failures 已写入 placement_acceptance。'
+      ),
+    };
+    if (args.evidenceDir) {
+      const evidenceDir = path.resolve(args.evidenceDir);
+      fs.mkdirSync(evidenceDir, { recursive: true });
+      const jsonPath = path.join(evidenceDir, 'ad-placement-inspector-preflight.json');
+      const screenshotPath = path.join(evidenceDir, 'ad-placement-inspector-preflight.png');
+      fs.writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`);
+      await jsonFetch(
+        `${PROXY}/screenshot?target=${encodeURIComponent(targetId)}&file=${encodeURIComponent(screenshotPath)}`,
+      );
+      result.evidence = { json: jsonPath, screenshot: screenshotPath };
+      fs.writeFileSync(jsonPath, `${JSON.stringify(result, null, 2)}\n`);
+    }
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!passed) process.exitCode = 2;
+  } finally {
+    if (createdTarget && !args.keepTab) {
+      await jsonFetch(`${PROXY}/close?target=${encodeURIComponent(targetId)}`).catch(() => undefined);
+    }
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(`${JSON.stringify({ status: 'blocked', error: String(error.message || error) })}\n`);
+  process.exitCode = 2;
+});

--- a/vendor/web-access/scripts/check-deps.mjs
+++ b/vendor/web-access/scripts/check-deps.mjs
@@ -18,6 +18,7 @@ import { selectBrowser, knownBrowsers, findFallbackPort, browserEnvironment } fr
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PROXY_SCRIPT = path.join(ROOT, 'scripts', 'cdp-proxy.mjs');
 const PROXY_PORT = Number(process.env.CDP_PROXY_PORT || 3456);
+const PROXY_HEALTH_URL = `http://127.0.0.1:${PROXY_PORT}/health`;
 const CONFIG_PATH = path.join(ROOT, 'config.env');
 const CONFIG_TEMPLATE = path.join(ROOT, 'templates', 'config.env.template');
 
@@ -61,6 +62,20 @@ function httpGetJson(url, timeoutMs = 3000) {
     .catch(() => null);
 }
 
+export function isConnectedProxyHealth(health) {
+  return health?.status === 'ok' && health.connected === true;
+}
+
+function isCompatibleProxyHealth(health, expectedBrowserId) {
+  return isConnectedProxyHealth(health)
+    && (!expectedBrowserId || health.browser?.id === expectedBrowserId);
+}
+
+async function connectedProxyHealth() {
+  const health = await httpGetJson(PROXY_HEALTH_URL);
+  return isConnectedProxyHealth(health) ? health : null;
+}
+
 function startProxyDetached(browserOverride) {
   const logFile = path.join(os.tmpdir(), 'cdp-proxy.log');
   const logFd = fs.openSync(logFile, 'a');
@@ -76,17 +91,16 @@ function startProxyDetached(browserOverride) {
 }
 
 async function ensureProxy(expectedBrowserId, browserOverride) {
-  const healthUrl = `http://127.0.0.1:${PROXY_PORT}/health`;
   const targetsUrl = `http://127.0.0.1:${PROXY_PORT}/targets`;
 
   // 复用：proxy 已运行 + 已连接浏览器 → 校验 expected vs actual
-  const health = await httpGetJson(healthUrl);
-  if (health?.status === 'ok' && health.connected) {
+  const health = await connectedProxyHealth();
+  if (health) {
     const runningId = health.browser?.id;
     const runningLabel = health.browser?.label || runningId || 'unknown';
     if (expectedBrowserId && runningId && runningId !== 'unknown' && runningId !== expectedBrowserId) {
       console.log(`proxy: 浏览器不一致 — 当前已连着 ${runningLabel}，但本次需要 ${expectedBrowserId}`);
-      console.log('  请在终端运行 pkill -f cdp-proxy.mjs 重置后再试');
+      console.log('  请先核对并停止当前 web-access proxy 的精确 PID，再重试');
       return false;
     }
     console.log(`proxy: ready (${runningLabel})`);
@@ -101,7 +115,7 @@ async function ensureProxy(expectedBrowserId, browserOverride) {
   for (let i = 1; i <= 15; i++) {
     const result = await httpGetJson(targetsUrl, 8000);
     if (Array.isArray(result)) {
-      const newHealth = await httpGetJson(healthUrl);
+      const newHealth = await httpGetJson(PROXY_HEALTH_URL);
       const label = newHealth?.browser?.label || 'unknown';
       console.log(`proxy: ready (${label})`);
       return true;
@@ -135,7 +149,11 @@ async function resolveAndReport(override) {
 
   switch (result.kind) {
     case 'ok': {
-      const sourceTag = result.source === 'override' ? '[--browser 指定]' : '[config.env 偏好]';
+      const sourceTag = result.source === 'override'
+        ? '[--browser 指定]'
+        : result.source === 'fallback'
+          ? '[固定端口候选，连接后验证]'
+          : '[config.env 偏好]';
       console.log(`browser: ok (${result.browser.label}, port ${result.browser.port}) ${sourceTag}`);
       return { proceed: true, browserId: result.browser.id };
     }
@@ -167,7 +185,7 @@ async function resolveAndReport(override) {
       // 末路兜底：尝试常见固定端口（用户手动 --remote-debugging-port=9222 启动的场景）
       const fallbackPort = await findFallbackPort();
       if (fallbackPort) {
-        console.log(`browser: ok (port ${fallbackPort}) [通过手动调试端口连接]`);
+        console.log(`browser: candidate (port ${fallbackPort.port}) [由 proxy CDP 握手验证]`);
         return { proceed: true };
       }
       console.log('browser: 未连接 — 没有任何浏览器打开远程调试开关');
@@ -178,10 +196,32 @@ async function resolveAndReport(override) {
   }
 }
 
+function reportSitePatterns() {
+  const patternsDir = path.join(ROOT, 'references', 'site-patterns');
+  try {
+    const sites = fs.readdirSync(patternsDir)
+      .filter(f => f.endsWith('.md'))
+      .map(f => f.replace(/\.md$/, ''));
+    if (sites.length) {
+      console.log(`\nsite-patterns: ${sites.join(', ')}`);
+    }
+  } catch {}
+}
+
 // --- main ---
 
-async function main() {
+export async function main() {
   const opts = parseArgs(process.argv.slice(2));
+
+  // A connected proxy is authoritative and remains reachable when sandbox TCC blocks DevToolsActivePort.
+  const health = await connectedProxyHealth();
+  if (isCompatibleProxyHealth(health, opts.browser)) {
+    const label = health.browser?.label || health.browser?.id || 'unknown';
+    console.log(`proxy: ready (${label})`);
+    reportSitePatterns();
+    return;
+  }
+
   ensureConfigExists();
   checkNode();
 
@@ -200,16 +240,10 @@ async function main() {
   const proxyOk = await ensureProxy(browserId, opts.browser);
   if (!proxyOk) process.exit(1);
 
-  // 列出已有站点经验
-  const patternsDir = path.join(ROOT, 'references', 'site-patterns');
-  try {
-    const sites = fs.readdirSync(patternsDir)
-      .filter(f => f.endsWith('.md'))
-      .map(f => f.replace(/\.md$/, ''));
-    if (sites.length) {
-      console.log(`\nsite-patterns: ${sites.join(', ')}`);
-    }
-  } catch {}
+  reportSitePatterns();
 }
 
-await main();
+const isDirectExecution = process.argv[1]
+  && fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
+
+if (isDirectExecution) await main();

--- a/vendor/web-access/test/browser-discovery.test.mjs
+++ b/vendor/web-access/test/browser-discovery.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { productMatchesBrowser } from '../scripts/browser-discovery.mjs';
+
+test('fixed-port fallback only accepts the configured browser product', () => {
+  assert.equal(productMatchesBrowser('Chrome/150.0.0.0', 'chrome'), true);
+  assert.equal(productMatchesBrowser('Edg/150.0.0.0', 'edge'), true);
+  assert.equal(productMatchesBrowser('Chrome/150.0.0.0', 'edge'), false);
+  assert.equal(productMatchesBrowser('Edg/150.0.0.0', 'chrome'), false);
+  assert.equal(productMatchesBrowser('Chrome/150.0.0.0', 'chrome-canary'), false);
+});

--- a/vendor/web-access/test/check-ad-placement-inspector.test.mjs
+++ b/vendor/web-access/test/check-ad-placement-inspector.test.mjs
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { once } from 'node:events';
+import test from 'node:test';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CHECKER = path.join(ROOT, 'scripts', 'check-ad-placement-inspector.mjs');
+
+function runChecker(args, env) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CHECKER, ...args], {
+      env: { ...process.env, ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+test('reuses the supplied task-owned target without creating or closing a tab', async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'adi-reuse-target-'));
+  const extensionRoot = path.join(tempDir, 'extension');
+  const acceptancePath = path.join(tempDir, 'acceptance.json');
+  const buildHash = 'a'.repeat(64);
+  await mkdir(extensionRoot);
+  await writeFile(path.join(extensionRoot, 'manifest.json'), JSON.stringify({ name: '广告位检查器', version: '0.8.0' }));
+  await writeFile(path.join(extensionRoot, 'build-attestation.json'), JSON.stringify({
+    schema: 'ad-placement-inspector.build-attestation.v1',
+    version: '0.8.0',
+    buildHash,
+  }));
+  await writeFile(acceptancePath, JSON.stringify({
+    schema: 'ad-placement-inspector.manifest.v1',
+    placements: [{ slot: 'home_1' }],
+    source: { taskGuid: 't103490', revision: 1 },
+    manifestHash: 'b'.repeat(64),
+  }));
+
+  let newCalls = 0;
+  let closeCalls = 0;
+  let navigatedUrl = '';
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    res.setHeader('Content-Type', 'application/json');
+    if (url.pathname === '/health') {
+      res.end(JSON.stringify({ status: 'ok', connected: true, browser: { id: 'chrome' } }));
+    } else if (url.pathname === '/targets') {
+      res.end(JSON.stringify([{ targetId: 'task-owned', type: 'page' }]));
+    } else if (url.pathname === '/navigate') {
+      navigatedUrl = await readBody(req);
+      res.end(JSON.stringify({ frameId: 'frame-1' }));
+    } else if (url.pathname === '/eval') {
+      res.end(JSON.stringify({ value: JSON.stringify({
+        enabled: 'enabled',
+        schema: 'ad-placement-inspector.handshake.v2',
+        version: '0.8.0',
+        buildHash,
+        url: navigatedUrl,
+      }) }));
+    } else if (url.pathname === '/extension-status') {
+      res.end(JSON.stringify({ status: 'passed' }));
+    } else if (url.pathname === '/extension-acceptance') {
+      res.end(JSON.stringify({ status: 'passed', acceptance: { allPass: true } }));
+    } else if (url.pathname === '/new') {
+      newCalls++;
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: 'must not create a tab' }));
+    } else if (url.pathname === '/close') {
+      closeCalls++;
+      res.statusCode = 500;
+      res.end(JSON.stringify({ error: 'must not close a reused tab' }));
+    } else {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: `unexpected ${url.pathname}` }));
+    }
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const result = await runChecker([
+    '--url', 'https://example.test/reader',
+    '--target', 'task-owned',
+    '--manifest', acceptancePath,
+  ], {
+    AD_PLACEMENT_INSPECTOR_ROOT: extensionRoot,
+    CDP_PROXY_PORT: String(port),
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.status, 'passed');
+  assert.equal(report.target.reused, true);
+  assert.equal(newCalls, 0);
+  assert.equal(closeCalls, 0);
+  assert.match(navigatedUrl, /^https:\/\/example\.test\/reader\?.*__adi_inspection=/);
+});
+
+test('sets mobile emulation on a reused task-owned target before navigation', async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'adi-mobile-target-'));
+  const extensionRoot = path.join(tempDir, 'extension');
+  const acceptancePath = path.join(tempDir, 'acceptance.json');
+  const buildHash = 'c'.repeat(64);
+  await mkdir(extensionRoot);
+  await writeFile(path.join(extensionRoot, 'manifest.json'), JSON.stringify({ name: '广告位检查器', version: '0.8.0' }));
+  await writeFile(path.join(extensionRoot, 'build-attestation.json'), JSON.stringify({
+    schema: 'ad-placement-inspector.build-attestation.v1',
+    version: '0.8.0',
+    buildHash,
+  }));
+  await writeFile(acceptancePath, JSON.stringify({
+    schema: 'ad-placement-inspector.manifest.v1',
+    placements: [{ slot: 'read_1' }],
+    source: { taskGuid: 't103490', revision: 1 },
+    context: { viewportClass: 'mobile' },
+    manifestHash: 'd'.repeat(64),
+  }));
+
+  const calls = [];
+  let navigatedUrl = '';
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://127.0.0.1');
+    const body = await readBody(req);
+    calls.push({ path: url.pathname, body });
+    res.setHeader('Content-Type', 'application/json');
+    if (url.pathname === '/health') {
+      res.end(JSON.stringify({ status: 'ok', connected: true, browser: { id: 'chrome' } }));
+    } else if (url.pathname === '/targets') {
+      res.end(JSON.stringify([{ targetId: 'task-owned', type: 'page' }]));
+    } else if (url.pathname === '/setViewport') {
+      res.end(JSON.stringify({ status: 'ok' }));
+    } else if (url.pathname === '/navigate') {
+      navigatedUrl = body;
+      res.end(JSON.stringify({ frameId: 'frame-1' }));
+    } else if (url.pathname === '/eval') {
+      res.end(JSON.stringify({ value: JSON.stringify({
+        enabled: 'enabled', schema: 'ad-placement-inspector.handshake.v2', version: '0.8.0', buildHash, url: navigatedUrl,
+      }) }));
+    } else if (url.pathname === '/extension-status') {
+      res.end(JSON.stringify({ status: 'passed' }));
+    } else if (url.pathname === '/extension-acceptance') {
+      res.end(JSON.stringify({ status: 'passed', acceptance: { allPass: true } }));
+    } else {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: `unexpected ${url.pathname}` }));
+    }
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const result = await runChecker([
+    '--url', 'https://example.test/reader', '--target', 'task-owned', '--manifest', acceptancePath,
+  ], { AD_PLACEMENT_INSPECTOR_ROOT: extensionRoot, CDP_PROXY_PORT: String(port) });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.deepEqual(JSON.parse(calls.find((call) => call.path === '/setViewport').body), {
+    width: 390, height: 844, deviceScaleFactor: 1, mobile: true,
+  });
+  assert.ok(calls.findIndex((call) => call.path === '/setViewport') < calls.findIndex((call) => call.path === '/navigate'));
+});

--- a/vendor/web-access/test/check-deps.test.mjs
+++ b/vendor/web-access/test/check-deps.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, rmdir, writeFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { once } from 'node:events';
+import test from 'node:test';
+
+import { isConnectedProxyHealth } from '../scripts/check-deps.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CHECK_DEPS = path.join(ROOT, 'scripts', 'check-deps.mjs');
+
+function runCheckDeps(env, args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CHECK_DEPS, ...args], {
+      env: { ...process.env, ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+test('isConnectedProxyHealth only accepts an explicitly connected healthy proxy', () => {
+  assert.equal(isConnectedProxyHealth({ status: 'ok', connected: true }), true);
+  assert.equal(isConnectedProxyHealth({ status: 'ok', connected: false }), false);
+  assert.equal(isConnectedProxyHealth({ status: 'ok', connected: 'true' }), false);
+  assert.equal(isConnectedProxyHealth({ status: 'error', connected: true }), false);
+});
+
+test('check-deps accepts a connected proxy before sandbox browser discovery', async (t) => {
+  const hostHome = await mkdtemp(path.join(os.tmpdir(), 'web-access-empty-home-'));
+  const patternsDir = path.join(ROOT, 'references', 'site-patterns');
+  const patternFile = path.join(patternsDir, 'test-proxy-health-pattern.md');
+  await mkdir(patternsDir, { recursive: true });
+  await writeFile(patternFile, '# test pattern\n');
+
+  const server = http.createServer((req, res) => {
+    assert.equal(req.url, '/health');
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({
+      status: 'ok',
+      connected: true,
+      browser: { id: 'chrome', label: 'Chrome' },
+    }));
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(hostHome, { recursive: true, force: true });
+    await rm(patternFile, { force: true });
+    await rmdir(patternsDir).catch(() => {});
+  });
+
+  const result = await runCheckDeps({
+    CDP_PROXY_PORT: String(port),
+    WEB_ACCESS_HOST_HOME: hostHome,
+  });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /proxy: ready \(Chrome\)/);
+  assert.match(result.stdout, /site-patterns: .*test-proxy-health-pattern/);
+  assert.doesNotMatch(result.stdout, /browser:/);
+});
+
+test('check-deps does not early-pass when --browser conflicts with proxy health', async (t) => {
+  const hostHome = await mkdtemp(path.join(os.tmpdir(), 'web-access-empty-home-'));
+  const configPath = path.join(ROOT, 'config.env');
+  const hadConfig = fs.existsSync(configPath);
+  const configBefore = hadConfig ? await readFile(configPath) : null;
+  const server = http.createServer((req, res) => {
+    assert.equal(req.url, '/health');
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({
+      status: 'ok',
+      connected: true,
+      browser: { id: 'chrome', label: 'Chrome' },
+    }));
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(hostHome, { recursive: true, force: true });
+    if (hadConfig) await writeFile(configPath, configBefore);
+    else await rm(configPath, { force: true });
+  });
+
+  const result = await runCheckDeps({
+    CDP_PROXY_PORT: String(port),
+    WEB_ACCESS_HOST_HOME: hostHome,
+  }, ['--browser', 'edge']);
+
+  assert.equal(result.code, 1, result.stderr);
+  assert.match(result.stdout, /(?:browser: error — 本次指定的浏览器是 "edge"|proxy: 浏览器不一致 — 当前已连着 Chrome，但本次需要 edge)/);
+  assert.doesNotMatch(result.stdout, /proxy: ready/);
+});


### PR DESCRIPTION
## Why

Bounded-review (Kimi) follow-up to the web-access canonical migration: the tracked cross-machine vendor snapshot was still `2.5.3-mmf.1`, missing the ad-placement attestation contract and the safe proxy-lifecycle guidance (it still recommended a global `pkill`). Fresh sessions materialized on *other* machines from this snapshot would lack the current contracts.

## What

- Snapshot synced to canonical `CtriXin/web-access@e2a9e1d` (distribution `2.6.0-ctrixin.1`), using the canonical tracked file set (`git ls-files`)
- Excludes git-ignored `config.env` (template lives at `templates/config.env.template`)
- Adds `SNAPSHOT.md`: marks this directory as a snapshot, not a source, with the sync rule

## Verify

- `node --test vendor/web-access/test/*.test.mjs` → 6 pass, 0 fail
- `vendor/web-access/SKILL.md` byte-identical to canonical