### PR TITLE
fix(pi): stop rewriting request payloads and widen malformed-body retry

### DIFF
--- a/scripts/pi-retry-extension.mjs
+++ b/scripts/pi-retry-extension.mjs
@@ -1,32 +1,12 @@
-const TOKYO_PROVIDER_PREFIX = "mms-newapi-personal-tokyo";
+const MMS_PROVIDER_PREFIX = "mms-";
 
-function normalizeTokyoParserString(value) {
-  return value
-    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, (character) => {
-      return `\\u${character.codePointAt(0).toString(16).padStart(4, "0")}`;
-    })
-    .replace(/\\x([0-9a-f]{2})/gi, (_match, hex) => `\\u00${hex.toLowerCase()}`)
-    .replace(/\\([aev])/gi, (_match, escape) => {
-      const code = { a: "0007", e: "001b", v: "000b" }[escape.toLowerCase()];
-      return `\\u${code}`;
-    })
-    .replace(/\\0(?![0-9])/g, "\\u0000");
-}
-
-function normalizeTokyoParserPayload(value) {
-  if (typeof value === "string") {
-    return normalizeTokyoParserString(value);
-  }
-  if (Array.isArray(value)) {
-    return value.map(normalizeTokyoParserPayload);
-  }
-  if (!value || Object.getPrototypeOf(value) !== Object.prototype) {
-    return value;
-  }
-  return Object.fromEntries(
-    Object.entries(value).map(([key, child]) => [key, normalizeTokyoParserPayload(child)]),
-  );
-}
+// A relay rejecting the request body outright. Observed on more than one MMS
+// route, with the offending byte spread across the whole byte space, so this is
+// transport-level corruption of an otherwise valid request rather than anything
+// the payload can be normalized out of. Keep the signatures narrow: they must
+// only match "the body did not parse", never a genuine validation error.
+const MALFORMED_BODY_SIGNATURE =
+  /invalid character .* in string (literal|escape code)|invalid json/i;
 
 // Responses-API relays that front a pool of upstream accounts encrypt each
 // reasoning item for the account that produced it. When the pool rotates or
@@ -87,14 +67,6 @@ export default function (pi) {
     return messages ? { messages } : undefined;
   });
 
