### PR TITLE
[codex] fix Pi Tokyo parser payloads

### DIFF
--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -830,6 +830,10 @@ def _pi_pick_protocol(runtime, model_name):
     variant_by_protocol = {item["protocol"]: item for item in variants}
     caps = _pi_model_capabilities(runtime, model_name)
     normalized_model = _pi_normalize_model_key(model_name)
+    if "openai_chat_completions" in available and normalized_model.startswith(("glm-", "k3")):
+        # Active GLM/K3 CRS channels accept OpenAI-compatible requests; avoid
+        # routing them through NewAPI's incompatible Anthropic adapter.
+        return variant_by_protocol["openai_chat_completions"], caps
     if "anthropic_messages" in available and (
         normalized_model.startswith("k3") or normalized_model.startswith(("claude-", "qwen", "kimi-", "gemini-"))
     ):

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -830,9 +830,11 @@ def _pi_pick_protocol(runtime, model_name):
     variant_by_protocol = {item["protocol"]: item for item in variants}
     caps = _pi_model_capabilities(runtime, model_name)
     normalized_model = _pi_normalize_model_key(model_name)
-    if "openai_chat_completions" in available and normalized_model.startswith(("glm-", "k3")):
+    if "openai_chat_completions" in available and (
+        normalized_model.startswith("glm-") or _pi_is_kimi_k3_selector(normalized_model)
+    ):
         # Active GLM/K3 CRS channels accept OpenAI-compatible requests; avoid
-        # routing them through NewAPI's incompatible Anthropic adapter.
+        # routing K3 aliases through NewAPI's incompatible Anthropic adapter.
         return variant_by_protocol["openai_chat_completions"], caps
     if "anthropic_messages" in available and (
         normalized_model.startswith("k3") or normalized_model.startswith(("claude-", "qwen", "kimi-", "gemini-"))

--- a/scripts/pi-retry-extension.mjs
+++ b/scripts/pi-retry-extension.mjs
@@ -1,4 +1,42 @@
+const TOKYO_PROVIDER_PREFIX = "mms-newapi-personal-tokyo";
+
+function normalizeTokyoParserString(value) {
+  return value
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, (character) => {
+      return `\\u${character.codePointAt(0).toString(16).padStart(4, "0")}`;
+    })
+    .replace(/\\x([0-9a-f]{2})/gi, (_match, hex) => `\\u00${hex.toLowerCase()}`)
+    .replace(/\\([aev])/gi, (_match, escape) => {
+      const code = { a: "0007", e: "001b", v: "000b" }[escape.toLowerCase()];
+      return `\\u${code}`;
+    })
+    .replace(/\\0(?![0-9])/g, "\\u0000");
+}
+
+function normalizeTokyoParserPayload(value) {
+  if (typeof value === "string") {
+    return normalizeTokyoParserString(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalizeTokyoParserPayload);
+  }
+  if (!value || Object.getPrototypeOf(value) !== Object.prototype) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, normalizeTokyoParserPayload(child)]),
+  );
+}
+
 export default function (pi) {
+  pi.on("before_provider_request", (event, ctx) => {
+    const provider = String(ctx.model?.provider || "").trim();
+    if (!provider.startsWith(TOKYO_PROVIDER_PREFIX)) {
+      return;
+    }
+    return normalizeTokyoParserPayload(event.payload);
+  });
+
   pi.on("message_end", (event, ctx) => {
     const message = event.message;
     if (!message || message.role !== "assistant" || message.stopReason !== "error") {
@@ -38,7 +76,7 @@ export default function (pi) {
     // NewAPI intermittently rejects an already-valid Pi request while decoding
     // tool history. Limit retries to its known parser signatures and provider.
     if (
-      provider.startsWith("mms-newapi-personal-tokyo") &&
+      provider.startsWith(TOKYO_PROVIDER_PREFIX) &&
       /invalid character .* in string (literal|escape code)/i.test(errorMessage)
     ) {
       return {

--- a/scripts/pi-retry-extension.mjs
+++ b/scripts/pi-retry-extension.mjs
@@ -34,5 +34,19 @@ export default function (pi) {
         },
       };
     }
+
+    // NewAPI intermittently rejects an already-valid Pi request while decoding
+    // tool history. Limit retries to its known parser signatures and provider.
+    if (
+      provider.startsWith("mms-newapi-personal-tokyo") &&
+      /invalid character .* in string (literal|escape code)/i.test(errorMessage)
+    ) {
+      return {
+        message: {
+          ...message,
+          errorMessage: `internal_error transient relay parser retry: ${errorMessage}`,
+        },
+      };
+    }
   });
 }

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -933,7 +933,9 @@ def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path
     monkeypatch.setattr(
         mms_launchers,
         "_probe_models",
-        lambda runtime, emit_output=False: {"models": ["k3[1m]", "k3", "kimi-for-coding-highspeed"]},
+        lambda runtime, emit_output=False: {
+            "models": ["k3[1m]", "k3", "kimi-k3", "kimi-for-coding-highspeed"]
+        },
     )
 
     exports = mms_launchers.get_export_env(
@@ -949,7 +951,7 @@ def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path
             "protocols": ["anthropic_messages", "openai_chat_completions"],
             "supported_clis": ["pi"],
         },
-        model_info={"model": "k3[1m]"},
+        model_info={"model": "kimi-k3"},
     )
 
     payload = json.loads(Path(exports["MMS_PI_MODELS_JSON"]).read_text(encoding="utf-8"))
@@ -961,6 +963,10 @@ def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path
     }
     assert provider["api"] == "openai-completions"
     assert provider["baseUrl"] == "https://api.kimi.com/coding/v1"
