### PR TITLE
feat(pi): add opt-in request capture for relay 400 diagnosis

### DIFF
--- a/docs/PI_REQUEST_CAPTURE.md
+++ b/docs/PI_REQUEST_CAPTURE.md
@@ -66,4 +66,4 @@ python3 scripts/pi_capture_proxy.py --port 41999 --log-dir /tmp/pi-capture
 
 ## 注意
 
-抓包目录里的原始 body 含完整对话内容，请求 header 不落盘（避免记录 API key），但 body 本身是明文，不要外传。
+抓包目录里的原始 body 含完整对话内容，请求 header 不落盘（避免记录 API key），但 body 本身是明文，不要外传。目录与全部产物默认 owner-only（目录 `0700`，文件 `0600`），启动时会强制修正已有目录的权限。

--- a/docs/PI_REQUEST_CAPTURE.md
+++ b/docs/PI_REQUEST_CAPTURE.md
@@ -1,0 +1,69 @@
+# Pi Request Capture
+
+诊断开关，用来抓 mmf 启动的 Pi 实际发出的请求字节。默认关闭；不设环境变量时，Pi 启动链路和生成的 `models.json` 完全不变。
+
+对应 issue #97。
+
+## 要解决的问题
+
+mmf 启动的 Pi 会间歇性收到上游 400：
+
+- `invalid character '\x00' in string literal`（New API）
+- `400 "Invalid JSON"`
+
+已确认的事实：
+
+- 这条报错文案可以用"body 里带一个真实未转义控制字节"逐字复现
+- 正常转义的控制字符（content / `tool_calls.arguments` / tool result）在 `/v1/messages` 与 `/v1/chat/completions` 上都是 200
+- 抓包实测 Pi 的三条协议路径，含真实控制字符的 tool result 全部被正确转义
+- 用真实 Pi 回放失败 session 的 620KB 上下文，字节干净、200 OK
+- 失败字符近似覆盖整个字节空间（含 `\t`、`{`、`§`、`Û`），属于随机字节损坏
+
+合成压测复现不出来，所以只能在真实 session 上抓现场。
+
+## 用法
+
+```bash
+# 自动分配端口并拉起 capture proxy，随本次启动生命周期结束
+MMS_PI_CAPTURE_PROXY=1 mmf
+
+# 复用一个已经在跑的 proxy
+MMS_PI_CAPTURE_PROXY=127.0.0.1:41999 mmf
+MMS_PI_CAPTURE_PROXY=:41999 mmf
+```
+
+启动后会打印抓包目录，位置在 `<session_home>/pi-capture/`：
+
+| 文件 | 内容 |
+|---|---|
+| `capture.jsonl` | 每个请求一行：字节数、发现的原始控制字节及其偏移和上下文、UTF-8 是否合法、上游状态码 |
+| `req-NNNNN.bin` | 只有可疑请求（有原始控制字节 / 非法 UTF-8 / 上游 4xx）才落盘原始 body |
+| `routes.json` | 被改写的 provider baseUrl 与原始 upstream 的对照 |
+| `proxy.out` | proxy 自身的 stdout |
+
+也可以脱离 mmf 单独跑：
+
+```bash
+python3 scripts/pi_capture_proxy.py --port 41999 --log-dir /tmp/pi-capture
+```
+
+## 判定规则
+
+出错那一刻去看 `capture.jsonl` 里对应那条记录：
+
+- `raw_control_bytes` 非空 → **Pi 侧**序列化或传输缺陷，可以直接拿 `req-NNNNN.bin` 给 Pi 提 issue
+- `raw_control_bytes` 为空但 `status` 是 4xx → Pi 发出的字节是干净的，问题在 relay 或网络路径
+- `valid_utf8` 为 false → 编码层被截断或破坏，按传输问题查
+
+## 设计约束
+
+- 默认零行为变化：未设开关时不读不写 `models.json`
+- 上游 origin 编码在路径里（`/__mms_capture__/<base64url-origin>/...`），一个 proxy 覆盖本次启动的全部 provider
+- 保留 keep-alive 与 chunked 流式转发，避免抓包本身改变要观察的传输特征
+- 请求 body 原样透传，不做任何归一化
+- proxy 跟随发起启动的进程退出，不留孤儿进程
+- 任何一步失败都 fail-open 到"不抓包、正常启动"，不会因为诊断开关阻断 Pi
+
+## 注意
+
+抓包目录里的原始 body 含完整对话内容，请求 header 不落盘（避免记录 API key），但 body 本身是明文，不要外传。

