### PR TITLE
fix: load CtriTerm bridge for MMF Pi sessions

### DIFF
--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -145,6 +145,27 @@ def _pi_retry_extension_path():
     return ""
 
 
+def _glint_pi_bridge_path(env):
+    """Return Glint's managed Pi bridge only for a Glint-owned pane."""
+    env = env if isinstance(env, dict) else {}
+    if not str(env.get("GLINT_PANE_ID") or "").strip():
+        return ""
+    if not str(env.get("GLINT_AGENT_SOCK") or "").strip():
+        return ""
+
+    extension_path = Path(
+        _real_user_path(".pi", "agent", "extensions", "glint-agent-bridge.ts")
+    )
+    try:
+        if not extension_path.is_file():
+            return ""
+        if "Glint pi extension" not in extension_path.read_text(encoding="utf-8"):
+            return ""
+    except (OSError, UnicodeError):
+        return ""
+    return str(extension_path)
+
+
 def _pi_npx_cache_dir():
     return str(Path(__file__).resolve().parent / ".ai" / "cache" / "pi-npx")
 
@@ -1312,6 +1333,10 @@ def launch_pi(model_info, runtime, once=False, extra_args=None):
     cmd = ["pi", "--provider", provider_ref]
     if model:
         cmd += ["--model", model]
+    glint_bridge = _glint_pi_bridge_path(env)
+    if glint_bridge:
+        # MMS isolates PI_CODING_AGENT_DIR, so load the global Glint bridge explicitly.
+        cmd += ["--extension", glint_bridge]
     skill_overlay = str(env.get("MMS_PI_SKILLS_OVERLAY") or "").strip()
     if skill_overlay:
         cmd += ["--no-skills", "--skill", skill_overlay]

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -64,6 +64,7 @@ _PYTEST_TARGETS = [
     "tests/test_reset_mms_install.py",
     "tests/test_install_script_paths.py",
     "tests/test_nsr_bundled_wrapper.py",
+    "tests/test_pi_launcher.py",
     "tests/test_mms_installer_runtime.py",
     "tests/test_command_smoke.py",
 ]
@@ -76,6 +77,8 @@ _QUICK_PYTEST_TARGETS = [
     "tests/test_mms_resume_command.py::test_handle_resume_command_passes_claude_resume_args_and_project",
     "tests/test_install_script_paths.py",
     "tests/test_nsr_bundled_wrapper.py",
+    "tests/test_pi_launcher.py::test_glint_pi_bridge_requires_glint_pane_and_managed_extension",
+    "tests/test_pi_launcher.py::test_launch_pi_adds_glint_bridge_as_explicit_extension",
 ]
 
 _SCENARIO_MATRIX = [

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -32,6 +32,68 @@ def test_pi_global_executable_uses_path_binary(monkeypatch, tmp_path):
     assert mms_pi_support._pi_global_executable() == str(binary)
 
 
+def test_glint_pi_bridge_requires_glint_pane_and_managed_extension(monkeypatch, tmp_path):
+    import mms_pi_support
+
+    real_home = tmp_path / "real-home"
+    bridge = real_home / ".pi" / "agent" / "extensions" / "glint-agent-bridge.ts"
+    monkeypatch.setattr(
+        mms_pi_support,
+        "_real_user_path",
+        lambda *parts: str(real_home.joinpath(*parts)),
+    )
+    pane_env = {
+        "GLINT_PANE_ID": "workspace:pane",
+        "GLINT_AGENT_SOCK": "/tmp/glint.sock",
+    }
+
+    assert mms_pi_support._glint_pi_bridge_path(pane_env) == ""
+    bridge.parent.mkdir(parents=True)
+    bridge.write_text("export default function () {}\n", encoding="utf-8")
+    assert mms_pi_support._glint_pi_bridge_path(pane_env) == ""
+
+    bridge.write_text("// Glint pi extension\n", encoding="utf-8")
+    assert mms_pi_support._glint_pi_bridge_path(pane_env) == str(bridge)
+    assert mms_pi_support._glint_pi_bridge_path({"GLINT_PANE_ID": "workspace:pane"}) == ""
+
+
+def test_launch_pi_adds_glint_bridge_as_explicit_extension(monkeypatch):
+    import mms_pi_support
+
+    captured = {}
+    bridge = "/tmp/glint-agent-bridge.ts"
+    env = {
+        "MMS_PI_PROVIDER": "mms-relay-a",
+        "MMS_PI_SELECTED_MODEL": "gpt-5.4",
+    }
+    monkeypatch.setattr(mms_pi_support, "_pi_gateway_env", lambda *_args, **_kwargs: env)
+    monkeypatch.setattr(mms_pi_support, "_pi_effective_selected_model", lambda *_args: "gpt-5.4")
+    monkeypatch.setattr(mms_pi_support, "_glint_pi_bridge_path", lambda _env: bridge)
+    monkeypatch.setattr(
+        mms_pi_support,
+        "_exec_or_run",
+        lambda cmd, launch_env, once: captured.update(cmd=cmd, env=launch_env, once=once),
+    )
+
+    mms_pi_support.launch_pi(
+        {"model": "gpt-5.4"},
+        {"id": "relay-a", "auth_mode": "api_key"},
+        once=True,
+    )
+
+    assert captured["cmd"] == [
+        "pi",
+        "--provider",
+        "mms-relay-a",
+        "--model",
+        "gpt-5.4",
+        "--extension",
+        bridge,
+    ]
+    assert captured["env"] == env
+    assert captured["once"] is True
+
+
 def test_pi_policy_context_override_beats_provider_profile_default():
     import mms_pi_support
 


### PR DESCRIPTION
## Summary

Fixes #102.

MMF launches Pi with a session-local `PI_CODING_AGENT_DIR`, so Pi does not auto-discover the real global CtriTerm/Glint bridge extension. This adds that existing extension explicitly only when:

- the process has both `GLINT_PANE_ID` and `GLINT_AGENT_SOCK`; and
- the real-home bridge file exists and carries Glint's managed marker.

Non-CtriTerm Pi launches receive no new argument. Model/provider selection, transport, session isolation, credentials, HOME/XDG behavior, and real MMS config are unchanged.

## Validation

- `python3 -m py_compile mms_pi_support.py scripts/regression_fresh_user_gate.py`
- `python3 -m pytest -q tests/test_pi_launcher.py` -> 41 passed
- `python3 scripts/regression_fresh_user_gate.py --quick` -> 66 passed
- Auditor predeploy receipt -> PASS

The full fresh-user gate reached 431 passing tests then hit one unrelated existing host-global `web-access` fixture conflict in `test_overlay_web_access_session_entries_merges_session_and_web_access_skill`; this change does not touch that path.

## Review Boundary

This PR changes only Pi command assembly and its tests/gate coverage. It does not change runtime selection, provider routing, account state, credentials, or any real MMS config file.
