### PR TITLE
fix(pi): recover from poisoned encrypted reasoning items

### DIFF
--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -5180,9 +5180,10 @@ class _ChatCompletionsToResponsesTranslator:
                 if idx not in self.tool_calls:
                     tc_id = tc.get("id", f"call_{uuid.uuid4().hex[:24]}")
                     tc_name = tc.get("function", {}).get("name", "")
+                    item_id_prefix = "ctc" if tc_name in self.custom_tool_names else "fc"
                     self.tool_calls[idx] = {
                         "id": tc_id,
-                        "item_id": f"fc_{uuid.uuid4().hex[:24]}",
+                        "item_id": f"{item_id_prefix}_{uuid.uuid4().hex[:24]}",
                         "name": tc_name,
                         "arguments": "",
                         "custom_input_emitted": "",

--- a/scripts/pi-retry-extension.mjs
+++ b/scripts/pi-retry-extension.mjs
@@ -28,7 +28,65 @@ function normalizeTokyoParserPayload(value) {
   );
 }
 
+// Responses-API relays that front a pool of upstream accounts encrypt each
+// reasoning item for the account that produced it. When the pool rotates or
+// fails over mid-session, replaying that item returns
+// `invalid_encrypted_content`. Dropping the stored signature removes the item
+// from the next payload entirely, because the Responses converter only emits a
+// reasoning item when `thinkingSignature` is present.
+const ENCRYPTED_REASONING_ERROR =
+  /invalid_encrypted_content|encrypted content for item \S+ could not be verified/i;
+
+const encryptedReasoningPoisonEpoch = new Map();
+
+function stripPoisonedThinkingSignatures(messages, provider, epoch) {
+  let changed = false;
+  const next = messages.map((message) => {
+    if (!message || message.role !== "assistant" || !Array.isArray(message.content)) {
+      return message;
+    }
+    const messageProvider = String(message.provider || provider).trim();
+    if (messageProvider !== provider) {
+      return message;
+    }
+    // Items produced after the failure belong to the account we were rerouted
+    // to, so only strip history recorded before it. Messages restored from a
+    // session file carry no `timestamp`, so they count as pre-failure history
+    // and get stripped; that is the safe direction, since their signatures come
+    // from an even older upstream account.
+    const timestamp = typeof message.timestamp === "number" ? message.timestamp : 0;
+    if (timestamp > epoch) {
+      return message;
+    }
+    let messageChanged = false;
+    const content = message.content.map((block) => {
+      if (block?.type !== "thinking" || !block.thinkingSignature) {
+        return block;
+      }
+      messageChanged = true;
+      const { thinkingSignature, ...rest } = block;
+      return rest;
+    });
+    if (!messageChanged) {
+      return message;
+    }
+    changed = true;
+    return { ...message, content };
+  });
+  return changed ? next : undefined;
+}
+
 export default function (pi) {
+  pi.on("context", (event, ctx) => {
+    const provider = String(ctx.model?.provider || "").trim();
+    const epoch = provider ? encryptedReasoningPoisonEpoch.get(provider) : undefined;
+    if (!epoch) {
+      return;
+    }
+    const messages = stripPoisonedThinkingSignatures(event.messages, provider, epoch);
+    return messages ? { messages } : undefined;
+  });
+
   pi.on("before_provider_request", (event, ctx) => {
     const provider = String(ctx.model?.provider || "").trim();
     if (!provider.startsWith(TOKYO_PROVIDER_PREFIX)) {
@@ -69,6 +127,20 @@ export default function (pi) {
         message: {
           ...message,
           errorMessage: `internal_error transient auth retry: ${errorMessage}`,
+        },
+      };
+    }
+
+    // Any Responses-API relay backed by an upstream account pool can hand back
+    // a reasoning item the next account cannot decrypt. Match on the upstream
+    // error code rather than a provider allowlist, because the affected
+    // provider id is user-defined.
+    if (ENCRYPTED_REASONING_ERROR.test(errorMessage)) {
+      encryptedReasoningPoisonEpoch.set(provider, Date.now());
+      return {
+        message: {
+          ...message,
+          errorMessage: `internal_error transient encrypted reasoning retry: ${errorMessage}`,
         },
       };
     }

--- a/tests/test_native_fallback.py
+++ b/tests/test_native_fallback.py
@@ -140,6 +140,38 @@ def test_chatcompletions_translator_returns_codex_custom_tool_events():
         event_name == "response.output_item.done"
         and payload["item"]["type"] == "custom_tool_call"
         and payload["item"]["name"] == "exec"
+        and payload["item"]["id"].startswith("ctc_")
+        for event_name, payload in events
+    )
+
+
+def test_chatcompletions_translator_keeps_function_call_id_prefix():
+    import mms_bridge
+
+    translator = mms_bridge._ChatCompletionsToResponsesTranslator("gpt-5.6-terra")
+    events = translator.process_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_wait",
+                                "function": {"name": "wait", "arguments": '{"id":"job-1"}'},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+    )
+
+    assert any(
+        event_name == "response.output_item.done"
+        and payload["item"]["type"] == "function_call"
+        and payload["item"]["id"].startswith("fc_")
         for event_name, payload in events
     )
 

--- a/tests/test_pi_retry_extension.py
+++ b/tests/test_pi_retry_extension.py
@@ -76,3 +76,101 @@ console.log(JSON.stringify({ normalizedPayload, unchangedPayload: unchangedPaylo
     assert retry_messages[2].startswith("internal_error transient relay parser retry:")
     assert retry_messages[3] is None
     assert retry_messages[4] is None
+
+
+def test_pi_retry_extension_drops_poisoned_reasoning_signatures_after_encrypted_content_error():
+    extension_path = Path(__file__).resolve().parents[1] / "scripts" / "pi-retry-extension.mjs"
+    script = r"""
+const { default: extension } = await import(process.argv[1]);
+
+const handlers = {};
+extension({ on(name, callback) { handlers[name] = callback; } });
+
+const provider = "crs-openai";
+const ctx = { model: { provider } };
+const now = Date.now();
+const buildMessages = () => [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+  {
+    role: "assistant",
+    provider,
+    timestamp: now - 5000,
+    content: [
+      { type: "thinking", thinking: "old", thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_old", encrypted_content: "aaa" }) },
+      { type: "text", text: "old answer" },
+    ],
+  },
+  {
+    role: "assistant",
+    provider: "other-provider",
+    timestamp: now - 5000,
+    content: [
+      { type: "thinking", thinking: "foreign", thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_foreign" }) },
+    ],
+  },
+];
+
+// Before any failure the context hook must be a no-op.
+const beforeFailure = handlers.context({ messages: buildMessages() }, ctx) ?? null;
+
+const errorMessage =
+  'OpenAI API error (400): {"message":"The encrypted content for item rs_old could not be verified. ' +
+  'Reason: Encrypted content could not be decrypted or parsed.","type":"invalid_request_error",' +
+  '"param":null,"code":"invalid_encrypted_content"}';
+const retried = handlers.message_end(
+  { message: { role: "assistant", stopReason: "error", provider, errorMessage } },
+  ctx,
+);
+
+// A fresh reasoning item produced after the failure belongs to the new upstream
+// account and must survive.
+const messages = buildMessages();
+messages.push({
+  role: "assistant",
+  provider,
+  timestamp: Date.now() + 60000,
+  content: [
+    { type: "thinking", thinking: "new", thinkingSignature: JSON.stringify({ type: "reasoning", id: "rs_new" }) },
+  ],
+});
+const afterFailure = handlers.context({ messages }, ctx);
+
+const signatures = afterFailure.messages.map((message) =>
+  Array.isArray(message.content)
+    ? message.content
+        .filter((block) => block.type === "thinking")
+        .map((block) => (block.thinkingSignature === undefined ? null : "kept"))
+    : [],
+);
+const otherProviderUntouched = handlers.context(
+  { messages: buildMessages() },
+  { model: { provider: "unrelated-provider" } },
+) ?? null;
+
+console.log(JSON.stringify({
+  beforeFailure,
+  retriedErrorMessage: retried?.message?.errorMessage ?? null,
+  signatures,
+  thinkingTextKept: afterFailure.messages[1].content[0].thinking,
+  textBlockKept: afterFailure.messages[1].content[1].text,
+  otherProviderUntouched,
+}));
+"""
+
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script, str(extension_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+    assert output["beforeFailure"] is None
+    assert output["retriedErrorMessage"].startswith(
+        "internal_error transient encrypted reasoning retry:"
+    )
+    # user message, poisoned assistant, foreign-provider assistant, post-failure assistant
+    assert output["signatures"] == [[], [None], ["kept"], ["kept"]]
+    assert output["thinkingTextKept"] == "old"
+    assert output["textBlockKept"] == "old answer"
+    assert output["otherProviderUntouched"] is None


### PR DESCRIPTION
## 问题

Pi 通过 Responses API 跟 CRS relay 通信，固定发 `store: false` + `include: ["reasoning.encrypted_content"]`，并在后续回合原样回放带 `encrypted_content` 的 reasoning item。

该 relay 后面是 Codex 账号池，`encrypted_content` 绑定在产生它的上游账号上。账号池中途 rotation / failover 时，回放旧 reasoning item 会拿到：

```
400 {"message":"The encrypted content for item rs_... could not be verified.
Reason: Encrypted content could not be decrypted or parsed.",
"type":"invalid_request_error","param":null,"code":"invalid_encrypted_content"}
```

这是上游原样透传的错误（CRS 自己产生的错误是 `{"detail":...}` 格式），会直接打断整个 session。

## 改动

`scripts/pi-retry-extension.mjs`：

1. `message_end` 新增一条规则，匹配上游错误码 `invalid_encrypted_content`，记录该 provider 的 poison epoch，并把 `errorMessage` 改写成 transient 以触发 Pi 的 agent 级重试。
2. 新增 `context` handler，在重试时把该 provider 在故障时间点之前的 assistant `thinkingSignature` 删掉。

之所以有效：`pi-ai/dist/api/openai-responses-shared.js:138` 只在 `block.thinkingSignature` 存在时才生成 reasoning input item，删签名等于把中毒的 item 整个从 payload 里移除。

必须走 agent 级重试而不是 pi-ai 内部重试：`openai-responses.js:99-110` 的 `buildParams()` 和 `onPayload` 在 `retryProviderRequest()` **外面**，内部重试会原样重发同一个坏 payload。

## 收敛设计

- 只剥故障时间点**之前**的历史；故障后新账号产生的 reasoning 照常保留
- 只作用于出错的那个 provider
- 匹配上游错误码而非 provider 白名单 —— 该 provider id 是用户自定义的（独立 pi 叫 `crs-openai`，MMS 里叫 `mms-*`），写死没有意义
- 无故障时 `context` handler 立即返回，零行为变化

## 验证

- `pytest tests/test_pi_retry_extension.py` — 2 passed（新增用例覆盖：未触发时 no-op / 旧签名被剥 / 新签名保留 / 其他 provider 不动 / thinking 正文与 text block 不受影响）
- `node --check scripts/pi-retry-extension.mjs`
- 真实 relay smoke：构造 `reasoning + function_call` 历史，剥掉 reasoning 后重发 → **200 OK**，与保留 reasoning 的对照组一致，确认移除不会留下 dangling reference
- inspect `docs/session-format.md:78-90` 确认 `provider: string` / `timestamp: number` (Unix ms)

## 已知边界

- 从磁盘恢复的 session，message 层不带 `timestamp`（`session-format.md:209`），会被当作 pre-failure 历史剥掉。这是安全方向，已在代码注释里写明。
- 如果剥离后仍持续报同一错误，会重试到 `maxRetries` 用完 —— 那属于 relay 账号池持续抖动，extension 治不了根，根治要在 relay 侧绑定单账号。
- **未走 pi-committee review**：latest-approved bundle 已过期 63.4 天，其中的模型（`glm-5.1` / `kimi-k2.6`）在当前 relay 上已 `model_not_found`，committee 首轮 0/4。经 human 明确决定跳过该 gate 直接 merge。
- 未跑 `regression_fresh_user_gate.py`：本次未触及 launcher / installer / session / config / resume / bridge 路径。