--- a/mms_pi_capture.py
+++ b/mms_pi_capture.py
@@ -1,0 +1,199 @@
+"""Opt-in request capture for Pi launches.
+
+Diagnostic surface for issue #97: mmf-launched Pi intermittently gets a 400 from
+the relay complaining about a raw control byte inside a JSON string literal.
+Synthetic replays never reproduce it, so the only way to settle whether Pi wrote
+the bad bytes is to record what leaves its socket during a real session.
+
+Default-off. With ``MMS_PI_CAPTURE_PROXY`` unset nothing here touches the launch
+path: the generated ``models.json`` and the launch environment are unchanged.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from mms_state_io import atomic_write_text
+
+CAPTURE_ENV = "MMS_PI_CAPTURE_PROXY"
+CAPTURE_DIR_ENV = "MMS_PI_CAPTURE_DIR"
+CAPTURE_ENDPOINT_ENV = "MMS_PI_CAPTURE_ENDPOINT"
+CAPTURE_PATH_PREFIX = "/__mms_capture__"
+
+_STARTUP_TIMEOUT_SECONDS = 8.0
+_STARTUP_POLL_SECONDS = 0.1
+
+
+def capture_setting(env=None):
+    """Return the raw opt-in value, or "" when capture is disabled."""
+    source = env if isinstance(env, dict) else os.environ
+    value = str(source.get(CAPTURE_ENV) or "").strip()
+    if value.lower() in ("", "0", "false", "off", "no"):
+        return ""
+    return value
+
+
+def encode_origin(origin):
+    """Encode an upstream origin so it can ride inside the proxied URL path."""
+    raw = str(origin or "").strip().rstrip("/")
+    return base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_origin(token):
+    """Inverse of :func:`encode_origin`."""
+    text = str(token or "").strip()
+    padding = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode((text + padding).encode("ascii")).decode("utf-8")
+
+
+def capture_url(endpoint, base_url):
+    """Rewrite one provider baseUrl so it resolves to the capture proxy."""
+    parsed = urlsplit(str(base_url or "").strip())
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    suffix = parsed.path.rstrip("/")
+    return f"http://{endpoint}{CAPTURE_PATH_PREFIX}/{encode_origin(origin)}{suffix}"
+
+
+def rewrite_models_payload(payload, endpoint):
+    """Point every provider in a models.json payload at the capture proxy.
+
+    Returns ``(payload, routes)``. Providers whose baseUrl cannot be parsed are
+    left alone so an unexpected shape degrades to "no capture" instead of a
+    broken launch.
+    """
+    routes = {}
+    providers = payload.get("providers") if isinstance(payload, dict) else None
+    if not isinstance(providers, dict):
+        return payload, routes
+    for name, provider in providers.items():
+        if not isinstance(provider, dict):
+            continue
+        original = str(provider.get("baseUrl") or "").strip()
+        rewritten = capture_url(endpoint, original)
+        if not rewritten:
+            continue
+        provider["baseUrl"] = rewritten
+        routes[name] = {"original": original, "captured": rewritten}
+    return payload, routes
+
+
+def _proxy_script_path():
+    path = Path(__file__).resolve().parent / "scripts" / "pi_capture_proxy.py"
+    return str(path) if path.is_file() else ""
+
+
+def _normalize_endpoint(value):
+    """Accept "1"/"auto" (spawn), ":PORT", "PORT", or "HOST:PORT"."""
+    text = str(value or "").strip()
+    if text.lower() in ("1", "true", "on", "yes", "auto"):
+        return ""
+    if text.startswith(":"):
+        return "127.0.0.1" + text
+    if text.isdigit():
+        return f"127.0.0.1:{text}"
+    return text
+
+
+def _free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_until_listening(port, timeout=_STARTUP_TIMEOUT_SECONDS):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(_STARTUP_POLL_SECONDS)
+    return False
+
+
+def _spawn_proxy(capture_dir, parent_pid):
+    script = _proxy_script_path()
+    if not script:
+        return "", "capture proxy script is missing"
+    port = _free_port()
+    os.makedirs(capture_dir, exist_ok=True)
+    stdout_path = os.path.join(capture_dir, "proxy.out")
+    command = [
+        sys.executable,
+        script,
+        "--port",
+        str(port),
+        "--log-dir",
+        capture_dir,
+        "--parent-pid",
+        str(parent_pid),
+    ]
+    try:
+        with open(stdout_path, "ab", buffering=0) as stream:
+            subprocess.Popen(
+                command,
+                stdout=stream,
+                stderr=stream,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+    except OSError as exc:
+        return "", f"capture proxy failed to start: {exc}"
+    if not _wait_until_listening(port):
+        return "", f"capture proxy did not start listening on 127.0.0.1:{port}"
+    return f"127.0.0.1:{port}", ""
+
+
+def apply_capture_proxy(models_path, env, session_home, *, setting=None):
+    """Route the launch's Pi providers through a local capture proxy.
+
+    No-op unless the opt-in env var is set. On any failure the models config is
+    left untouched so the normal launch path keeps working.
+    """
+    value = setting if setting is not None else capture_setting(env)
+    if not value:
+        return ""
+
+    capture_dir = os.path.join(str(session_home or "."), "pi-capture")
+    endpoint = _normalize_endpoint(value)
+    if not endpoint:
+        endpoint, error = _spawn_proxy(capture_dir, os.getpid())
+        if error:
+            print(f"[mms] {error}; Pi launch continues without capture", file=sys.stderr)
+            return ""
+    else:
+        os.makedirs(capture_dir, exist_ok=True)
+
+    try:
+        payload = json.loads(Path(models_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"[mms] capture proxy could not read {models_path}: {exc}", file=sys.stderr)
+        return ""
+
+    payload, routes = rewrite_models_payload(payload, endpoint)
+    if not routes:
+        print("[mms] capture proxy found no rewritable provider baseUrl", file=sys.stderr)
+        return ""
+
+    atomic_write_text(models_path, json.dumps(payload, indent=2) + "\n", mode=0o600)
+    atomic_write_text(
+        os.path.join(capture_dir, "routes.json"),
+        json.dumps(routes, indent=2, ensure_ascii=False) + "\n",
+        mode=0o600,
+    )
+    if isinstance(env, dict):
+        env[CAPTURE_DIR_ENV] = capture_dir
+        env[CAPTURE_ENDPOINT_ENV] = endpoint
+    print(f"[mms] Pi request capture active: {capture_dir}", file=sys.stderr)
+    return capture_dir

--- a/mms_pi_capture.py
+++ b/mms_pi_capture.py
@@ -126,7 +126,8 @@ def _spawn_proxy(capture_dir, parent_pid):
     if not script:
         return "", "capture proxy script is missing"
     port = _free_port()
-    os.makedirs(capture_dir, exist_ok=True)
+    os.makedirs(capture_dir, mode=0o700, exist_ok=True)
+    os.chmod(capture_dir, 0o700)
     stdout_path = os.path.join(capture_dir, "proxy.out")
     command = [
         sys.executable,
@@ -139,7 +140,8 @@ def _spawn_proxy(capture_dir, parent_pid):
         str(parent_pid),
     ]
     try:
-        with open(stdout_path, "ab", buffering=0) as stream:
+        fd = os.open(stdout_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "ab", buffering=0) as stream:
             subprocess.Popen(
                 command,
                 stdout=stream,
@@ -173,7 +175,8 @@ def apply_capture_proxy(models_path, env, session_home, *, setting=None):
             print(f"[mms] {error}; Pi launch continues without capture", file=sys.stderr)
             return ""
     else:
-        os.makedirs(capture_dir, exist_ok=True)
+        os.makedirs(capture_dir, mode=0o700, exist_ok=True)
+        os.chmod(capture_dir, 0o700)
 
     try:
         payload = json.loads(Path(models_path).read_text(encoding="utf-8"))

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -12,6 +12,7 @@ from urllib.parse import urlsplit
 from mms_capability_resolver import resolve_model_capabilities
 from mms_core import _model_supports_vision, _probe_models
 from mms_opencode_config import opencode_config_slug as _opencode_config_slug
+from mms_pi_capture import apply_capture_proxy as apply_pi_capture_proxy
 from mms_provider_profiles import resolve_provider_profile
 from mms_provider_profiles import profile_thinking_capabilities
 from mms_state_io import atomic_write_text
@@ -1341,6 +1342,8 @@ def _pi_gateway_env(runtime, model_info=None):
     session_dir = _pi_session_dir()
     models_path, provider_ref = _write_pi_models_config(agent_dir, runtime, model)
     settings_path = _write_pi_settings_config(agent_dir)
+    # Opt-in only (MMS_PI_CAPTURE_PROXY); a no-op otherwise. See issue #97.
+    apply_pi_capture_proxy(models_path, env, session_home)
     os.makedirs(session_dir, exist_ok=True)
     _seed_pi_trust_store(agent_dir, os.getcwd())
     env["PI_CODING_AGENT_DIR"] = agent_dir

--- a/scripts/pi_capture_proxy.py
+++ b/scripts/pi_capture_proxy.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Recording reverse proxy for Pi provider traffic (issue #97).
+
+Sits between Pi and the relay, records the exact bytes Pi puts on the wire, and
+forwards them unmodified. The upstream origin travels inside the request path as
+``/__mms_capture__/<base64url-origin>/<rest>`` so one proxy can serve every
+provider in a launch.
+
+Keep-alive and chunked response streaming are preserved: the point is to observe
+the transport, not to change it.
+
+Raw request bodies are written only for suspicious or failing requests, so a long
+session does not fill the disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import http.client
+import json
+import os
+import socketserver
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler
+
+CAPTURE_PATH_PREFIX = "/__mms_capture__"
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+_COUNTER_LOCK = threading.Lock()
+_COUNTER = {"n": 0}
+
+
+def decode_origin(token):
+    padding = "=" * (-len(token) % 4)
+    return base64.urlsafe_b64decode((token + padding).encode("ascii")).decode("utf-8")
+
+
+def scan_raw_control_bytes(body):
+    """Return every raw control byte with its offset.
+
+    ``JSON.stringify`` escapes the whole C0 range, so a compact JSON body from Pi
+    must contain none of these. Any hit is the smoking gun.
+    """
+    hits = []
+    for offset, value in enumerate(body):
+        if value < 0x20 or value == 0x7F:
+            hits.append((offset, value))
+            if len(hits) >= 20:
+                break
+    return hits
+
+
+def describe_hits(body, hits):
+    described = []
+    for offset, value in hits:
+        window = body[max(0, offset - 70):offset + 30]
+        described.append({
+            "offset": offset,
+            "byte": f"0x{value:02x}",
+            "context": repr(window),
+        })
+    return described
+
+
+class CaptureHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    log_dir = "."
+
+    def log_message(self, *args):  # noqa: D102 - stderr noise is not useful here
+        return
+
+    def _record(self, entry, body=None):
+        line = json.dumps(entry, ensure_ascii=False)
+        with _COUNTER_LOCK:
+            with open(os.path.join(self.log_dir, "capture.jsonl"), "a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        if body is not None:
+            path = os.path.join(self.log_dir, f"req-{entry['index']:05d}.bin")
+            with open(path, "wb") as handle:
+                handle.write(body)
+
+    def _read_request_body(self):
+        if str(self.headers.get("Transfer-Encoding") or "").lower() == "chunked":
+            chunks = []
+            while True:
+                size_line = self.rfile.readline().strip()
+                size = int(size_line.split(b";")[0] or b"0", 16)
+                if size == 0:
+                    self.rfile.readline()
+                    break
+                chunks.append(self.rfile.read(size))
+                self.rfile.readline()
+            return b"".join(chunks)
+        length = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(length) if length else b""
+
+    def _split_target(self):
+        if not self.path.startswith(CAPTURE_PATH_PREFIX + "/"):
+            return "", ""
+        remainder = self.path[len(CAPTURE_PATH_PREFIX) + 1:]
+        token, _, rest = remainder.partition("/")
+        try:
+            origin = decode_origin(token)
+        except Exception:
+            return "", ""
+        return origin, "/" + rest
+
+    def _fail(self, status, message):
+        payload = json.dumps({"error": {"message": message}}).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _handle(self):
+        origin, upstream_path = self._split_target()
+        body = self._read_request_body()
+        if not origin:
+            self._fail(400, f"capture proxy could not decode an upstream origin from {self.path}")
+            return
+
+        with _COUNTER_LOCK:
+            _COUNTER["n"] += 1
+            index = _COUNTER["n"]
+
+        hits = scan_raw_control_bytes(body)
+        try:
+            body.decode("utf-8")
+            valid_utf8 = True
+        except UnicodeDecodeError:
+            valid_utf8 = False
+
+        entry = {
+            "index": index,
+            "time": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "method": self.command,
+            "origin": origin,
+            "path": upstream_path,
+            "request_bytes": len(body),
+            "raw_control_bytes": describe_hits(body, hits),
+            "valid_utf8": valid_utf8,
+        }
+
+        scheme, _, netloc = origin.partition("://")
+        connection_class = (http.client.HTTPSConnection if scheme == "https"
+                            else http.client.HTTPConnection)
+        headers = {}
+        for key, value in self.headers.items():
+            if key.lower() in HOP_BY_HOP or key.lower() in ("host", "content-length"):
+                continue
+            headers[key] = value
+
+        try:
+            connection = connection_class(netloc, timeout=600)
+            connection.request(self.command, upstream_path, body=body, headers=headers)
+            response = connection.getresponse()
+        except Exception as exc:
+            entry["upstream_error"] = f"{type(exc).__name__}: {exc}"
+            self._record(entry, body if (hits or not valid_utf8) else None)
+            self._fail(502, entry["upstream_error"])
+            return
+
+        entry["status"] = response.status
+        suspicious = bool(hits) or not valid_utf8 or response.status >= 400
+        # Record before relaying the response: a hang mid-stream must still leave
+        # the request evidence on disk.
+        self._record(entry, body if suspicious else None)
+
+        self.send_response(response.status)
+        for key, value in response.getheaders():
+            if key.lower() in HOP_BY_HOP or key.lower() == "content-length":
+                continue
+            self.send_header(key, value)
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+
+        collected = bytearray()
+        relay_error = ""
+        try:
+            while True:
+                # read1, not read: SSE must reach Pi as it arrives instead of
+                # being buffered until the block size is filled.
+                chunk = response.read1(65536)
+                if not chunk:
+                    break
+                if response.status >= 400 and len(collected) < 65536:
+                    collected.extend(chunk)
+                self.wfile.write(f"{len(chunk):x}\r\n".encode("ascii") + chunk + b"\r\n")
+                self.wfile.flush()
+            self.wfile.write(b"0\r\n\r\n")
+            self.wfile.flush()
+        except Exception as exc:
+            relay_error = f"{type(exc).__name__}: {exc}"
+        finally:
+            connection.close()
+
+        if collected or relay_error:
+            self._record({
+                "index": index,
+                "time": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "phase": "response",
+                "status": response.status,
+                "relay_error": relay_error,
+                "response_body": collected.decode("utf-8", "replace")[:2000],
+            })
+
+    do_POST = _handle
+    do_GET = _handle
+    do_PUT = _handle
+    do_DELETE = _handle
+    do_PATCH = _handle
+
+
+class CaptureServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def watch_parent(parent_pid, server):
+    """Exit with the launch that asked for the capture, so nothing is orphaned."""
+    while True:
+        time.sleep(5)
+        try:
+            os.kill(parent_pid, 0)
+        except OSError:
+            server.shutdown()
+            return
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--log-dir", required=True)
+    parser.add_argument("--parent-pid", type=int, default=0)
+    args = parser.parse_args(argv)
+
+    os.makedirs(args.log_dir, exist_ok=True)
+    CaptureHandler.log_dir = args.log_dir
+    server = CaptureServer(("127.0.0.1", args.port), CaptureHandler)
+    if args.parent_pid:
+        threading.Thread(target=watch_parent, args=(args.parent_pid, server), daemon=True).start()
+    print(f"pi capture proxy listening on 127.0.0.1:{args.port} -> {args.log_dir}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pi_capture_proxy.py
+++ b/scripts/pi_capture_proxy.py
@@ -83,11 +83,18 @@ class CaptureHandler(BaseHTTPRequestHandler):
     def _record(self, entry, body=None):
         line = json.dumps(entry, ensure_ascii=False)
         with _COUNTER_LOCK:
-            with open(os.path.join(self.log_dir, "capture.jsonl"), "a", encoding="utf-8") as handle:
+            # Plaintext request metadata; keep it owner-readable only.
+            fd = os.open(
+                os.path.join(self.log_dir, "capture.jsonl"),
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+            with os.fdopen(fd, "a", encoding="utf-8") as handle:
                 handle.write(line + "\n")
         if body is not None:
             path = os.path.join(self.log_dir, f"req-{entry['index']:05d}.bin")
-            with open(path, "wb") as handle:
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "wb") as handle:
                 handle.write(body)
 
     def _read_request_body(self):
@@ -246,7 +253,8 @@ def main(argv=None):
     parser.add_argument("--parent-pid", type=int, default=0)
     args = parser.parse_args(argv)
 
-    os.makedirs(args.log_dir, exist_ok=True)
+    os.makedirs(args.log_dir, mode=0o700, exist_ok=True)
+    os.chmod(args.log_dir, 0o700)
     CaptureHandler.log_dir = args.log_dir
     server = CaptureServer(("127.0.0.1", args.port), CaptureHandler)
     if args.parent_pid:

--- a/tests/test_pi_capture_proxy.py
+++ b/tests/test_pi_capture_proxy.py
@@ -228,3 +228,71 @@ def test_proxy_keeps_clean_requests_out_of_the_raw_body_dump(tmp_path):
         proxy.terminate()
         proxy.wait(timeout=10)
         upstream.shutdown()
+
+
+def test_capture_artifacts_are_owner_readable_only(tmp_path):
+    """Privacy: plaintext request bodies must never be world-readable.
+
+    The capture directory carries full plaintext conversations (req-NNNNN.bin,
+    capture.jsonl), so the directory is 0700 and every artifact inside is 0600.
+    """
+    upstream = HTTPServer(("127.0.0.1", 0), _EchoUpstream)
+    _EchoUpstream.received = []
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    upstream_origin = f"http://127.0.0.1:{upstream.server_address[1]}"
+
+    capture_dir = tmp_path / "pi-capture"
+    port = _free_port()
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pi_capture_proxy.py"
+    proxy = subprocess.Popen(
+        [sys.executable, str(script), "--port", str(port), "--log-dir", str(capture_dir)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                socket.create_connection(("127.0.0.1", port), timeout=0.5).close()
+                break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            pytest.fail("capture proxy never started listening")
+
+        token = mms_pi_capture.encode_origin(upstream_origin)
+        url = f"http://127.0.0.1:{port}{mms_pi_capture.CAPTURE_PATH_PREFIX}/{token}/v1/messages"
+        body = b'{"model":"glm-5.2","messages":[{"role":"user","content":"secret\x00"}]}'
+
+        import urllib.request
+
+        request = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            assert response.status == 200
+
+        assert (capture_dir.stat().st_mode & 0o777) == 0o700
+        jsonl = capture_dir / "capture.jsonl"
+        assert jsonl.exists()
+        assert (jsonl.stat().st_mode & 0o777) == 0o600
+        entry = json.loads(jsonl.read_text(encoding="utf-8").splitlines()[0])
+        raw_body = capture_dir / f"req-{entry['index']:05d}.bin"
+        assert raw_body.exists()
+        assert (raw_body.stat().st_mode & 0o777) == 0o600
+    finally:
+        proxy.terminate()
+        proxy.wait(timeout=10)
+        upstream.shutdown()
+
+
+def test_capture_dir_and_routes_are_owner_only(tmp_path):
+    models_path = _write_models(tmp_path)
+    env = {}
+
+    capture_dir = mms_pi_capture.apply_capture_proxy(
+        models_path, env, tmp_path, setting="127.0.0.1:9000"
+    )
+
+    assert (Path(capture_dir).stat().st_mode & 0o777) == 0o700
+    routes = Path(capture_dir) / "routes.json"
+    assert routes.exists()
+    assert (routes.stat().st_mode & 0o777) == 0o600

--- a/tests/test_pi_capture_proxy.py
+++ b/tests/test_pi_capture_proxy.py
@@ -1,0 +1,230 @@
+"""Coverage for the opt-in Pi request capture (issue #97).
+
+The point of the capture surface is to be invisible unless explicitly asked for,
+and to reliably flag raw control bytes when it is.
+"""
+
+import json
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mms_pi_capture
+
+
+MODELS_PAYLOAD = {
+    "providers": {
+        "mms-relay-anthropic": {
+            "name": "relay",
+            "baseUrl": "http://relay.example.com",
+            "api": "anthropic-messages",
+            "apiKey": "secret",
+            "models": [{"id": "glm-5.2"}],
+        },
+        "mms-relay-responses": {
+            "name": "relay responses",
+            "baseUrl": "http://relay.example.com:3000/openai/v1",
+            "api": "openai-responses",
+            "apiKey": "secret",
+            "models": [{"id": "gpt-5.6-terra"}],
+        },
+    }
+}
+
+
+def _write_models(tmp_path):
+    models_path = tmp_path / "models.json"
+    models_path.write_text(json.dumps(MODELS_PAYLOAD, indent=2) + "\n", encoding="utf-8")
+    return models_path
+
+
+def test_capture_disabled_leaves_launch_untouched(tmp_path):
+    models_path = _write_models(tmp_path)
+    before = models_path.read_text(encoding="utf-8")
+    env = {}
+
+    assert mms_pi_capture.apply_capture_proxy(models_path, env, tmp_path) == ""
+    assert models_path.read_text(encoding="utf-8") == before
+    assert env == {}
+
+
+@pytest.mark.parametrize("disabled", ["", "0", "false", "off", "no"])
+def test_falsy_settings_stay_disabled(disabled):
+    assert mms_pi_capture.capture_setting({mms_pi_capture.CAPTURE_ENV: disabled}) == ""
+
+
+def test_origin_token_roundtrip():
+    for origin in ("http://relay.example.com", "https://relay.example.com:3000"):
+        token = mms_pi_capture.encode_origin(origin)
+        assert "/" not in token
+        assert mms_pi_capture.decode_origin(token) == origin
+
+
+def test_capture_url_keeps_the_upstream_path_suffix():
+    url = mms_pi_capture.capture_url("127.0.0.1:9000", "http://relay.example.com:3000/openai/v1")
+    prefix = f"http://127.0.0.1:9000{mms_pi_capture.CAPTURE_PATH_PREFIX}/"
+    assert url.startswith(prefix)
+    token = url[len(prefix):].split("/", 1)[0]
+    assert mms_pi_capture.decode_origin(token) == "http://relay.example.com:3000"
+    assert url.endswith("/openai/v1")
+
+
+def test_explicit_endpoint_rewrites_every_provider(tmp_path):
+    models_path = _write_models(tmp_path)
+    env = {}
+
+    capture_dir = mms_pi_capture.apply_capture_proxy(
+        models_path, env, tmp_path, setting="127.0.0.1:9000"
+    )
+
+    assert capture_dir == str(tmp_path / "pi-capture")
+    assert env[mms_pi_capture.CAPTURE_ENDPOINT_ENV] == "127.0.0.1:9000"
+    payload = json.loads(models_path.read_text(encoding="utf-8"))
+    for provider in payload["providers"].values():
+        assert provider["baseUrl"].startswith(
+            f"http://127.0.0.1:9000{mms_pi_capture.CAPTURE_PATH_PREFIX}/"
+        )
+    # Everything except the baseUrl must survive the rewrite untouched.
+    assert payload["providers"]["mms-relay-anthropic"]["apiKey"] == "secret"
+    assert payload["providers"]["mms-relay-responses"]["api"] == "openai-responses"
+
+    routes = json.loads((Path(capture_dir) / "routes.json").read_text(encoding="utf-8"))
+    assert routes["mms-relay-anthropic"]["original"] == "http://relay.example.com"
+
+
+def test_unparsable_base_url_is_left_alone():
+    payload = {"providers": {"broken": {"baseUrl": "not-a-url"}}}
+    _, routes = mms_pi_capture.rewrite_models_payload(payload, "127.0.0.1:9000")
+    assert routes == {}
+    assert payload["providers"]["broken"]["baseUrl"] == "not-a-url"
+
+
+class _EchoUpstream(BaseHTTPRequestHandler):
+    received = []
+
+    def log_message(self, *args):
+        return
+
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        type(self).received.append((self.path, body))
+        payload = b'{"ok":true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def test_proxy_flags_raw_control_bytes_and_forwards_bytes_verbatim(tmp_path):
+    upstream = HTTPServer(("127.0.0.1", 0), _EchoUpstream)
+    _EchoUpstream.received = []
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    upstream_origin = f"http://127.0.0.1:{upstream.server_address[1]}"
+
+    port = _free_port()
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pi_capture_proxy.py"
+    proxy = subprocess.Popen(
+        [sys.executable, str(script), "--port", str(port), "--log-dir", str(tmp_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                socket.create_connection(("127.0.0.1", port), timeout=0.5).close()
+                break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            pytest.fail("capture proxy never started listening")
+
+        token = mms_pi_capture.encode_origin(upstream_origin)
+        url = f"http://127.0.0.1:{port}{mms_pi_capture.CAPTURE_PATH_PREFIX}/{token}/v1/messages"
+        # A body carrying the exact defect we are hunting: an unescaped control byte.
+        body = b'{"model":"glm-5.2","messages":[{"role":"user","content":"a\x00b"}]}'
+
+        import urllib.request
+
+        request = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            assert response.status == 200
+            assert json.loads(response.read())["ok"] is True
+
+        assert _EchoUpstream.received == [("/v1/messages", body)]
+
+        entries = [
+            json.loads(line)
+            for line in (tmp_path / "capture.jsonl").read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["origin"] == upstream_origin
+        assert entry["path"] == "/v1/messages"
+        assert entry["status"] == 200
+        assert [hit["byte"] for hit in entry["raw_control_bytes"]] == ["0x00"]
+        # Suspicious requests keep their raw body for byte-level inspection.
+        assert (tmp_path / f"req-{entry['index']:05d}.bin").read_bytes() == body
+    finally:
+        proxy.terminate()
+        proxy.wait(timeout=10)
+        upstream.shutdown()
+
+
+def test_proxy_keeps_clean_requests_out_of_the_raw_body_dump(tmp_path):
+    upstream = HTTPServer(("127.0.0.1", 0), _EchoUpstream)
+    _EchoUpstream.received = []
+    threading.Thread(target=upstream.serve_forever, daemon=True).start()
+    upstream_origin = f"http://127.0.0.1:{upstream.server_address[1]}"
+
+    port = _free_port()
+    script = Path(__file__).resolve().parents[1] / "scripts" / "pi_capture_proxy.py"
+    proxy = subprocess.Popen(
+        [sys.executable, str(script), "--port", str(port), "--log-dir", str(tmp_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                socket.create_connection(("127.0.0.1", port), timeout=0.5).close()
+                break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            pytest.fail("capture proxy never started listening")
+
+        token = mms_pi_capture.encode_origin(upstream_origin)
+        url = f"http://127.0.0.1:{port}{mms_pi_capture.CAPTURE_PATH_PREFIX}/{token}/v1/messages"
+        body = json.dumps({"content": "clean payload"}).encode("utf-8")
+
+        import urllib.request
+
+        request = urllib.request.Request(url, data=body, headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(request, timeout=30) as response:
+            assert response.status == 200
+
+        entry = json.loads((tmp_path / "capture.jsonl").read_text(encoding="utf-8").splitlines()[0])
+        assert entry["raw_control_bytes"] == []
+        assert not (tmp_path / f"req-{entry['index']:05d}.bin").exists()
+    finally:
+        proxy.terminate()
+        proxy.wait(timeout=10)
+        upstream.shutdown()


### PR DESCRIPTION
Closes #97

## 为什么

mmf 启动的 pi 会间歇性收到上游 400（`invalid character '\xNN' in string literal` / `400 "Invalid JSON"`）。这一轮先做了诊断，结论是**现有的修复方向是错的**：

- 该报错文案可以用"body 里带一个真实未转义控制字节"逐字复现（含重复的"无效的请求，无效的请求"）
- 正常转义的控制字符在 content / `tool_calls.arguments` / tool result 上，`/v1/messages` 与 `/v1/chat/completions` 都返回 200
- 抓包实测 pi 的 `openai-completions` / `openai-responses` / `anthropic-messages` 三条路径，含真实 `\x00\x16\x1b` 的 tool result 全部被正确转义
- 用真实 pi 0.83.0 回放失败 session 的 620KB 上下文，字节干净、200 OK
- 失败字符近似覆盖整个字节空间（含 `\t`、`{`、`§`、`Û`），是随机字节损坏，不是"内容里有控制字符"

也就是说 `scripts/pi-retry-extension.mjs` 里的 `before_provider_request` 归一化不可能修好这个问题（`JSON.stringify` 本来就会转义），而且它会改写用户内容里字面的 `\xNN` / `\a` / `\e` / `\v` / `\0`。回退它另开一轮处理，不叠进本 PR。

合成压测复现不出来（大 body、走/不走本地代理、undici 连接池并发、中断流后复用连接，全部 0 失败），所以只能在真实 session 上抓现场。

## 改了什么

`MMS_PI_CAPTURE_PROXY` 开关，把本次启动的 provider baseUrl 指向本地 recording proxy，原样透传字节并标出原始控制字节。

判定规则：`raw_control_bytes` 非空 → pi 侧缺陷；为空但 4xx → relay 或网络路径。

## 边界

- **默认零行为变化**：未设开关时不读不写 `models.json`，不加任何 env
- 未动 provider / account 决策优先级、runtime 与 `auth_mode` 语义、bridge 路由、config schema、HOME/XDG 隔离
- `mms_pi_support.py` 只加 2 行（import + 调用）
- 保留 keep-alive 与 chunked 流式转发，避免抓包本身改变要观察的传输特征
- 任何一步失败都 fail-open 回正常启动
- proxy 跟随发起启动的进程退出，不留孤儿

## 验证

- `py_compile` 覆盖所有改动的 Python 文件
- `tests/test_pi_capture_proxy.py` 12 passed
- `tests/test_pi_launcher.py` + `tests/test_pi_retry_extension.py` 40 passed
- fresh-user gate `--quick` PASS；完整 gate 390 passed / 1 failed
- 完整 gate 的那个 failed 是 `test_overlay_web_access_session_entries_merges_session_and_web_access_skill`，在干净 `dev` 上同样失败，**既有红灯，与本改动无关**
- 端到端：真实 pi 0.83.0 → 自动拉起的 proxy → 真实 Tokyo relay，抓到 2 个请求、流式正常、0 个原始控制字节、父进程退出后无孤儿

过程中修掉两个自身缺陷：转发用 `read(65536)` 会阻塞 SSE（改 `read1`）；抓包记录原本在转发结束后才落盘，挂住就没有证据（改成收到响应头即落盘）。

## 残余风险

抓包目录里的原始 body 是明文完整对话（header 不落盘，避免记录 API key）。仅诊断期开启。

https://claude.ai/code/session_01VA2vRxuCpZsLmXR8sLeUgG