### PR TITLE
feat: gate Codex max effort by model

### DIFF
--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -70,6 +70,21 @@
             }
           }
         },
+        "gpt-5.6": {
+          "effort": {
+            "responses": {
+              "allowed": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          }
+        },
         "gpt-5-pro": {
           "effort": {
             "responses": {

--- a/mms_flywheel.py
+++ b/mms_flywheel.py
@@ -1054,12 +1054,17 @@ def _transport_evidence_for_route(
     }
 
 
-def _launcher_effort(value: Any) -> str:
+def _launcher_effort(value: Any, model_name: Any = "") -> str:
     raw = str(value or "").strip().lower()
     if raw in {"low", "medium", "high", "xhigh"}:
         return raw
     if raw == "max":
-        return "xhigh"
+        try:
+            from mms_reasoning_effort import model_supports_max_reasoning_effort
+
+            return "max" if model_supports_max_reasoning_effort(model_name) else "xhigh"
+        except Exception:
+            return "xhigh"
     if raw in {"none", "minimal"}:
         return "low"
     return raw
@@ -1109,7 +1114,7 @@ def _runtime_from_route(resolved: dict[str, Any], route: dict[str, Any]) -> dict
     if native_fallback_routes:
         runtime["native_fallback_routes"] = native_fallback_routes
         runtime["native_fallback_max"] = len(native_fallback_routes)
-    effort = _launcher_effort(resolved.get("reasoning_effort"))
+    effort = _launcher_effort(resolved.get("reasoning_effort"), resolved.get("model"))
     if effort:
         runtime["reasoning_effort"] = effort
     for key in ("proxy", "no_proxy", "provider_profile", "profile"):
@@ -1248,6 +1253,8 @@ def _codex_exec_args(*, cwd: Path, prompt: str, sandbox: str) -> list[str]:
 def _run_codex_headless(*, runtime: dict[str, Any], model: str, prompt: str, cwd: Path, sandbox: str) -> tuple[int, str, str]:
     import mms_launchers
 
+    runtime = dict(runtime)
+    runtime.setdefault("model", model)
     mms_launchers._ensure_bridge_helpers()  # noqa: SLF001 - flywheel runner reuses launcher bridge setup.
     mms_launchers._ensure_speed_stats()  # noqa: SLF001 - keep launcher lazy imports initialized.
     mms_launchers.gateway_health_check(runtime)
@@ -1390,6 +1397,7 @@ def _run_claude_headless(*, runtime: dict[str, Any], model: str, prompt: str, cw
     mms_launchers._ensure_speed_stats()  # noqa: SLF001 - keep launcher lazy imports initialized.
     wire_evidence_sink = runtime.get("_wire_evidence_sink") if isinstance(runtime.get("_wire_evidence_sink"), dict) else None
     runtime = dict(runtime)
+    runtime.setdefault("model", model)
     runtime.pop("_wire_evidence_sink", None)
     if sandbox == "danger-full-access":
         runtime["bypass"] = True

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -122,6 +122,7 @@ from mms_project_store import (
     write_slot_marker,
 )
 from mms_provider_profiles import profile_context_window, resolve_provider_profile
+from mms_reasoning_effort import model_supports_max_reasoning_effort
 import mms_pi_support as _pi_support
 from mms_runtime import cli_search_dirs, prepare_cli_command
 from mms_session_index import finalize_claude_session, list_indexed_sessions, record_claude_session_start
@@ -3382,15 +3383,25 @@ def _runtime_thinking_enabled(runtime):
     return _normalize_thinking_mode((runtime or {}).get("thinking_mode", "enable")) == "enable"
 
 
-def _normalize_reasoning_effort(value, default="high"):
+def _normalize_reasoning_effort(value, default="high", *, model_name=""):
     raw = str(value or "").strip().lower()
-    if raw in {"low", "medium", "high", "xhigh"}:
+    allowed = {"low", "medium", "high", "xhigh"}
+    if model_supports_max_reasoning_effort(model_name):
+        allowed.add("max")
+    if raw in allowed:
         return raw
+    if raw == "max":
+        return "xhigh"
     return default if default in {"low", "medium", "high", "xhigh"} else "high"
 
 
-def _runtime_reasoning_effort(runtime, default="high"):
-    return _normalize_reasoning_effort((runtime or {}).get("reasoning_effort", default), default=default)
+def _runtime_reasoning_effort(runtime, default="high", *, model_name=""):
+    model_name = model_name or (runtime or {}).get("model", "")
+    return _normalize_reasoning_effort(
+        (runtime or {}).get("reasoning_effort", default),
+        default=default,
+        model_name=model_name,
+    )
 
 
 def _claude_code_effort_env_value(model_name, runtime):
@@ -9488,7 +9499,11 @@ def launch_claude(model_info, runtime, once=False, extra_args=None):
         _thinking_enabled = _runtime_thinking_enabled(runtime)
         _gpt_default_effort = _default_gpt_reasoning_effort()
         if "reasoning_effort" in runtime:
-            _reasoning_effort = _runtime_reasoning_effort(runtime, default=_gpt_default_effort)
+            _reasoning_effort = _runtime_reasoning_effort(
+                runtime,
+                default=_gpt_default_effort,
+                model_name=probe_model,
+            )
         elif _gpt_openai_url and _is_gpt_model(probe_model):
             from mms_tui import select_reasoning_effort_tui as _sel_effort_claude
             _reasoning_effort = _sel_effort_claude(default=_gpt_default_effort)
@@ -11517,7 +11532,7 @@ def launch_codex(model_info, runtime, once=False, extra_args=None):
         bridge_label = f"模型 {model}" if model else "当前模型"
         console.print(f"[dim]{bridge_label} 通过本地 Chat Completions bridge 启动 Codex...[/dim]")
         bridge_thinking_enabled = _runtime_thinking_enabled(runtime)
-        bridge_reasoning_effort = _runtime_reasoning_effort(runtime, default="high")
+        bridge_reasoning_effort = _runtime_reasoning_effort(runtime, default="high", model_name=model)
         rescue_bridge_kwargs = _rescue_bridge_kwargs()
         with codex_chatcompletions_bridge(
             gateway_url,
@@ -11564,10 +11579,16 @@ def launch_codex(model_info, runtime, once=False, extra_args=None):
     thinking_enabled = _runtime_thinking_enabled(runtime)
     gpt_default_effort = _default_gpt_reasoning_effort()
     if "reasoning_effort" in runtime:
-        reasoning_effort = _runtime_reasoning_effort(runtime, default=gpt_default_effort)
+        reasoning_effort = _runtime_reasoning_effort(runtime, default=gpt_default_effort, model_name=model)
     else:
-        from mms_tui import select_reasoning_effort_tui as _sel_effort
-        reasoning_effort = _sel_effort(default=gpt_default_effort)
+        from mms_tui import (
+            _reasoning_effort_options_for_model,
+            select_reasoning_effort_tui as _sel_effort,
+        )
+        reasoning_effort = _sel_effort(
+            default=gpt_default_effort,
+            options=_reasoning_effort_options_for_model(model),
+        )
     console.print(f"[dim]thinking: {'on' if thinking_enabled else 'off'} · effort: {reasoning_effort}[/dim]")
     native_fallback_routes = _resolve_codex_responses_fallback_routes(runtime, model)
     if native_fallback_routes:

--- a/mms_reasoning_effort.py
+++ b/mms_reasoning_effort.py
@@ -1,0 +1,33 @@
+"""Shared model-specific reasoning effort capability helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+CODEX_MAX_EFFORT_MODEL_PREFIXES = ("gpt-5.6",)
+
+
+def _model_tokens(model_info: Any) -> list[str]:
+    if isinstance(model_info, Mapping):
+        values = model_info.values()
+    elif isinstance(model_info, Iterable) and not isinstance(model_info, (str, bytes)):
+        values = model_info
+    else:
+        values = [model_info]
+    tokens: list[str] = []
+    for value in values:
+        token = str(value or "").strip().lower()
+        if "/" in token:
+            token = token.rsplit("/", 1)[-1]
+        if token:
+            tokens.append(token)
+    return tokens
+
+
+def model_supports_max_reasoning_effort(model_info: Any) -> bool:
+    return any(
+        token.startswith(CODEX_MAX_EFFORT_MODEL_PREFIXES)
+        for token in _model_tokens(model_info)
+    )

--- a/mms_tui.py
+++ b/mms_tui.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from math import pow
 from mms_fake_upstream import status_payload as _fake_upstream_status_payload
 from mms_i18n import pick as _L, get_language as _get_language
+from mms_reasoning_effort import model_supports_max_reasoning_effort
 from mms_state_io import resolve_mms_config_dir
 
 # CJK locale 下 ambiguous-width 字符渲染为 2 列
@@ -4405,6 +4406,14 @@ _EFFORT_OPTIONS = [
     ("high",   "High   — 深度思考，慢但更准"),
     ("xhigh",  "XHigh  — 更深推理，最慢但更稳"),
 ]
+_MAX_EFFORT_OPTION = ("max", "Max    — 模型支持时的最高推理")
+
+
+def _reasoning_effort_options_for_model(model_info=None):
+    options = list(_EFFORT_OPTIONS)
+    if model_supports_max_reasoning_effort(model_info):
+        options.append(_MAX_EFFORT_OPTION)
+    return options
 
 
 def _confirm_model_tokens(model_info):
@@ -4567,9 +4576,11 @@ def _confirm_profile_capabilities(model_info, runtime=None):
 
 
 def _confirm_effort_values(profile_caps, model_tokens):
-    values = [value for value, _label in _EFFORT_OPTIONS]
     allowed = set(profile_caps.get("effort_allowed") or [])
     effort_map = profile_caps.get("effort_map") if isinstance(profile_caps.get("effort_map"), dict) else {}
+    values = [value for value, _label in _EFFORT_OPTIONS]
+    if model_supports_max_reasoning_effort(model_tokens):
+        values.append("max")
     if allowed:
         filtered = [
             value for value in values
@@ -4577,12 +4588,15 @@ def _confirm_effort_values(profile_caps, model_tokens):
         ]
         return filtered or values
     if not any(_confirm_is_gpt_like_token(token) for token in model_tokens):
-        return [value for value in values if value != "xhigh"]
+        return [value for value in values if value not in {"xhigh", "max"}]
+    if not model_supports_max_reasoning_effort(model_tokens):
+        return [value for value in values if value != "max"]
     return values
 
 
-def select_reasoning_effort_tui(default="high"):
-    """选择 GPT reasoning effort。返回 'low' / 'medium' / 'high' / 'xhigh'，Esc 返回 default。"""
+def select_reasoning_effort_tui(default="high", *, options=None):
+    """选择 GPT reasoning effort。Esc 返回 default。"""
+    options = list(options or _EFFORT_OPTIONS)
 
     def _inner(stdscr):
         curses.curs_set(0)
@@ -4590,7 +4604,7 @@ def select_reasoning_effort_tui(default="high"):
         curses.init_pair(1, curses.COLOR_CYAN, -1)
         curses.init_pair(2, curses.COLOR_WHITE, -1)
 
-        default_idx = next((i for i, (v, _) in enumerate(_EFFORT_OPTIONS) if v == default), 1)
+        default_idx = next((i for i, (v, _) in enumerate(options) if v == default), 1)
         sel = default_idx
 
         while True:
@@ -4600,7 +4614,7 @@ def select_reasoning_effort_tui(default="high"):
             stdscr.addstr(1, 2, title, curses.color_pair(1) | curses.A_BOLD)
             stdscr.addstr(2, 2, "─" * min(40, max_w - 4), curses.color_pair(2))
 
-            for i, (_, label) in enumerate(_EFFORT_OPTIONS):
+            for i, (_, label) in enumerate(options):
                 row = 4 + i
                 if row >= max_y - 1:
                     break
@@ -4616,11 +4630,11 @@ def select_reasoning_effort_tui(default="high"):
 
             key = stdscr.getch()
             if key == curses.KEY_UP:
-                sel = (sel - 1) % len(_EFFORT_OPTIONS)
+                sel = (sel - 1) % len(options)
             elif key == curses.KEY_DOWN:
-                sel = (sel + 1) % len(_EFFORT_OPTIONS)
+                sel = (sel + 1) % len(options)
             elif key in (10, 13):
-                return _EFFORT_OPTIONS[sel][0]
+                return options[sel][0]
             elif key == 27:
                 return default
 

--- a/tests/test_codex_reasoning_effort_launch.py
+++ b/tests/test_codex_reasoning_effort_launch.py
@@ -9,6 +9,12 @@ def test_runtime_reasoning_helpers_normalize_values():
     assert mms_launchers._runtime_thinking_enabled({"thinking_mode": "disable"}) is False
     assert mms_launchers._runtime_thinking_enabled({"thinking_mode": "enable"}) is True
     assert mms_launchers._runtime_reasoning_effort({"reasoning_effort": "xhigh"}) == "xhigh"
+    assert mms_launchers._runtime_reasoning_effort(
+        {"reasoning_effort": "max"}, model_name="gpt-5.6-luna"
+    ) == "max"
+    assert mms_launchers._runtime_reasoning_effort(
+        {"reasoning_effort": "max"}, model_name="gpt-5.5"
+    ) == "xhigh"
     assert mms_launchers._runtime_reasoning_effort({"reasoning_effort": "weird"}) == "high"
     assert mms_launchers._claude_code_effort_env_value("glm-5.2", {"reasoning_effort": "xhigh"}) == "max"
     assert mms_launchers._claude_code_effort_env_value("k3[1m]", {}) == "max"
@@ -155,8 +161,9 @@ def test_launch_codex_passes_reasoning_effort_to_codex_config(monkeypatch):
         lambda runtime, model: [{"provider_id": "codex-fallback", "gateway_url": "https://fallback.test/v1"}],
     )
 
-    def fake_select_reasoning_effort_tui(default="medium"):
+    def fake_select_reasoning_effort_tui(default="medium", **kwargs):
         captured["default_effort"] = default
+        captured["options"] = kwargs.get("options")
         return "xhigh"
 
     monkeypatch.setattr(mms_tui, "select_reasoning_effort_tui", fake_select_reasoning_effort_tui)
@@ -190,6 +197,7 @@ def test_launch_codex_passes_reasoning_effort_to_codex_config(monkeypatch):
         {"provider_id": "codex-fallback", "gateway_url": "https://fallback.test/v1"}
     ]
     assert captured["default_effort"] == "xhigh"
+    assert [value for value, _label in captured["options"]] == ["low", "medium", "high", "xhigh"]
     assert '-c' in captured["cmd"]
     assert 'model_reasoning_effort="xhigh"' in captured["cmd"]
     assert captured["force_subprocess"] is True

--- a/tests/test_mms_flywheel.py
+++ b/tests/test_mms_flywheel.py
@@ -14,6 +14,11 @@ sys.path.insert(0, str(REPO_ROOT))
 import mms_flywheel
 
 
+def test_launcher_effort_preserves_model_specific_max():
+    assert mms_flywheel._launcher_effort("max", "gpt-5.6-luna") == "max"
+    assert mms_flywheel._launcher_effort("max", "gpt-5.5") == "xhigh"
+
+
 def _write_json(path, payload):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -399,6 +399,7 @@ def test_launch_pi_rewrites_deprecated_antigravity_gemini_alias_to_live_replacem
         lambda *parts: str(real_home.joinpath(*parts)),
     )
     monkeypatch.setattr(mms_launchers, "_cleanup_stale_sessions", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mms_launchers._pi_support, "_pi_materialize_skill_overlay", lambda *_args: "")
     monkeypatch.setattr(mms_launchers, "_scrub_inherited_runtime_env", lambda env, **_kwargs: env)
     monkeypatch.setattr(mms_launchers, "_inject_real_home_hints", lambda env, include_xdg=False: env)
     monkeypatch.setattr(mms_launchers, "_inject_host_capability_hints", lambda env: env)
@@ -708,7 +709,7 @@ def test_pi_profile_derived_effort_maps_expose_only_truthful_levels():
         "medium": "medium",
         "high": "high",
         "xhigh": "xhigh",
-        "max": None,
+        "max": "max",
     }
 
     kimi_map = mms_launchers._pi_model_thinking_level_map(

--- a/tests/test_reasoning_effort_tui.py
+++ b/tests/test_reasoning_effort_tui.py
@@ -8,6 +8,7 @@ from mms_tui import (
     _build_family_menu_items,
     _confirm_effort_values,
     _confirm_profile_capabilities,
+    _reasoning_effort_options_for_model,
     confirm_tui,
     select_reasoning_effort_tui,
 )
@@ -20,6 +21,22 @@ def test_reasoning_effort_options_include_xhigh():
 
 def test_reasoning_effort_tui_defaults_to_high():
     assert select_reasoning_effort_tui.__defaults__ == ("high",)
+
+
+def test_reasoning_effort_max_is_model_specific():
+    assert [value for value, _label in _reasoning_effort_options_for_model("gpt-5.6-luna")] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    ]
+    assert [value for value, _label in _reasoning_effort_options_for_model("gpt-5.5")] == [
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
 
 
 def test_confirm_tui_thinking_and_effort_defaults():
@@ -76,6 +93,27 @@ def test_confirm_profile_capabilities_apply_model_defaults(monkeypatch, tmp_path
     assert qwen_caps["default_enabled"] is False
     assert deepseek_caps["effort_supported"] is True
     assert _confirm_effort_values(deepseek_caps, deepseek_caps["tokens"]) == ["high", "xhigh"]
+
+
+def test_confirm_profile_capabilities_expose_max_only_for_gpt56(monkeypatch, tmp_path):
+    import mms_provider_profiles
+
+    monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
+    mms_provider_profiles.load_provider_profiles.cache_clear()
+
+    luna_caps = _confirm_profile_capabilities(
+        "gpt-5.6-luna",
+        {"id": "uscrsopenai", "openai_base_url": "https://example.test/v1"},
+    )
+    gpt55_caps = _confirm_profile_capabilities(
+        "gpt-5.5",
+        {"id": "uscrsopenai", "openai_base_url": "https://example.test/v1"},
+    )
+
+    assert "max" in luna_caps["effort_allowed"]
+    assert _confirm_effort_values(luna_caps, luna_caps["tokens"])[-1] == "max"
+    assert "max" not in gpt55_caps["effort_allowed"]
+    assert "max" not in _confirm_effort_values(gpt55_caps, gpt55_caps["tokens"])
 
 
 def test_core_confirm_tui_keeps_ecc_default_off():


### PR DESCRIPTION
## Summary

This PR carries the preserved local Codex max-effort feature plus its required Pi launcher regression repair.

- `f601c5ca feat: gate Codex max effort by model` enables `max` only for GPT-5.6-family models and normalizes stale unsupported `max` to `xhigh`.
- Fixes #104 by making the Antigravity Pi command assertion independent of checkout-local skill discovery and by aligning the GPT-5.6 Pi `max` expectation with the feature's intended model gate.

## Scope Boundary

No Provider/account selection, credentials, real MMS config, HOME/XDG isolation, transport routing, or CtriTerm bridge behavior changes.

## Validation

- `python3 -m pytest -q tests/test_pi_launcher.py tests/test_codex_reasoning_effort_launch.py tests/test_reasoning_effort_tui.py tests/test_mms_flywheel.py` -> 91 passed
- `python3 -m py_compile mms_pi_support.py mms_reasoning_effort.py scripts/regression_fresh_user_gate.py`
- `python3 scripts/regression_fresh_user_gate.py --quick` -> 66 passed
- `git diff --check`