-  pi.on("before_provider_request", (event, ctx) => {
-    const provider = String(ctx.model?.provider || "").trim();
-    if (!provider.startsWith(TOKYO_PROVIDER_PREFIX)) {
-      return;
-    }
-    return normalizeTokyoParserPayload(event.payload);
-  });
-
   pi.on("message_end", (event, ctx) => {
     const message = event.message;
     if (!message || message.role !== "assistant" || message.stopReason !== "error") {
@@ -145,12 +117,7 @@ export default function (pi) {
       };
     }
 
-    // NewAPI intermittently rejects an already-valid Pi request while decoding
-    // tool history. Limit retries to its known parser signatures and provider.
-    if (
-      provider.startsWith(TOKYO_PROVIDER_PREFIX) &&
-      /invalid character .* in string (literal|escape code)/i.test(errorMessage)
-    ) {
+    if (provider.startsWith(MMS_PROVIDER_PREFIX) && MALFORMED_BODY_SIGNATURE.test(errorMessage)) {
       return {
         message: {
           ...message,

--- a/tests/test_pi_retry_extension.py
+++ b/tests/test_pi_retry_extension.py
@@ -3,40 +3,50 @@ from pathlib import Path
 import subprocess
 
 
-def test_pi_retry_extension_normalizes_only_tokyo_parser_payloads_and_retries_parser_errors():
+def _run_extension(script):
     extension_path = Path(__file__).resolve().parents[1] / "scripts" / "pi-retry-extension.mjs"
-    script = r"""
-const { default: extension } = await import(process.argv[1]);
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script, str(extension_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
 
+
+def test_pi_retry_extension_does_not_rewrite_outgoing_payloads():
+    """Control characters are escaped by JSON.stringify before they reach the wire.
+
+    Normalizing them in the payload cannot change what is sent, and rewriting
+    literal escape text corrupts user content, so no request hook may exist.
+    """
+    output = _run_extension(
+        """
+const { default: extension } = await import(process.argv[1]);
+const registered = [];
+extension({ on(name) { registered.push(name); } });
+console.log(JSON.stringify({ registered }));
+"""
+    )
+    assert output["registered"] == ["context", "message_end"]
+
+
+def test_pi_retry_extension_retries_malformed_body_rejections_across_mms_routes():
+    script = """
+const { default: extension } = await import(process.argv[1]);
 const handlers = {};
 extension({ on(name, callback) { handlers[name] = callback; } });
-const parserPayload = {
-  messages: [
-    { role: "tool", content: "actual-control:\u001b[31mred\u001b[0m" },
-    { role: "tool", content: String.raw`legacy-escape:\x1b` },
-    { role: "tool", content: String.raw`legacy-escape-upper:\xAF` },
-    { role: "tool", content: String.raw`legacy-bell:\a` },
-    { role: "tool", content: String.raw`legacy-short:\e` },
-    { role: "tool", content: String.raw`legacy-vtab:\v` },
-    { role: "tool", content: String.raw`legacy-null:\0` },
-    { role: "tool", content: "actual-del:\u007f" },
-    { role: "tool", content: "safe\tline\n" },
-  ],
-};
-const normalizedPayload = handlers.before_provider_request(
-  { payload: parserPayload },
-  { model: { provider: "mms-newapi-personal-tokyo-responses" } },
-);
-const unchangedPayload = handlers.before_provider_request(
-  { payload: parserPayload },
-  { model: { provider: "mms-uscrsopenai" } },
-);
 const cases = [
-  ["mms-newapi-personal-tokyo-responses", "invalid character '\\x1b' in string literal"],
+  ["mms-newapi-personal-tokyo-responses", "invalid character '\\u001b' in string literal"],
   ["mms-newapi-personal-tokyo-anthropic", "invalid character '\\f' in string literal"],
   ["mms-newapi-personal-tokyo-responses", "invalid character '+' in string escape code"],
+  ["mms-uscrsopenai", "invalid character '\\u001b' in string literal"],
+  ["mms-uscrsopenai", "400 \\"Invalid JSON\\""],
+  ["mms-us-cpa-local-codex", "token has been invalidated"],
+  ["mms-us-cpa-local-antigravity", "model_capacity_exhausted"],
   ["mms-newapi-personal-tokyo-responses", "invalid request body"],
-  ["mms-uscrsopenai", "invalid character '\\x1b' in string literal"],
+  ["mms-newapi-personal-tokyo-responses", "model_not_found"],
+  ["openai", "invalid character '\\u001b' in string literal"],
 ];
 const results = cases.map(([provider, errorMessage]) => {
   const result = handlers.message_end(
@@ -45,37 +55,47 @@ const results = cases.map(([provider, errorMessage]) => {
   );
   return result?.message?.errorMessage ?? null;
 });
-console.log(JSON.stringify({ normalizedPayload, unchangedPayload: unchangedPayload ?? null, results }));
+console.log(JSON.stringify({ results }));
 """
+    results = _run_extension(script)["results"]
 
-    result = subprocess.run(
-        ["node", "--input-type=module", "--eval", script, str(extension_path)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    parser_retry = "internal_error transient relay parser retry:"
+    auth_retry = "internal_error transient auth retry:"
 
-    output = json.loads(result.stdout)
-    normalized_contents = [item["content"] for item in output["normalizedPayload"]["messages"]]
-    assert normalized_contents == [
-        r"actual-control:\u001b[31mred\u001b[0m",
-        r"legacy-escape:\u001b",
-        r"legacy-escape-upper:\u00af",
-        r"legacy-bell:\u0007",
-        r"legacy-short:\u001b",
-        r"legacy-vtab:\u000b",
-        r"legacy-null:\u0000",
-        r"actual-del:\u007f",
-        "safe\tline\n",
-    ]
-    assert output["unchangedPayload"] is None
+    # Both relays that exhibit the corruption now retry, on either signature.
+    assert results[0].startswith(parser_retry)
+    assert results[1].startswith(parser_retry)
+    assert results[2].startswith(parser_retry)
+    assert results[3].startswith(parser_retry)
+    assert results[4].startswith(parser_retry)
 
-    retry_messages = output["results"]
-    assert retry_messages[0].startswith("internal_error transient relay parser retry:")
-    assert retry_messages[1].startswith("internal_error transient relay parser retry:")
-    assert retry_messages[2].startswith("internal_error transient relay parser retry:")
-    assert retry_messages[3] is None
-    assert retry_messages[4] is None
+    # Pre-existing transient-auth branches are untouched.
+    assert results[5].startswith(auth_retry)
+    assert results[6].startswith(auth_retry)
+
+    # Genuine rejections must still surface instead of being retried away.
+    assert results[7] is None
+    assert results[8] is None
+
+    # Only MMS-managed providers participate.
+    assert results[9] is None
+
+
+def test_pi_retry_extension_ignores_non_error_messages():
+    script = """
+const { default: extension } = await import(process.argv[1]);
+const handlers = {};
+extension({ on(name, callback) { handlers[name] = callback; } });
+const provider = "mms-uscrsopenai";
+const errorMessage = "invalid character '\\u001b' in string literal";
+const results = [
+  handlers.message_end({ message: { role: "assistant", stopReason: "stop", provider, errorMessage } }, { model: { provider } }),
+  handlers.message_end({ message: { role: "user", stopReason: "error", provider, errorMessage } }, { model: { provider } }),
+  handlers.message_end({ message: { role: "assistant", stopReason: "error", provider, errorMessage: "" } }, { model: { provider } }),
+];
+console.log(JSON.stringify({ results: results.map((item) => item ?? null) }));
+"""
+    assert _run_extension(script)["results"] == [None, None, None]
 
 
 def test_pi_retry_extension_drops_poisoned_reasoning_signatures_after_encrypted_content_error():


### PR DESCRIPTION
Closes #99

跟进 #97 / #98 的诊断结论。这个 PR 只动 `scripts/pi-retry-extension.mjs` 和它的测试。

## 1. 移除 `before_provider_request` 归一化

它对报错**零作用**：`JSON.stringify` 本来就转义整个 C0 区间，抓包实测确认 pi 发出的字节里没有任何原始控制字节。

它的副作用**是真的**：

```js
.replace(/\\x([0-9a-f]{2})/gi, ...)
.replace(/\\([aev])/gi, ...)
.replace(/\\0(?![0-9])/g, "\\u0000")
```

这几条作用在每个字符串上，会把源码里**字面的** `\x41` / `\a` / `\e` / `\v` / `\0` 静默改写成 `\u00XX`。编辑含这些文本的文件时内容会被破坏。

## 2. 扩大 malformed-body retry 的范围

原来锁死在 `mms-newapi-personal-tokyo` 前缀，所以 `mms-uscrsopenai` 报的 `400 "Invalid JSON"` 不进 retry，直接硬失败。

改为：MMS 托管的 provider（`mms-` 前缀）+ 窄 signature。

**这里比 issue 里写的范围更宽，需要 reviewer 确认**：没有只加 `mms-uscrsopenai`，而是覆盖所有 `mms-` provider。理由是这个损坏在两个不同 relay 上都出现过，本来就不是 provider-specific 的；只加一个 relay 等于等着下一个 relay 再踩一次。如果希望收窄成显式白名单，我改。

signature 保持窄，只匹配"请求体没解析成功"：

```
/invalid character .* in string (literal|escape code)|invalid json/i
```

真实的校验失败（`invalid request body`、`model_not_found`）仍然照常抛出来，测试里有覆盖。

## 边界

- 未动 provider / model 路由
- 未动其它两个 `message_end` 分支（codex token 失效、antigravity capacity）
- 未动任何 Python 侧启动链路

## 验证

- `node --check` 通过
- `tests/test_pi_retry_extension.py` 3 passed，重写为覆盖：没有注册任何请求钩子、两个 relay 的两种 signature 都 retry、既有 auth 分支不变、真实校验错误不被 retry 吞掉、非 MMS provider 不参与
- `tests/test_pi_launcher.py` 39 passed
- **live smoke**：把改后的 extension 用 `-e` 显式加载进真实 pi 0.83.0，对 Tokyo relay 跑通，返回 OK
- 完整 fresh-user gate：390 passed / 1 failed。那个 failed 是 `test_overlay_web_access_session_entries_merges_session_and_web_access_skill`，在干净 `dev` 上同样失败，**既有红灯，与本改动无关**

## 残余风险

retry 会把"请求体畸形"这类 400 变成重试。如果将来出现一个真的由 pi 构造错误请求导致的稳定 400，会被重试 8 次才暴露出来，症状是变慢而不是立刻报错。#98 的抓包开关就是用来区分这两种情况的。

https://claude.ai/code/session_01VA2vRxuCpZsLmXR8sLeUgG