+    assert model_by_id["kimi-k3"]["input"] == ["text", "image"]
+    assert model_by_id["kimi-k3"]["contextWindow"] == 1_048_576
+    assert model_by_id["kimi-k3"]["maxTokens"] == 1_048_576
+    assert model_by_id["kimi-k3"]["reasoning"] is True
     assert model_by_id["k3[1m]"]["input"] == ["text", "image"]
     assert model_by_id["k3[1m]"]["contextWindow"] == 1_048_576
     assert model_by_id["k3[1m]"]["maxTokens"] == 1_048_576

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -537,6 +537,46 @@ def test_pi_dual_protocol_payload_splits_models_by_preferred_protocol(monkeypatc
     assert openai_models[0]["maxTokens"] == 128_000
 
 
+def test_pi_glm_dual_protocol_prefers_openai(monkeypatch, tmp_path):
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    monkeypatch.setattr(
+        mms_launchers,
+        "_real_user_path",
+        lambda *parts: str(real_home.joinpath(*parts)),
+    )
+    monkeypatch.setattr(mms_launchers, "_pi_wrapper_path", lambda: "/tmp/pi-wrapper")
+    monkeypatch.setattr(
+        mms_launchers,
+        "_probe_models",
+        lambda runtime, emit_output=False: {"models": ["glm-5.2"]},
+    )
+
+    exports = mms_launchers.get_export_env(
+        "pi",
+        {
+            "id": "newapi-personal-tokyo",
+            "name": "NewAPI Tokyo",
+            "enabled": True,
+            "auth_mode": "api_key",
+            "api_key": "sk-relay",
+            "openai_base_url": "https://relay.example.com/v1",
+            "anthropic_base_url": "https://relay.example.com/anthropic",
+            "protocols": ["anthropic_messages", "openai_chat_completions"],
+            "supported_clis": ["pi"],
+        },
+        model_info={"model": "glm-5.2"},
+    )
+
+    payload = json.loads(Path(exports["MMS_PI_MODELS_JSON"]).read_text(encoding="utf-8"))
+    provider = payload["providers"][exports["MMS_PI_PROVIDER"]]
+    assert provider["api"] == "openai-completions"
+    assert provider["baseUrl"] == "https://relay.example.com/v1"
+    assert [item["id"] for item in provider["models"]] == ["glm-5.2"]
+
+
 def test_pi_openai_provider_compat_uses_profile_specific_flags(monkeypatch, tmp_path):
     import mms_launchers
 
@@ -855,7 +895,7 @@ def test_pi_kimi_family_uses_builtin_max_token_hint(monkeypatch, tmp_path):
     assert provider["models"][0]["maxTokens"] == 32_768
 
 
-def test_pi_kimi_k3_exports_1m_context_and_anthropic_protocol(monkeypatch, tmp_path):
+def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path):
     import mms_capability_resolver
     import mms_launchers
 
@@ -914,28 +954,27 @@ def test_pi_kimi_k3_exports_1m_context_and_anthropic_protocol(monkeypatch, tmp_p
 
     payload = json.loads(Path(exports["MMS_PI_MODELS_JSON"]).read_text(encoding="utf-8"))
     provider = payload["providers"][exports["MMS_PI_PROVIDER"]]
-    model_by_id = {item["id"]: item for item in provider["models"]}
-    assert provider["api"] == "anthropic-messages"
+    model_by_id = {
+        item["id"]: item
+        for payload_provider in payload["providers"].values()
+        for item in payload_provider["models"]
+    }
+    assert provider["api"] == "openai-completions"
+    assert provider["baseUrl"] == "https://api.kimi.com/coding/v1"
     assert model_by_id["k3[1m]"]["input"] == ["text", "image"]
     assert model_by_id["k3[1m]"]["contextWindow"] == 1_048_576
     assert model_by_id["k3[1m]"]["maxTokens"] == 1_048_576
     assert model_by_id["k3[1m]"]["reasoning"] is True
-    assert model_by_id["k3[1m]"]["thinkingLevelMap"] == {
-        "off": None,
-        "minimal": None,
-        "low": None,
-        "medium": None,
-        "high": None,
-        "xhigh": None,
-        "max": "max",
-    }
     assert model_by_id["k3"]["input"] == ["text", "image"]
     assert model_by_id["k3"]["contextWindow"] == 262_144
     assert model_by_id["k3"]["maxTokens"] == 131_072
     assert model_by_id["k3"]["reasoning"] is True
-    assert model_by_id["k3"]["thinkingLevelMap"] == model_by_id["k3[1m]"]["thinkingLevelMap"]
     assert model_by_id["kimi-for-coding-highspeed"]["contextWindow"] == 262_144
     assert model_by_id["kimi-for-coding-highspeed"]["maxTokens"] == 32_768
+    anthropic_provider = next(
+        item for item in payload["providers"].values() if item["api"] == "anthropic-messages"
+    )
+    assert [item["id"] for item in anthropic_provider["models"]] == ["kimi-for-coding-highspeed"]
 
 
 def test_pi_tokyo_k3_anthropic_export_exposes_only_max(monkeypatch, tmp_path):

--- a/tests/test_pi_retry_extension.py
+++ b/tests/test_pi_retry_extension.py
@@ -3,13 +3,34 @@ from pathlib import Path
 import subprocess
 
 
-def test_pi_retry_extension_retries_only_tokyo_parser_errors():
+def test_pi_retry_extension_normalizes_only_tokyo_parser_payloads_and_retries_parser_errors():
     extension_path = Path(__file__).resolve().parents[1] / "scripts" / "pi-retry-extension.mjs"
-    script = """
+    script = r"""
 const { default: extension } = await import(process.argv[1]);
 
-let handler;
-extension({ on(name, callback) { if (name === "message_end") handler = callback; } });
+const handlers = {};
+extension({ on(name, callback) { handlers[name] = callback; } });
+const parserPayload = {
+  messages: [
+    { role: "tool", content: "actual-control:\u001b[31mred\u001b[0m" },
+    { role: "tool", content: String.raw`legacy-escape:\x1b` },
+    { role: "tool", content: String.raw`legacy-escape-upper:\xAF` },
+    { role: "tool", content: String.raw`legacy-bell:\a` },
+    { role: "tool", content: String.raw`legacy-short:\e` },
+    { role: "tool", content: String.raw`legacy-vtab:\v` },
+    { role: "tool", content: String.raw`legacy-null:\0` },
+    { role: "tool", content: "actual-del:\u007f" },
+    { role: "tool", content: "safe\tline\n" },
+  ],
+};
+const normalizedPayload = handlers.before_provider_request(
+  { payload: parserPayload },
+  { model: { provider: "mms-newapi-personal-tokyo-responses" } },
+);
+const unchangedPayload = handlers.before_provider_request(
+  { payload: parserPayload },
+  { model: { provider: "mms-uscrsopenai" } },
+);
 const cases = [
   ["mms-newapi-personal-tokyo-responses", "invalid character '\\x1b' in string literal"],
   ["mms-newapi-personal-tokyo-anthropic", "invalid character '\\f' in string literal"],
@@ -18,13 +39,13 @@ const cases = [
   ["mms-uscrsopenai", "invalid character '\\x1b' in string literal"],
 ];
 const results = cases.map(([provider, errorMessage]) => {
-  const result = handler(
+  const result = handlers.message_end(
     { message: { role: "assistant", stopReason: "error", provider, errorMessage } },
     { model: { provider } },
   );
   return result?.message?.errorMessage ?? null;
 });
-console.log(JSON.stringify(results));
+console.log(JSON.stringify({ normalizedPayload, unchangedPayload: unchangedPayload ?? null, results }));
 """
 
     result = subprocess.run(
@@ -34,7 +55,22 @@ console.log(JSON.stringify(results));
         text=True,
     )
 
-    retry_messages = json.loads(result.stdout)
+    output = json.loads(result.stdout)
+    normalized_contents = [item["content"] for item in output["normalizedPayload"]["messages"]]
+    assert normalized_contents == [
+        r"actual-control:\u001b[31mred\u001b[0m",
+        r"legacy-escape:\u001b",
+        r"legacy-escape-upper:\u00af",
+        r"legacy-bell:\u0007",
+        r"legacy-short:\u001b",
+        r"legacy-vtab:\u000b",
+        r"legacy-null:\u0000",
+        r"actual-del:\u007f",
+        "safe\tline\n",
+    ]
+    assert output["unchangedPayload"] is None
+
+    retry_messages = output["results"]
     assert retry_messages[0].startswith("internal_error transient relay parser retry:")
     assert retry_messages[1].startswith("internal_error transient relay parser retry:")
     assert retry_messages[2].startswith("internal_error transient relay parser retry:")

--- a/tests/test_pi_retry_extension.py
+++ b/tests/test_pi_retry_extension.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+import subprocess
+
+
+def test_pi_retry_extension_retries_only_tokyo_parser_errors():
+    extension_path = Path(__file__).resolve().parents[1] / "scripts" / "pi-retry-extension.mjs"
+    script = """
+const { default: extension } = await import(process.argv[1]);
+
+let handler;
+extension({ on(name, callback) { if (name === "message_end") handler = callback; } });
+const cases = [
+  ["mms-newapi-personal-tokyo-responses", "invalid character '\\x1b' in string literal"],
+  ["mms-newapi-personal-tokyo-anthropic", "invalid character '\\f' in string literal"],
+  ["mms-newapi-personal-tokyo-responses", "invalid character '+' in string escape code"],
+  ["mms-newapi-personal-tokyo-responses", "invalid request body"],
+  ["mms-uscrsopenai", "invalid character '\\x1b' in string literal"],
+];
+const results = cases.map(([provider, errorMessage]) => {
+  const result = handler(
+    { message: { role: "assistant", stopReason: "error", provider, errorMessage } },
+    { model: { provider } },
+  );
+  return result?.message?.errorMessage ?? null;
+});
+console.log(JSON.stringify(results));
+"""
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script, str(extension_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    retry_messages = json.loads(result.stdout)
+    assert retry_messages[0].startswith("internal_error transient relay parser retry:")
+    assert retry_messages[1].startswith("internal_error transient relay parser retry:")
+    assert retry_messages[2].startswith("internal_error transient relay parser retry:")
+    assert retry_messages[3] is None
+    assert retry_messages[4] is None


### PR DESCRIPTION
## What changed

- Route GLM/K3 through OpenAI-compatible Pi transport when available.
- Normalize parser-sensitive control characters and legacy escape text in Tokyo Pi payloads before dispatch.
- Preserve Qwen Anthropic routing and retain a narrow Tokyo parser retry as fallback.

## Why

Tokyo NewAPI can reject Pi tool-history payloads with `invalid character` errors such as `\a` and `\xNN`. GLM/K3 also had a separate protocol-selection bug.

## Validation

- `node --check scripts/pi-retry-extension.mjs`
- `python3 -m pytest -q tests/test_pi_retry_extension.py` (1 passed)
- `env -u MMS_CONFIG_ROOT -u MMS_CONFIG_DIR -u MMS_PREVIEW_MODE python3 -m pytest -q tests/test_pi_launcher.py tests/test_pi_retry_extension.py` (40 passed)
- `python3 scripts/regression_fresh_user_gate.py --quick` (64 passed)
- `git diff --check`

## Follow-up

After merge, start a new Pi session and run a long tool-history Tokyo smoke. If another 400 occurs, capture a redacted provider, model, request path, Tokyo request id, and error text to distinguish a server-side conversion fault from a character payload fault.