### PR TITLE
feat(closeout): TB-46 explicit state-core closeout reference binding

### DIFF
--- a/docs/STATE_CORE_CLOSEOUT_BINDING.md
+++ b/docs/STATE_CORE_CLOSEOUT_BINDING.md
@@ -60,7 +60,8 @@ adapter 会独立重算 `completion_ref=sha256(task_id:revision_sha256)`，再�
 adapter 不复制指针解析，因此不把 `state_path` 带进最终可信 compact receipt。
 
 **success envelope 硬规则**：`closeout` 或 `verify-completion` 在 exit 0 时只要 stderr 非空就
-fail closed；closeout JSON 必须恰好是 canonical 五字段，多出 `errors` 等矛盾字段也拒绝。
+fail closed（包括只有空白字符）；closeout/verify JSON 的 key set 必须恰好等于 canonical
+producer contract，任意层级的 duplicate member 或多出 `errors`/warning 等矛盾字段也拒绝。
 
 **error vs blocked 的硬规则**（host-review P1-2）：只有 state-core 明确拒绝 phase 或 done-gate 内容时才报 `blocked`；路径 / 指针 / CLI / 文件异常一律报 `error`。理由：把“任务不存在 / root 指错”伪装成“业务 gate blocker”会误导下游以为是任务未过门，而其实是查不到任务。
 done-gate blockers 仅接受 state-core 当前输出的 canonical Python `list[str]` repr；注释、尾逗号、

--- a/docs/STATE_CORE_CLOSEOUT_BINDING.md
+++ b/docs/STATE_CORE_CLOSEOUT_BINDING.md
@@ -1,0 +1,96 @@
+# MMS × state-core Closeout Reference Binding (TB-46)
+
+> Owner: MMS hook-parity / runner adapters.
+> Contract source (read-only): `/Users/xin/auto-skills/CtriXin-repo/state-core/docs/runner-adapter-hooks.md`(ratified amendment `2026-06-14-runner-adapter-hooks-contract`)。
+> state-core 仍唯一拥有 canonical state、done-gate 与 `completion_ref`;本 binding 不改 state-core 任何 schema/gate。
+
+## 这是什么
+
+把已 ratify 的 runner-adapter consume contract 接到第一个 MMS-managed reference binding:
+
+- **Adapter** = `mms_state_core_closeout.py`(runner-neutral、stdlib-only)。调 `python3 <state-core>/src/cli.py closeout --task-id <id> --root <root>`,成功后用 `verify-completion` read-back `completion_ref`;非零退出保留原 phase 并输出 compact blockers。不直接读写 `task-state.json`,不调 `set --next-action/--runner/--owner`。
+- **Reference binding** = `mms closeout` 子命令(`mms_core.main` 单一显式 dispatch 分支)。只在被显式调用时存在;不给任何 session 静默安装 global hard hook。
+
+## 何时触发
+
+**只有一种触发方式:显式调用。**
+
+```
+mms closeout --task-id <id> --root <repo-root> [--actor <name>] [--at <iso8601>]
+# 或 standalone: python3 mms_state_core_closeout.py --task-id <id> --root <root>
+```
+
+由正式的 finish 入口(work-done / 显式 human 指令)在 agent 明确宣布任务结束时调用。调用即表示"请求进入 state-core done-gate",不表示任务已经 done——done 由 state-core done-gate 唯一裁决。
+
+### task_id / root 解析优先级(fail closed)
+
+1. 显式 argv(`--task-id` / `--root`)
+2. env(`STATE_CORE_TASK_ID` / `STATE_CORE_ROOT`)
+3. handover pickup pointer(`.agent.local/continuity/pickup.json` 的 `active.task_id` → `checkpoint.task_id`,及顶层 `root`)
+4. 都找不到 → **fail closed**(exit 2),绝不从聊天文本猜。
+
+state-core CLI 本身的定位:`--state-core-root` argv(authoritative,指向不存在的路径即 fail closed)> `STATE_CORE_ROOT` env > 祖先遍历(兼容主 checkout 与 `.worktrees/<slug>` 两种布局)。
+
+## 何时绝不触发
+
+- **普通 `Stop` / 回合结束 / 回答结束 / 进程退出 / `SessionEnd`** —— 一律不是任务完成。本 binding 不挂在任何事件 hook 上(`tests/test_state_core_closeout_binding.py::test_no_stop_or_sessionend_hook_is_wired_to_closeout` 静态断言 hooks/ 目录零引用)。
+- **NSR 的 `Stop` 循环语义** —— NSR 是否继续循环与任务是否 canonical done 是两件事,不复用。
+- **error / abort / timeout** —— adapter 返回 `status=error`(exit 4),不推断 `done` 也不推断 `blocked`,不改 canonical phase。
+- **聊天里出现"完成/上线/验证"字样** —— 不构成 finish 信号(红线:auto-advance 已判死,不按字面判断)。
+
+## 失败语义(确定性 exit code)
+
+| status | exit | 含义 |
+|---|---|---|
+| `done` | 0 | closeout 成功且 `completion_ref` read-back 通过 |
+| `blocked` | 1 | done-gate / phase 拒绝(`reason=phase_not_verifying` 或 `done_gate_blockers`),phase 不变,blockers 原样带出 |
+| `verify_failed` | 1 | closeout 本身成功但 `completion_ref` read-back 失败(视为未完成,不得宣称 done) |
+| `missing_task_id` / `missing_root` | 2 | 解析失败,fail closed,未触碰任何 state |
+| `cli_unavailable` | 3 | state-core CLI 找不到(含显式 override 指向不存在路径) |
+| `error` | 4 | subprocess crash / timeout / stdout 异常,不推断任何 phase |
+
+每次调用在 stdout 输出 compact JSON(machine-readable),人读的 hint/blockers 在 stderr。
+
+## fresh session 生效边界
+
+- 本 binding 是**纯显式命令**,不改任何 hook/config/环境注入,因此:
+  - **新 session**:安装(merge)后立即可用,无投影延迟。
+  - **旧 session**:已启动的 session 不受影响——它本来就只能通过显式敲 `mms closeout` 触发,不存在"旧 session 被静默更新/未更新"的问题面。
+- 若未来把本 adapter 接进某个 harness 的事件面(新增 binding),按 HANDBOOK 惯例:**变更只对新 session 生效**,旧 session 的旧 hook 配置会重放,需在变更记录中写明。
+
+## 如何手工复核 completion_ref
+
+```bash
+# 1) closeout 成功后拿到 ref(也存在 state 里)
+mms closeout --task-id <id> --root <repo>            # stdout JSON: completion_ref
+
+# 2) 独立 read-back(不依赖 adapter,直接用 state-core CLI)
+python3 <state-core>/src/cli.py verify-completion \
+  --task-id <id> --root <repo> --completion-ref <ref>
+# → {"status": "passed"} 且 exit 0;ref 与 task/revision 绑定,任何 state 后续变更都会使其失效
+
+# 3) 直接看 canonical state
+python3 <state-core>/src/cli.py read --task-id <id> --root <repo>
+# → phase=done 且 completion.completion_ref 与 1) 一致
+```
+
+注意:`completion_ref` 是 task/revision-bound 的(`completion:sha256:<hash>`,hash = task_id + 证据 revision)。done 之后任何 slot/evidence 变更都会让旧 ref verify 失败——这是特性不是 bug,防的是拿旧收据给新状态背书。
+
+## Cross-runner compliance suite
+
+`tests/test_state_core_closeout_binding.py` 冻结以下 contract cases,后续新 harness binding(Claude / Codex / OpenCode)**必须跑同一组 cases** 通过后才可标 parity-complete:
+
+1. explicit finish → closeout 成功 → `completion_ref` verified(read-back)。
+2. phase≠verifying → 非零退出 → phase 不变、无 completion。
+3. done-gate content blocker → 非零退出 → blockers 可见 → `task-state.json` 逐字节不变。
+4. 普通 Stop/turn end → 不触发 closeout(hooks/ 零引用静态断言)。
+5. task id / root 缺失 → fail closed(exit 2),不猜状态。
+6. cli unavailable → exit 3。
+7. 静态:adapter 无文件写原语(`open(`/`.write_text(`/`.write_bytes(`/`json.dump(`)、无 `set --next-action/--runner/--owner`、无聊天文本解析面。
+
+## 非目标(红线重申)
+
+- 不做 auto-advance;不按聊天字样判断完成。
+- 不把 state-core 变成 hook daemon;不把 runner-specific 依赖塞进 state-core。
+- 不修改其他既有 Map/Caveman/NSR hook 的顺序或默认启用状态。
+- adapter 不直接读写 `task-state.json`;唯一 state 写路径是 state-core CLI 自己的 `closeout`。

--- a/docs/STATE_CORE_CLOSEOUT_BINDING.md
+++ b/docs/STATE_CORE_CLOSEOUT_BINDING.md
@@ -51,11 +51,20 @@ state-core CLI 本身的定位:`--state-core-root` argv(authoritative,指向不�
 | `verify_failed` | 1 | closeout 本身成功但 `completion_ref` read-back 失败(视为未完成,不得宣称 done) |
 | `missing_task_id` / `missing_root` | 2 | 解析失败,fail closed,未触碰任何 state |
 | `cli_unavailable` | 3 | state-core CLI 找不到(含显式 override 指向不存在路径) |
-| `error` | 4 | task-state.json 缺失 / root 指错 / DIRECT_TO 指针缺或坏 / subprocess crash / timeout / stdout 异常——**不是** done-gate blocker，不推断任何 phase |
+| `error` | 4 | task-state.json 缺失 / root 指错 / DIRECT_TO 指针缺或坏 / subprocess crash / timeout / stdout 异常 / exit-0 伴随 stderr——**不是** done-gate blocker，不推断任何 phase |
 
 每次调用在 stdout 输出 compact JSON（machine-readable，含 `verified` 布尔），人读的 hint/blockers 在 stderr。
+成功收据只把互相绑定的 `task_id` / `revision_sha256` / `completion_ref` 当作可信证据：
+adapter 会独立重算 `completion_ref=sha256(task_id:revision_sha256)`，再调
+`verify-completion` read-back。state-core 输出的 `state_path` 可能经 DIRECT_TO/MOVED_TO 跨 root，
+adapter 不复制指针解析，因此不把 `state_path` 带进最终可信 compact receipt。
+
+**success envelope 硬规则**：`closeout` 或 `verify-completion` 在 exit 0 时只要 stderr 非空就
+fail closed；closeout JSON 必须恰好是 canonical 五字段，多出 `errors` 等矛盾字段也拒绝。
 
 **error vs blocked 的硬规则**（host-review P1-2）：只有 state-core 明确拒绝 phase 或 done-gate 内容时才报 `blocked`；路径 / 指针 / CLI / 文件异常一律报 `error`。理由：把“任务不存在 / root 指错”伪装成“业务 gate blocker”会误导下游以为是任务未过门，而其实是查不到任务。
+done-gate blockers 仅接受 state-core 当前输出的 canonical Python `list[str]` repr；注释、尾逗号、
+隐式字符串拼接或 JSON 双引号等“可解析但非 canonical”的 suffix 一律当 wrapper/CLI 异常。
 
 ### 关于 `--no-verify`
 
@@ -97,6 +106,7 @@ python3 <state-core>/src/cli.py read --task-id <id> --root <repo>
 5. task id / root 缺失 → fail closed(exit 2),不猜状态。
 6. cli unavailable → exit 3。
 7. 静态:adapter 无文件写原语(`open(`/`.write_text(`/`.write_bytes(`/`json.dump(`)、无 `set --next-action/--runner/--owner`、无聊天文本解析面。
+8. exit-0 payload 字段互绑、stderr 为空；非 canonical blocker literal 不能升格为 business `blocked`。
 
 ## 非目标(红线重申)
 

--- a/docs/STATE_CORE_CLOSEOUT_BINDING.md
+++ b/docs/STATE_CORE_CLOSEOUT_BINDING.md
@@ -22,6 +22,10 @@ mms closeout --task-id <id> --root <repo-root> [--actor <name>] [--at <iso8601>]
 
 由正式的 finish 入口(work-done / 显式 human 指令)在 agent 明确宣布任务结束时调用。调用即表示"请求进入 state-core done-gate",不表示任务已经 done——done 由 state-core done-gate 唯一裁决。
 
+### root 可以是 launch / business root
+
+`--root` 传的可以是真实 state root,也可以是只持有 `DIRECT_TO`/`MOVED_TO` 指针的 launch / business root(state-core `read` 会自动跟随指针)。这是合法用法——pickup.root 常是 launch repo。但当指针缺失、target 不存在、或显式 root 指错时,adapter 报 `status=error`(`reason=task_or_root_unresolved`,exit 4),**不**报 `blocked`(host-review P1-2)。
+
 ### task_id / root 解析优先级(fail closed)
 
 1. 显式 argv(`--task-id` / `--root`)
@@ -42,14 +46,20 @@ state-core CLI 本身的定位:`--state-core-root` argv(authoritative,指向不�
 
 | status | exit | 含义 |
 |---|---|---|
-| `done` | 0 | closeout 成功且 `completion_ref` read-back 通过 |
+| `done` | 0 | closeout 成功且 `completion_ref` read-back 通过（verify 是强制的，无 escape hatch） |
 | `blocked` | 1 | done-gate / phase 拒绝(`reason=phase_not_verifying` 或 `done_gate_blockers`),phase 不变,blockers 原样带出 |
 | `verify_failed` | 1 | closeout 本身成功但 `completion_ref` read-back 失败(视为未完成,不得宣称 done) |
 | `missing_task_id` / `missing_root` | 2 | 解析失败,fail closed,未触碰任何 state |
 | `cli_unavailable` | 3 | state-core CLI 找不到(含显式 override 指向不存在路径) |
-| `error` | 4 | subprocess crash / timeout / stdout 异常,不推断任何 phase |
+| `error` | 4 | task-state.json 缺失 / root 指错 / DIRECT_TO 指针缺或坏 / subprocess crash / timeout / stdout 异常——**不是** done-gate blocker，不推断任何 phase |
 
-每次调用在 stdout 输出 compact JSON(machine-readable),人读的 hint/blockers 在 stderr。
+每次调用在 stdout 输出 compact JSON（machine-readable，含 `verified` 布尔），人读的 hint/blockers 在 stderr。
+
+**error vs blocked 的硬规则**（host-review P1-2）：只有 state-core 明确拒绝 phase 或 done-gate 内容时才报 `blocked`；路径 / 指针 / CLI / 文件异常一律报 `error`。理由：把“任务不存在 / root 指错”伪装成“业务 gate blocker”会误导下游以为是任务未过门，而其实是查不到任务。
+
+### 关于 `--no-verify`
+
+**不存在。** 正式 `mms closeout` 没有跳过 read-back 的 escape：成功声明必须引用本 `closeout` 返回并 verify 过的 `completion_ref`（host-review P1-1）。
 
 ## fresh session 生效边界
 

--- a/mms_core.py
+++ b/mms_core.py
@@ -17131,6 +17131,13 @@ def main():
             from mms_review_dispatch import handle_review_dispatch_command
 
             raise SystemExit(handle_review_dispatch_command(argv[1:], command_name=current_command()))
+        if command == "closeout":
+            # TB-46: explicit opt-in state-core closeout reference binding.
+            # Only an explicit `mms closeout` invocation reaches state-core;
+            # never wired to Stop/SessionEnd (see docs/STATE_CORE_CLOSEOUT_BINDING.md).
+            from mms_state_core_closeout import handle_closeout_command
+
+            raise SystemExit(handle_closeout_command(argv[1:], command_name=current_command()))
         if command == "guard":
             handle_guard_command(argv[1:], bootstrap_cfg=bootstrap_cfg)
             return
@@ -17288,6 +17295,7 @@ def main():
             f"  {current_command()} fake-upstream ... 开发期 fake upstream 开关与日志\n"
             f"  {current_command()} review-launch ... 非交互 multi-review reviewer launcher 握手\n"
             f"  {current_command()} review-dispatch --root <artifact-root> 生成/启动 OpenCode Review Hub 派发\n"
+            f"  {current_command()} closeout --task-id <id> --root <repo>  显式 state-core 收口(read-back completion_ref；绝不接 Stop)\n"
             f"  {current_command()} flywheel resolve/run --lane worker --priority AI-P3  解析/运行 Flywheel lane\n"
             f"  {current_command()} env <preset>    输出预设对应的 export 环境变量\n"
             f"  {current_command()} activate <preset>  输出可 eval 的 export 语句\n"

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -1,0 +1,460 @@
+"""MMS-managed runner-neutral closeout adapter for state-core.
+
+TB-46 (workflow-reliability-batch9). This is the **first reference binding** of
+the ratified ``docs/runner-adapter-hooks.md`` consume contract (state-core owns
+canonical state + done-gate + ``completion_ref``; runner adapters only consume).
+
+What this module is
+-------------------
+- A runner-neutral adapter: only **explicit** finish/closeout requests reach
+  state-core ``closeout``. Ordinary turn ``Stop`` / ``SessionEnd`` / process
+  exit are **never** wired here (see docs/STATE_CORE_CLOSEOUT_BINDING.md for the
+  finish-vs-Stop boundary).
+- Explicit opt-in: it runs only when an agent/human invokes it (the
+  ``mms closeout`` subcommand, or directly as a script). It is **not** installed
+  as a global hard hook on any session.
+- Deterministic failure: missing task id / missing root / stale completion /
+  done-gate rejection / CLI unavailable each produce a distinct non-zero exit;
+  error/abort/timeout never infer ``done`` or ``blocked``.
+
+Hard boundaries (frozen by the consume contract)
+-------------------------------------------------
+- Never reads or writes ``task-state.json`` directly; the only state write is
+  state-core's own ``closeout`` (which the adapter shells out to).
+- Never calls ``set --next-action``, ``set --runner``, or ``set --owner``.
+- Never injects full task-state into a subagent (this adapter has no subagent
+  surface; it is a single explicit finish call).
+
+task_id / root resolution priority
+-----------------------------------
+1. explicit argv (``--task-id`` / ``--root``)
+2. env (``STATE_CORE_TASK_ID`` / ``STATE_CORE_ROOT``)
+3. handover pickup pointer (``.agent.local/continuity/pickup.json``
+   ``active.task_id`` and top-level ``root``)
+4. fail closed — never guessed from chat text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Exit code policy (kept distinct so runner bindings can branch deterministically).
+EXIT_OK = 0
+EXIT_BLOCKED = 1            # closeout ran but done-gate / phase rejected it
+EXIT_MISSING_SLOT = 2       # task_id or root could not be resolved
+EXIT_CLI_UNAVAILABLE = 3    # state-core cli.py missing / no closeout subcommand
+EXIT_ERROR = 4              # subprocess crash / timeout / unexpected
+
+_COMPLETION_PREFIX = "completion:sha256:"
+_PICKUP_DEFAULT_REL = ".agent.local/continuity/pickup.json"
+_CLOSEOUT_TIMEOUT_DEFAULT = 60  # seconds
+
+
+@dataclass
+class CloseoutResult:
+    """Machine-readable result of one closeout attempt.
+
+    ``status`` is one of: ``done`` | ``blocked`` | ``missing_task_id`` |
+    ``missing_root`` | ``cli_unavailable`` | ``verify_failed`` | ``error``.
+    Only ``status == "done"`` carries a verified ``completion_ref``.
+    """
+
+    status: str
+    task_id: str | None = None
+    root: str | None = None
+    completion_ref: str | None = None
+    revision_sha256: str | None = None
+    state_path: str | None = None
+    verified: bool = False
+    reason: str | None = None
+    blockers: list[str] = field(default_factory=list)
+    hint: str | None = None
+
+    def exit_code(self) -> int:
+        return {
+            "done": EXIT_OK,
+            "missing_task_id": EXIT_MISSING_SLOT,
+            "missing_root": EXIT_MISSING_SLOT,
+            "cli_unavailable": EXIT_CLI_UNAVAILABLE,
+            "blocked": EXIT_BLOCKED,
+            "verify_failed": EXIT_BLOCKED,
+            "error": EXIT_ERROR,
+        }.get(self.status, EXIT_ERROR)
+
+    def to_compact_json(self) -> str:
+        payload = {k: v for k, v in asdict(self).items() if v not in (None, [], False)}
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Resolution helpers (pure, no I/O side effects beyond reading env / files)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def resolve_state_core_cli(*, env: dict[str, str] | None = None,
+                           override_root: str | None = None) -> Path | None:
+    """Locate ``<state-core>/src/cli.py``.
+
+    Priority: explicit argv override (authoritative, fail closed if it points
+    nowhere) > ``STATE_CORE_ROOT`` env hint > ancestor walk. The ancestor walk
+    works for both the main checkout and ``.worktrees/<slug>`` layouts because it
+    walks up ancestors of *this file* and looks for a ``state-core`` sibling.
+    Returns ``None`` (fail closed) if no candidate resolves.
+    """
+    env = env or dict(os.environ)
+    # 1. explicit argv override is authoritative — never silently fall through.
+    if override_root:
+        cli = Path(override_root) / "src" / "cli.py"
+        return cli if cli.is_file() else None
+    # 2. env hint (best-effort; may be stale globally, so fall through on miss).
+    env_root = env.get("STATE_CORE_ROOT", "").strip()
+    if env_root:
+        candidate = Path(env_root) / "src" / "cli.py"
+        if candidate.is_file():
+            return candidate
+    # 3. ancestor walk (default discovery; handles main checkout + worktrees).
+    here = Path(__file__).resolve()
+    for ancestor in [here.parent, *here.parents]:
+        candidate = ancestor / "state-core" / "src" / "cli.py"
+        try:
+            if candidate.is_file():
+                return candidate
+        except OSError:
+            continue
+    return None
+
+
+def _read_pickup(pickup_path: Path) -> dict[str, Any] | None:
+    try:
+        if pickup_path.is_file():
+            data = json.loads(pickup_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    except (OSError, json.JSONDecodeError):
+        return None
+    return None
+
+
+def resolve_task_id(*, argv_value: str | None = None,
+                    env: dict[str, str] | None = None,
+                    pickup: dict[str, Any] | None = None) -> str | None:
+    """argv > env ``STATE_CORE_TASK_ID`` > pickup ``active.task_id`` (then
+    ``checkpoint.task_id``). Never guesses from chat text."""
+    if argv_value and argv_value.strip():
+        return argv_value.strip()
+    env = env or dict(os.environ)
+    env_value = env.get("STATE_CORE_TASK_ID", "").strip()
+    if env_value:
+        return env_value
+    if isinstance(pickup, dict):
+        active = pickup.get("active")
+        if isinstance(active, dict) and isinstance(active.get("task_id"), str):
+            tid = active["task_id"].strip()
+            if tid:
+                return tid
+        checkpoint = pickup.get("checkpoint")
+        if isinstance(checkpoint, dict) and isinstance(checkpoint.get("task_id"), str):
+            tid = checkpoint["task_id"].strip()
+            if tid:
+                return tid
+    return None
+
+
+def resolve_root(*, argv_value: str | None = None,
+                 env: dict[str, str] | None = None,
+                 pickup: dict[str, Any] | None = None) -> str | None:
+    """argv > env ``STATE_CORE_ROOT`` > pickup ``root``."""
+    if argv_value and argv_value.strip():
+        return argv_value.strip()
+    env = env or dict(os.environ)
+    env_value = env.get("STATE_CORE_ROOT", "").strip()
+    if env_value:
+        return env_value
+    if isinstance(pickup, dict) and isinstance(pickup.get("root"), str):
+        root = pickup["root"].strip()
+        if root:
+            return root
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Core closeout
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _parse_blockers(stderr: str) -> tuple[str, list[str]]:
+    """Classify a non-zero ``closeout`` stderr into (reason, blockers)."""
+    text = stderr or ""
+    if "transition to verifying first" in text or "cannot reach done from" in text:
+        return "phase_not_verifying", []
+    if "blockers:" in text:
+        # state-core prints e.g.  error: cannot advance to done; blockers: ['a', 'b']
+        after = text.split("blockers:", 1)[1].strip()
+        try:
+            parsed = json.loads(after)
+            if isinstance(parsed, list):
+                return "done_gate_blockers", [str(x) for x in parsed]
+        except json.JSONDecodeError:
+            stripped = after.strip("[]' \n")
+            return "done_gate_blockers", [
+                p.strip().strip("'\"") for p in stripped.split(",") if p.strip()
+            ] or [after]
+    return "cli_error", [text.strip()] if text.strip() else []
+
+
+def _run_cli(cli: Path, args: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(cli), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def closeout_task(
+    *,
+    task_id: str,
+    root: str,
+    cli: Path | None = None,
+    actor: str | None = None,
+    at: str | None = None,
+    verify: bool = True,
+    timeout: int = _CLOSEOUT_TIMEOUT_DEFAULT,
+) -> CloseoutResult:
+    """Run one explicit closeout against state-core and read-back the result.
+
+    The adapter performs no direct ``task-state.json`` access. On success it
+    read-backs ``completion_ref`` via ``verify-completion`` so a stale/tampered
+    receipt cannot be reported as done.
+    """
+    resolved_cli = cli or resolve_state_core_cli()
+    if resolved_cli is None:
+        return CloseoutResult(
+            status="cli_unavailable",
+            task_id=task_id,
+            root=root,
+            hint="state-core src/cli.py not found; set STATE_CORE_ROOT or pass --state-core-root",
+        )
+
+    close_args = ["closeout", "--task-id", task_id, "--root", root]
+    if actor:
+        close_args += ["--actor", actor]
+    if at:
+        close_args += ["--at", at]
+
+    try:
+        proc = _run_cli(resolved_cli, close_args, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return CloseoutResult(status="error", task_id=task_id, root=root,
+                              reason="timeout", hint=f"closeout exceeded {timeout}s")
+    except (OSError, ValueError) as exc:
+        return CloseoutResult(status="error", task_id=task_id, root=root,
+                              reason="cli_invoke_failed", hint=str(exc))
+
+    if proc.returncode != 0:
+        reason, blockers = _parse_blockers(proc.stderr)
+        return CloseoutResult(
+            status="blocked",
+            task_id=task_id,
+            root=root,
+            reason=reason,
+            blockers=blockers,
+            hint="phase preserved; resolve blockers or advance to verifying before retrying",
+        )
+
+    # success path: parse + verify completion_ref
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return CloseoutResult(status="error", task_id=task_id, root=root,
+                              reason="invalid_closeout_stdout",
+                              hint=f"closeout exited 0 but stdout was not JSON: {exc}")
+
+    completion_ref = payload.get("completion_ref")
+    if not isinstance(completion_ref, str) or not completion_ref.startswith(_COMPLETION_PREFIX):
+        return CloseoutResult(status="error", task_id=task_id, root=root,
+                              reason="invalid_completion_ref",
+                              hint="closeout succeeded but emitted no valid completion_ref")
+
+    if not verify:
+        return CloseoutResult(
+            status="done",
+            task_id=task_id,
+            root=root,
+            completion_ref=completion_ref,
+            revision_sha256=payload.get("revision_sha256"),
+            state_path=payload.get("state_path"),
+            verified=False,
+        )
+
+    verify_args = ["verify-completion", "--task-id", task_id, "--root", root,
+                   "--completion-ref", completion_ref]
+    try:
+        vproc = _run_cli(resolved_cli, verify_args, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return CloseoutResult(status="verify_failed", task_id=task_id, root=root,
+                              completion_ref=completion_ref,
+                              reason="verify_timeout")
+    except (OSError, ValueError) as exc:
+        return CloseoutResult(status="verify_failed", task_id=task_id, root=root,
+                              completion_ref=completion_ref,
+                              reason="verify_invoke_failed", hint=str(exc))
+
+    if vproc.returncode != 0:
+        try:
+            vpayload = json.loads(vproc.stdout)
+            errors = vpayload.get("errors", []) if isinstance(vpayload, dict) else []
+        except json.JSONDecodeError:
+            errors = [vproc.stderr.strip()] if vproc.stderr.strip() else []
+        return CloseoutResult(
+            status="verify_failed",
+            task_id=task_id,
+            root=root,
+            completion_ref=completion_ref,
+            reason="completion_ref_did_not_read_back",
+            blockers=[str(e) for e in errors] or ["verify-completion returned non-zero"],
+        )
+
+    return CloseoutResult(
+        status="done",
+        task_id=task_id,
+        root=root,
+        completion_ref=completion_ref,
+        revision_sha256=payload.get("revision_sha256"),
+        state_path=payload.get("state_path"),
+        verified=True,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# MMS subcommand binding (``mms closeout``) + standalone CLI
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _build_parser(command_name: str) -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog=f"{command_name} closeout",
+        description=(
+            "Explicit opt-in closeout: advance a state-core task through the "
+            "done-gate, read-back completion_ref. Only call this on an explicit "
+            "finish/closeout request — never on ordinary Stop/SessionEnd."
+        ),
+    )
+    p.add_argument("--task-id", help="state-core task id (or STATE_CORE_TASK_ID env / pickup)")
+    p.add_argument("--root", help="state-core state root, i.e. the task's repo (or STATE_CORE_ROOT env / pickup.root)")
+    p.add_argument("--state-core-root", help="state-core repo root containing src/cli.py (or STATE_CORE_ROOT env)")
+    p.add_argument("--actor", help="actor recorded on the completion receipt")
+    p.add_argument("--at", help="ISO timestamp recorded on the completion receipt")
+    p.add_argument("--pickup", default=_PICKUP_DEFAULT_REL,
+                   help=f"handover pickup.json path (default: {_PICKUP_DEFAULT_REL})")
+    p.add_argument("--no-verify", action="store_true",
+                   help="skip completion_ref read-back (NOT recommended for real closeout)")
+    p.add_argument("--timeout", type=int, default=_CLOSEOUT_TIMEOUT_DEFAULT,
+                   help=f"per-CLI-invocation timeout in seconds (default {_CLOSEOUT_TIMEOUT_DEFAULT})")
+    p.add_argument("--json", dest="as_json", action="store_true", default=True,
+                   help="emit compact machine-readable JSON (default)")
+    p.add_argument("--no-json", dest="as_json", action="store_false",
+                   help="emit a short human-readable line instead of JSON")
+    return p
+
+
+def _load_pickup(pickup_arg: str, root: str | None) -> dict[str, Any] | None:
+    pickup_path = Path(pickup_arg)
+    if not pickup_path.is_absolute():
+        base = Path(root) if root else Path.cwd()
+        pickup_path = base / pickup_path
+    return _read_pickup(pickup_path)
+
+
+def handle_closeout_command(argv: list[str], *, command_name: str = "mms") -> int:
+    """``mms closeout`` reference binding entry point.
+
+    Resolves task_id/root (argv > env > pickup; fail closed), then delegates to
+    :func:`closeout_task`. Emits compact JSON to stdout on every path so runner
+    bindings can parse deterministically; a short human hint goes to stderr.
+    """
+    args = _build_parser(command_name).parse_args(argv)
+
+    cli_override = args.state_core_root
+    resolved_cli = resolve_state_core_cli(override_root=cli_override)
+    # Pre-flight: fail closed with a precise status before touching state.
+    if resolved_cli is None:
+        result = CloseoutResult(
+            status="cli_unavailable",
+            hint="state-core src/cli.py not found; set STATE_CORE_ROOT or pass --state-core-root",
+        )
+        _emit(result, args.as_json)
+        return result.exit_code()
+
+    pickup = _load_pickup(args.pickup, args.root)
+    task_id = resolve_task_id(argv_value=args.task_id, pickup=pickup)
+    root = resolve_root(argv_value=args.root, pickup=pickup)
+
+    if not task_id:
+        result = CloseoutResult(
+            status="missing_task_id",
+            hint="pass --task-id, set STATE_CORE_TASK_ID, or provide a pickup.json with active.task_id",
+        )
+        _emit(result, args.as_json)
+        return result.exit_code()
+    if not root:
+        result = CloseoutResult(
+            status="missing_root",
+            task_id=task_id,
+            hint="pass --root, set STATE_CORE_ROOT, or provide a pickup.json with root",
+        )
+        _emit(result, args.as_json)
+        return result.exit_code()
+
+    result = closeout_task(
+        task_id=task_id,
+        root=root,
+        cli=resolved_cli,
+        actor=args.actor,
+        at=args.at,
+        verify=not args.no_verify,
+        timeout=args.timeout,
+    )
+    _emit(result, args.as_json)
+    return result.exit_code()
+
+
+def _emit(result: CloseoutResult, as_json: bool) -> None:
+    if as_json:
+        sys.stdout.write(result.to_compact_json() + "\n")
+    else:
+        if result.status == "done":
+            sys.stdout.write(
+                f"done: {result.task_id} completion_ref={result.completion_ref} "
+                f"verified={result.verified}\n"
+            )
+        else:
+            label = {
+                "blocked": "blocked (phase preserved)",
+                "verify_failed": "closeout ok but completion_ref did not read back",
+                "missing_task_id": "missing task_id (fail closed)",
+                "missing_root": "missing root (fail closed)",
+                "cli_unavailable": "state-core CLI unavailable",
+                "error": "error (no state inferred)",
+            }.get(result.status, result.status)
+            sys.stdout.write(f"{result.status}: {label}\n")
+    if result.status != "done" and result.hint:
+        sys.stderr.write(f"hint: {result.hint}\n")
+    if result.status not in ("done",) and result.blockers:
+        sys.stderr.write("blockers:\n")
+        for b in result.blockers:
+            sys.stderr.write(f"  - {b}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    return handle_closeout_command(sys.argv[1:] if argv is None else argv,
+                                   command_name=os.environ.get("MMS_COMMAND_NAME", "mms"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -58,6 +58,7 @@ EXIT_CLI_UNAVAILABLE = 3    # state-core cli.py missing / no closeout subcommand
 EXIT_ERROR = 4              # subprocess crash / timeout / unexpected
 
 _COMPLETION_PREFIX = "completion:sha256:"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _PICKUP_DEFAULT_REL = ".agent.local/continuity/pickup.json"
 _CLOSEOUT_TIMEOUT_DEFAULT = 60  # seconds
 
@@ -213,33 +214,26 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
         r"error: pointer chain detected at .+ — corruption",
         r"error: corruption: both task-state\.json and pointer exist at .+",
     )
-    if any(
-        re.fullmatch(pattern, line)
-        for pattern in path_error_patterns
-        for line in lines
+    if len(lines) == 1 and any(
+        re.fullmatch(pattern, lines[0]) for pattern in path_error_patterns
     ):
         return "error", "task_or_root_unresolved", []
 
     # Only state-core's anchored stderr grammar is a business-gate rejection.
-    if any(
-        re.fullmatch(
+    if len(lines) == 1 and re.fullmatch(
             r"error: cannot reach done from .+; transition to verifying first",
-            line,
-        )
-        for line in lines
-    ):
+            lines[0],
+        ):
         return "blocked", "phase_not_verifying", []
 
-    blocker_line = next(
-        (
-            match.group(1)
-            for line in lines
-            if (match := re.fullmatch(
-                r"error: cannot (?:advance to|reach) done; blockers: (.+)", line
-            ))
-        ),
-        None,
+    blocker_match = (
+        re.fullmatch(
+            r"error: cannot (?:advance to|reach) done; blockers: (.+)", lines[0]
+        )
+        if len(lines) == 1
+        else None
     )
+    blocker_line = blocker_match.group(1) if blocker_match else None
     if blocker_line is not None:
         after = blocker_line.strip()
         blockers: list[str] = []
@@ -348,10 +342,26 @@ def closeout_task(
                               hint="closeout exited 0 but stdout was not a JSON object")
 
     completion_ref = payload.get("completion_ref")
-    if not isinstance(completion_ref, str) or not completion_ref.startswith(_COMPLETION_PREFIX):
+    revision_sha256 = payload.get("revision_sha256")
+    state_path = payload.get("state_path")
+    closeout_contract_errors: list[str] = []
+    if payload.get("status") != "done":
+        closeout_contract_errors.append("closeout status is not done")
+    if payload.get("task_id") != task_id:
+        closeout_contract_errors.append("closeout task_id mismatch")
+    if not isinstance(completion_ref, str) or not re.fullmatch(
+        rf"{re.escape(_COMPLETION_PREFIX)}[0-9a-f]{{64}}", completion_ref
+    ):
+        closeout_contract_errors.append("closeout completion_ref is invalid")
+    if not isinstance(revision_sha256, str) or not _SHA256_RE.fullmatch(revision_sha256):
+        closeout_contract_errors.append("closeout revision_sha256 is invalid")
+    if not isinstance(state_path, str) or not state_path.strip():
+        closeout_contract_errors.append("closeout state_path is invalid")
+    if closeout_contract_errors:
         return CloseoutResult(status="error", task_id=task_id, root=root,
-                              reason="invalid_completion_ref",
-                              hint="closeout succeeded but emitted no valid completion_ref")
+                              reason="closeout_payload_contract_failed",
+                              blockers=closeout_contract_errors,
+                              hint="closeout exited 0 but its receipt payload was incomplete or contradictory")
 
     verify_args = ["verify-completion", "--task-id", task_id, "--root", root,
                    "--completion-ref", completion_ref]
@@ -379,7 +389,13 @@ def closeout_task(
         )
 
     if vproc.returncode != 0:
-        errors = vpayload.get("errors", []) if isinstance(vpayload, dict) else []
+        raw_errors = vpayload.get("errors") if isinstance(vpayload, dict) else None
+        errors = (
+            raw_errors
+            if isinstance(raw_errors, list)
+            and all(isinstance(item, str) for item in raw_errors)
+            else []
+        )
         return CloseoutResult(
             status="verify_failed",
             task_id=task_id,
@@ -400,7 +416,11 @@ def closeout_task(
         if vpayload.get("completion_ref") != completion_ref:
             contract_errors.append("verify-completion completion_ref mismatch")
         errors = vpayload.get("errors")
-        if errors not in (None, []):
+        if not isinstance(errors, list) or not all(
+            isinstance(item, str) for item in errors
+        ):
+            contract_errors.append("verify-completion errors must be an array of strings")
+        elif errors:
             contract_errors.append("verify-completion returned errors")
     if contract_errors:
         return CloseoutResult(
@@ -417,8 +437,8 @@ def closeout_task(
         task_id=task_id,
         root=root,
         completion_ref=completion_ref,
-        revision_sha256=payload.get("revision_sha256"),
-        state_path=payload.get("state_path"),
+        revision_sha256=revision_sha256,
+        state_path=state_path,
         verified=True,
     )
 

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -64,6 +64,23 @@ _PICKUP_DEFAULT_REL = ".agent.local/continuity/pickup.json"
 _CLOSEOUT_TIMEOUT_DEFAULT = 60  # seconds
 
 
+class _DuplicateJsonKey(ValueError):
+    """Raised when an untrusted JSON object repeats a member name."""
+
+
+def _strict_json_loads(raw: str) -> Any:
+    """Parse JSON while rejecting contradictory duplicate object members."""
+    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise _DuplicateJsonKey(f"duplicate JSON member: {key}")
+            result[key] = value
+        return result
+
+    return json.loads(raw, object_pairs_hook=unique_object)
+
+
 @dataclass
 class CloseoutResult:
     """Machine-readable result of one closeout attempt.
@@ -204,7 +221,16 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
     masquerade as a business gate blocker (TB-46 host-review P1-2).
     """
     text = stderr or ""
-    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    # Preserve the producer envelope byte-for-byte except for one optional
+    # terminal line ending from print(..., file=sys.stderr). Leading/trailing
+    # spaces, extra blank lines, and embedded CR/LF are wrapper-tainted.
+    if text.endswith("\r\n"):
+        line = text[:-2]
+    elif text.endswith("\n"):
+        line = text[:-1]
+    else:
+        line = text
+    canonical_line = line if line and "\n" not in line and "\r" not in line else None
 
     # Resolution/corruption errors take precedence. A task id or path is
     # untrusted text and may itself contain words from the blocker grammar.
@@ -215,29 +241,29 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
         r"error: pointer chain detected at .+ — corruption",
         r"error: corruption: both task-state\.json and pointer exist at .+",
     )
-    if len(lines) == 1 and any(
-        re.fullmatch(pattern, lines[0]) for pattern in path_error_patterns
+    if canonical_line is not None and any(
+        re.fullmatch(pattern, canonical_line) for pattern in path_error_patterns
     ):
         return "error", "task_or_root_unresolved", []
 
     # Only state-core's anchored stderr grammar is a business-gate rejection.
-    if len(lines) == 1 and re.fullmatch(
+    if canonical_line is not None and re.fullmatch(
             r"error: cannot reach done from (?:intake|scoped|executing|blocked); "
             r"transition to verifying first",
-            lines[0],
+            canonical_line,
         ):
         return "blocked", "phase_not_verifying", []
 
     blocker_match = (
         re.fullmatch(
-            r"error: cannot (?:advance to|reach) done; blockers: (.+)", lines[0]
+            r"error: cannot (?:advance to|reach) done; blockers: (.+)", canonical_line
         )
-        if len(lines) == 1
+        if canonical_line is not None
         else None
     )
     blocker_line = blocker_match.group(1) if blocker_match else None
     if blocker_line is not None:
-        after = blocker_line.strip()
+        after = blocker_line
         parsed: object = None
         try:
             parsed = ast.literal_eval(after)
@@ -335,7 +361,7 @@ def closeout_task(
             ),
         )
 
-    if proc.stderr.strip():
+    if proc.stderr:
         return CloseoutResult(
             status="error",
             task_id=task_id,
@@ -343,14 +369,14 @@ def closeout_task(
             reason="closeout_success_stderr",
             hint=(
                 "closeout exited 0 but emitted stderr; success envelope is contradictory "
-                f"(state-core stderr: {proc.stderr.strip()})"
+                f"(state-core stderr: {proc.stderr!r})"
             ),
         )
 
     # success path: parse + verify completion_ref
     try:
-        payload = json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
+        payload = _strict_json_loads(proc.stdout)
+    except (json.JSONDecodeError, _DuplicateJsonKey) as exc:
         return CloseoutResult(status="error", task_id=task_id, root=root,
                               reason="invalid_closeout_stdout",
                               hint=f"closeout exited 0 but stdout was not JSON: {exc}")
@@ -407,19 +433,19 @@ def closeout_task(
                               completion_ref=completion_ref,
                               reason="verify_invoke_failed", hint=str(exc))
 
-    if vproc.returncode == 0 and vproc.stderr.strip():
+    if vproc.returncode == 0 and vproc.stderr:
         return CloseoutResult(
             status="verify_failed",
             task_id=task_id,
             root=root,
             completion_ref=completion_ref,
             reason="verify_success_stderr",
-            blockers=[vproc.stderr.strip()],
+            blockers=[repr(vproc.stderr)],
         )
 
     try:
-        vpayload = json.loads(vproc.stdout)
-    except json.JSONDecodeError as exc:
+        vpayload = _strict_json_loads(vproc.stdout)
+    except (json.JSONDecodeError, _DuplicateJsonKey) as exc:
         return CloseoutResult(
             status="verify_failed",
             task_id=task_id,
@@ -450,6 +476,8 @@ def closeout_task(
     if not isinstance(vpayload, dict):
         contract_errors.append("verify-completion payload must be an object")
     else:
+        if set(vpayload) != {"status", "task_id", "completion_ref", "errors"}:
+            contract_errors.append("verify-completion payload keys are not canonical")
         if vpayload.get("status") != "passed":
             contract_errors.append("verify-completion status is not passed")
         if vpayload.get("task_id") != task_id:

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -40,8 +40,10 @@ task_id / root resolution priority
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import os
+import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
@@ -200,26 +202,60 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
     masquerade as a business gate blocker (TB-46 host-review P1-2).
     """
     text = stderr or ""
-    # identified phase rejection → legitimate "not ready yet"
-    if "transition to verifying first" in text or "cannot reach done from" in text:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+
+    # Resolution/corruption errors take precedence. A task id or path is
+    # untrusted text and may itself contain words from the blocker grammar.
+    path_error_markers = (
+        "pointer target does not exist:",
+        "has empty target",
+        "pointer chain detected",
+        "corruption: both task-state.json and pointer exist",
+    )
+    if (
+        ("No such file or directory" in text and ".state/" in text)
+        or any(marker in text for marker in path_error_markers)
+    ):
+        return "error", "task_or_root_unresolved", []
+
+    # Only state-core's anchored stderr grammar is a business-gate rejection.
+    if any(
+        re.fullmatch(
+            r"error: cannot reach done from .+; transition to verifying first",
+            line,
+        )
+        for line in lines
+    ):
         return "blocked", "phase_not_verifying", []
-    # identified done-gate content rejection → blocked with the real blockers
-    if "blockers:" in text:
-        after = text.split("blockers:", 1)[1].strip()
+
+    blocker_line = next(
+        (
+            match.group(1)
+            for line in lines
+            if (match := re.fullmatch(
+                r"error: cannot (?:advance to|reach) done; blockers: (.+)", line
+            ))
+        ),
+        None,
+    )
+    if blocker_line is not None:
+        after = blocker_line.strip()
         blockers: list[str] = []
         try:
             parsed = json.loads(after)
-            if isinstance(parsed, list):
-                blockers = [str(x) for x in parsed]
+            if isinstance(parsed, list) and all(isinstance(x, str) for x in parsed):
+                blockers = parsed
         except json.JSONDecodeError:
-            stripped = after.strip("[]' \n")
-            blockers = [
-                p.strip().strip("'\"") for p in stripped.split(",") if p.strip()
-            ] or [after]
+            try:
+                parsed = ast.literal_eval(after)
+                if isinstance(parsed, list) and all(isinstance(x, str) for x in parsed):
+                    blockers = parsed
+            except (SyntaxError, ValueError):
+                pass
+        # Never comma-split an opaque blocker: commas are valid detail text.
+        if not blockers:
+            blockers = [after]
         return "blocked", "done_gate_blockers", blockers
-    # missing task-state.json / wrong root / bad or missing DIRECT_TO pointer
-    if "No such file or directory" in text and ".state/" in text:
-        return "error", "task_or_root_unresolved", []
     # any other non-zero (unknown CLI error, state JSON corruption, etc.)
     return "error", "cli_rejected_unknown", [text.strip()] if text.strip() else []
 
@@ -304,6 +340,10 @@ def closeout_task(
         return CloseoutResult(status="error", task_id=task_id, root=root,
                               reason="invalid_closeout_stdout",
                               hint=f"closeout exited 0 but stdout was not JSON: {exc}")
+    if not isinstance(payload, dict):
+        return CloseoutResult(status="error", task_id=task_id, root=root,
+                              reason="invalid_closeout_stdout",
+                              hint="closeout exited 0 but stdout was not a JSON object")
 
     completion_ref = payload.get("completion_ref")
     if not isinstance(completion_ref, str) or not completion_ref.startswith(_COMPLETION_PREFIX):
@@ -324,12 +364,20 @@ def closeout_task(
                               completion_ref=completion_ref,
                               reason="verify_invoke_failed", hint=str(exc))
 
+    try:
+        vpayload = json.loads(vproc.stdout)
+    except json.JSONDecodeError as exc:
+        return CloseoutResult(
+            status="verify_failed",
+            task_id=task_id,
+            root=root,
+            completion_ref=completion_ref,
+            reason="invalid_verify_stdout",
+            blockers=[f"verify-completion stdout was not JSON: {exc}"],
+        )
+
     if vproc.returncode != 0:
-        try:
-            vpayload = json.loads(vproc.stdout)
-            errors = vpayload.get("errors", []) if isinstance(vpayload, dict) else []
-        except json.JSONDecodeError:
-            errors = [vproc.stderr.strip()] if vproc.stderr.strip() else []
+        errors = vpayload.get("errors", []) if isinstance(vpayload, dict) else []
         return CloseoutResult(
             status="verify_failed",
             task_id=task_id,
@@ -337,6 +385,29 @@ def closeout_task(
             completion_ref=completion_ref,
             reason="completion_ref_did_not_read_back",
             blockers=[str(e) for e in errors] or ["verify-completion returned non-zero"],
+        )
+
+    contract_errors: list[str] = []
+    if not isinstance(vpayload, dict):
+        contract_errors.append("verify-completion payload must be an object")
+    else:
+        if vpayload.get("status") != "passed":
+            contract_errors.append("verify-completion status is not passed")
+        if vpayload.get("task_id") != task_id:
+            contract_errors.append("verify-completion task_id mismatch")
+        if vpayload.get("completion_ref") != completion_ref:
+            contract_errors.append("verify-completion completion_ref mismatch")
+        errors = vpayload.get("errors")
+        if errors not in (None, []):
+            contract_errors.append("verify-completion returned errors")
+    if contract_errors:
+        return CloseoutResult(
+            status="verify_failed",
+            task_id=task_id,
+            root=root,
+            completion_ref=completion_ref,
+            reason="verify_payload_contract_failed",
+            blockers=contract_errors,
         )
 
     return CloseoutResult(

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -221,7 +221,8 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
 
     # Only state-core's anchored stderr grammar is a business-gate rejection.
     if len(lines) == 1 and re.fullmatch(
-            r"error: cannot reach done from .+; transition to verifying first",
+            r"error: cannot reach done from (?:intake|scoped|executing|blocked); "
+            r"transition to verifying first",
             lines[0],
         ):
         return "blocked", "phase_not_verifying", []
@@ -236,22 +237,25 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
     blocker_line = blocker_match.group(1) if blocker_match else None
     if blocker_line is not None:
         after = blocker_line.strip()
-        blockers: list[str] = []
+        parsed: object = None
         try:
             parsed = json.loads(after)
-            if isinstance(parsed, list) and all(isinstance(x, str) for x in parsed):
-                blockers = parsed
         except json.JSONDecodeError:
             try:
                 parsed = ast.literal_eval(after)
-                if isinstance(parsed, list) and all(isinstance(x, str) for x in parsed):
-                    blockers = parsed
             except (SyntaxError, ValueError):
-                pass
-        # Never comma-split an opaque blocker: commas are valid detail text.
-        if not blockers:
-            blockers = [after]
-        return "blocked", "done_gate_blockers", blockers
+                parsed = None
+        if (
+            isinstance(parsed, list)
+            and parsed
+            and all(isinstance(item, str) and item.strip() for item in parsed)
+        ):
+            # Never comma-split blocker details: commas are valid detail text.
+            return "blocked", "done_gate_blockers", parsed
+        # Canonical state-core always emits a non-empty list[str]. A matching
+        # prefix with malformed suffix is unknown CLI/wrapper output, not proof
+        # of a business blocker.
+        return "error", "cli_rejected_unknown", [text.strip()]
     # any other non-zero (unknown CLI error, state JSON corruption, etc.)
     return "error", "cli_rejected_unknown", [text.strip()] if text.strip() else []
 

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import os
 import re
@@ -239,17 +240,18 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
         after = blocker_line.strip()
         parsed: object = None
         try:
-            parsed = json.loads(after)
-        except json.JSONDecodeError:
-            try:
-                parsed = ast.literal_eval(after)
-            except (SyntaxError, ValueError):
-                parsed = None
+            parsed = ast.literal_eval(after)
+        except (SyntaxError, ValueError):
+            parsed = None
         if (
             isinstance(parsed, list)
             and parsed
             and all(isinstance(item, str) and item.strip() for item in parsed)
+            and after == repr(parsed)
         ):
+            # state-core emits Python's canonical list repr. Merely equivalent
+            # Python literals (comments, trailing commas, implicit string
+            # concatenation) are wrapper-tainted, not business-gate evidence.
             # Never comma-split blocker details: commas are valid detail text.
             return "blocked", "done_gate_blockers", parsed
         # Canonical state-core always emits a non-empty list[str]. A matching
@@ -333,6 +335,18 @@ def closeout_task(
             ),
         )
 
+    if proc.stderr.strip():
+        return CloseoutResult(
+            status="error",
+            task_id=task_id,
+            root=root,
+            reason="closeout_success_stderr",
+            hint=(
+                "closeout exited 0 but emitted stderr; success envelope is contradictory "
+                f"(state-core stderr: {proc.stderr.strip()})"
+            ),
+        )
+
     # success path: parse + verify completion_ref
     try:
         payload = json.loads(proc.stdout)
@@ -349,6 +363,11 @@ def closeout_task(
     revision_sha256 = payload.get("revision_sha256")
     state_path = payload.get("state_path")
     closeout_contract_errors: list[str] = []
+    expected_payload_keys = {
+        "status", "task_id", "completion_ref", "revision_sha256", "state_path",
+    }
+    if set(payload) != expected_payload_keys:
+        closeout_contract_errors.append("closeout payload keys are not canonical")
     if payload.get("status") != "done":
         closeout_contract_errors.append("closeout status is not done")
     if payload.get("task_id") != task_id:
@@ -359,6 +378,14 @@ def closeout_task(
         closeout_contract_errors.append("closeout completion_ref is invalid")
     if not isinstance(revision_sha256, str) or not _SHA256_RE.fullmatch(revision_sha256):
         closeout_contract_errors.append("closeout revision_sha256 is invalid")
+    elif isinstance(completion_ref, str):
+        expected_ref = _COMPLETION_PREFIX + hashlib.sha256(
+            f"{task_id}:{revision_sha256}".encode("utf-8")
+        ).hexdigest()
+        if completion_ref != expected_ref:
+            closeout_contract_errors.append(
+                "closeout completion_ref does not bind task_id and revision_sha256"
+            )
     if not isinstance(state_path, str) or not state_path.strip():
         closeout_contract_errors.append("closeout state_path is invalid")
     if closeout_contract_errors:
@@ -379,6 +406,16 @@ def closeout_task(
         return CloseoutResult(status="verify_failed", task_id=task_id, root=root,
                               completion_ref=completion_ref,
                               reason="verify_invoke_failed", hint=str(exc))
+
+    if vproc.returncode == 0 and vproc.stderr.strip():
+        return CloseoutResult(
+            status="verify_failed",
+            task_id=task_id,
+            root=root,
+            completion_ref=completion_ref,
+            reason="verify_success_stderr",
+            blockers=[vproc.stderr.strip()],
+        )
 
     try:
         vpayload = json.loads(vproc.stdout)
@@ -442,7 +479,12 @@ def closeout_task(
         root=root,
         completion_ref=completion_ref,
         revision_sha256=revision_sha256,
-        state_path=state_path,
+        # state_path may legitimately resolve through DIRECT_TO/MOVED_TO to a
+        # different root. The adapter cannot bind that path without duplicating
+        # state-core pointer resolution, so it deliberately does not surface it
+        # as trusted receipt evidence. task/revision/ref are cryptographically
+        # cross-bound above and then verified by state-core read-back.
+        state_path=None,
         verified=True,
     )
 

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -206,15 +206,17 @@ def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
 
     # Resolution/corruption errors take precedence. A task id or path is
     # untrusted text and may itself contain words from the blocker grammar.
-    path_error_markers = (
-        "pointer target does not exist:",
-        "has empty target",
-        "pointer chain detected",
-        "corruption: both task-state.json and pointer exist",
+    path_error_patterns = (
+        r"(?:error|FileNotFoundError): \[Errno 2\] No such file or directory: ['\"].*[/\\]\.state[/\\].*['\"]",
+        r"error: pointer target does not exist: .+ \(from (?:DIRECT_TO|MOVED_TO) at .+\)",
+        r"error: pointer (?:DIRECT_TO|MOVED_TO) at .+ has empty target",
+        r"error: pointer chain detected at .+ — corruption",
+        r"error: corruption: both task-state\.json and pointer exist at .+",
     )
-    if (
-        ("No such file or directory" in text and ".state/" in text)
-        or any(marker in text for marker in path_error_markers)
+    if any(
+        re.fullmatch(pattern, line)
+        for pattern in path_error_patterns
+        for line in lines
     ):
         return "error", "task_or_root_unresolved", []
 

--- a/mms_state_core_closeout.py
+++ b/mms_state_core_closeout.py
@@ -15,7 +15,10 @@ What this module is
   as a global hard hook on any session.
 - Deterministic failure: missing task id / missing root / stale completion /
   done-gate rejection / CLI unavailable each produce a distinct non-zero exit;
-  error/abort/timeout never infer ``done`` or ``blocked``.
+  error/abort/timeout never infer ``done`` or ``blocked``. Only *identified*
+  phase / done-gate rejections are reported as ``blocked``; a missing task,
+  wrong root, or bad DIRECT_TO pointer is reported as ``error`` so a path
+  failure can never masquerade as a business gate blocker.
 
 Hard boundaries (frozen by the consume contract)
 -------------------------------------------------
@@ -89,7 +92,8 @@ class CloseoutResult:
         }.get(self.status, EXIT_ERROR)
 
     def to_compact_json(self) -> str:
-        payload = {k: v for k, v in asdict(self).items() if v not in (None, [], False)}
+        # keep booleans (verified flag is meaningful); drop only None / empty lists
+        payload = {k: v for k, v in asdict(self).items() if v is not None and v != []}
         return json.dumps(payload, ensure_ascii=False, sort_keys=True)
 
 
@@ -187,24 +191,37 @@ def resolve_root(*, argv_value: str | None = None,
 # Core closeout
 # ──────────────────────────────────────────────────────────────────────────────
 
-def _parse_blockers(stderr: str) -> tuple[str, list[str]]:
-    """Classify a non-zero ``closeout`` stderr into (reason, blockers)."""
+def _classify_closeout_failure(stderr: str) -> tuple[str, str, list[str]]:
+    """Classify a non-zero ``closeout`` stderr into (status, reason, blockers).
+
+    Only *identified* phase / done-gate rejections are ``blocked``. Everything
+    else (missing task-state.json, wrong root, bad DIRECT_TO pointer, JSON parse
+    errors, unknown CLI errors) is ``error`` so a path/pointer failure can never
+    masquerade as a business gate blocker (TB-46 host-review P1-2).
+    """
     text = stderr or ""
+    # identified phase rejection → legitimate "not ready yet"
     if "transition to verifying first" in text or "cannot reach done from" in text:
-        return "phase_not_verifying", []
+        return "blocked", "phase_not_verifying", []
+    # identified done-gate content rejection → blocked with the real blockers
     if "blockers:" in text:
-        # state-core prints e.g.  error: cannot advance to done; blockers: ['a', 'b']
         after = text.split("blockers:", 1)[1].strip()
+        blockers: list[str] = []
         try:
             parsed = json.loads(after)
             if isinstance(parsed, list):
-                return "done_gate_blockers", [str(x) for x in parsed]
+                blockers = [str(x) for x in parsed]
         except json.JSONDecodeError:
             stripped = after.strip("[]' \n")
-            return "done_gate_blockers", [
+            blockers = [
                 p.strip().strip("'\"") for p in stripped.split(",") if p.strip()
             ] or [after]
-    return "cli_error", [text.strip()] if text.strip() else []
+        return "blocked", "done_gate_blockers", blockers
+    # missing task-state.json / wrong root / bad or missing DIRECT_TO pointer
+    if "No such file or directory" in text and ".state/" in text:
+        return "error", "task_or_root_unresolved", []
+    # any other non-zero (unknown CLI error, state JSON corruption, etc.)
+    return "error", "cli_rejected_unknown", [text.strip()] if text.strip() else []
 
 
 def _run_cli(cli: Path, args: list[str], *, timeout: int) -> subprocess.CompletedProcess[str]:
@@ -224,14 +241,14 @@ def closeout_task(
     cli: Path | None = None,
     actor: str | None = None,
     at: str | None = None,
-    verify: bool = True,
     timeout: int = _CLOSEOUT_TIMEOUT_DEFAULT,
 ) -> CloseoutResult:
     """Run one explicit closeout against state-core and read-back the result.
 
-    The adapter performs no direct ``task-state.json`` access. On success it
-    read-backs ``completion_ref`` via ``verify-completion`` so a stale/tampered
-    receipt cannot be reported as done.
+    The adapter performs no direct ``task-state.json`` access. A successful
+    closeout is **always** followed by a ``verify-completion`` read-back — there
+    is no opt-out, so no code path can emit ``status=done`` without a verified
+    ``completion_ref`` (TB-46 consume contract; host-review P1-1).
     """
     resolved_cli = cli or resolve_state_core_cli()
     if resolved_cli is None:
@@ -258,14 +275,26 @@ def closeout_task(
                               reason="cli_invoke_failed", hint=str(exc))
 
     if proc.returncode != 0:
-        reason, blockers = _parse_blockers(proc.stderr)
+        status, reason, blockers = _classify_closeout_failure(proc.stderr)
+        if status == "blocked":
+            return CloseoutResult(
+                status="blocked",
+                task_id=task_id,
+                root=root,
+                reason=reason,
+                blockers=blockers,
+                hint="phase preserved; resolve done-gate blockers or advance to verifying before retrying",
+            )
+        # path / pointer / CLI exception — NOT a business gate blocker
         return CloseoutResult(
-            status="blocked",
+            status="error",
             task_id=task_id,
             root=root,
             reason=reason,
-            blockers=blockers,
-            hint="phase preserved; resolve blockers or advance to verifying before retrying",
+            hint=(
+                "no state inferred; check task id / root / DIRECT_TO pointer "
+                f"(state-core stderr: {proc.stderr.strip() or 'empty'})"
+            ),
         )
 
     # success path: parse + verify completion_ref
@@ -281,17 +310,6 @@ def closeout_task(
         return CloseoutResult(status="error", task_id=task_id, root=root,
                               reason="invalid_completion_ref",
                               hint="closeout succeeded but emitted no valid completion_ref")
-
-    if not verify:
-        return CloseoutResult(
-            status="done",
-            task_id=task_id,
-            root=root,
-            completion_ref=completion_ref,
-            revision_sha256=payload.get("revision_sha256"),
-            state_path=payload.get("state_path"),
-            verified=False,
-        )
 
     verify_args = ["verify-completion", "--task-id", task_id, "--root", root,
                    "--completion-ref", completion_ref]
@@ -352,8 +370,6 @@ def _build_parser(command_name: str) -> argparse.ArgumentParser:
     p.add_argument("--at", help="ISO timestamp recorded on the completion receipt")
     p.add_argument("--pickup", default=_PICKUP_DEFAULT_REL,
                    help=f"handover pickup.json path (default: {_PICKUP_DEFAULT_REL})")
-    p.add_argument("--no-verify", action="store_true",
-                   help="skip completion_ref read-back (NOT recommended for real closeout)")
     p.add_argument("--timeout", type=int, default=_CLOSEOUT_TIMEOUT_DEFAULT,
                    help=f"per-CLI-invocation timeout in seconds (default {_CLOSEOUT_TIMEOUT_DEFAULT})")
     p.add_argument("--json", dest="as_json", action="store_true", default=True,
@@ -417,7 +433,6 @@ def handle_closeout_command(argv: list[str], *, command_name: str = "mms") -> in
         cli=resolved_cli,
         actor=args.actor,
         at=args.at,
-        verify=not args.no_verify,
         timeout=args.timeout,
     )
     _emit(result, args.as_json)

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -163,6 +163,67 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         )
         self.assertEqual(adapter.EXIT_CLI_UNAVAILABLE, rc)
 
+    # ── P1-2: path / pointer failures must NOT masquerade as done-gate blocked ──
+    def test_missing_task_state_is_error_not_blocked(self) -> None:
+        """A task whose task-state.json does not exist is a path failure, not a
+        business gate blocker. Must be ``error`` (exit 4), never ``blocked``."""
+        with tempfile.TemporaryDirectory() as root:
+            result = adapter.closeout_task(
+                task_id="never-created", root=str(root), cli=self.cli,
+            )
+            self.assertEqual("error", result.status, result.to_compact_json())
+            self.assertEqual("task_or_root_unresolved", result.reason)
+            self.assertEqual([], result.blockers)
+            self.assertEqual(adapter.EXIT_ERROR, result.exit_code())
+
+    def test_wrong_root_is_error_not_blocked(self) -> None:
+        """An explicit root with no .state tree is a path failure → error, not blocked."""
+        with tempfile.TemporaryDirectory() as empty:
+            result = adapter.closeout_task(
+                task_id="anything", root=str(empty), cli=self.cli,
+            )
+            self.assertEqual("error", result.status)
+            self.assertEqual("task_or_root_unresolved", result.reason)
+            self.assertNotEqual(adapter.EXIT_BLOCKED, result.exit_code())
+
+    def test_direct_to_pointer_business_root_succeeds(self) -> None:
+        """business root + valid DIRECT_TO pointer must close out successfully.
+        pickup.root / launch roots that only hold a pointer are legitimate."""
+        with tempfile.TemporaryDirectory() as real_root, tempfile.TemporaryDirectory() as launch_root:
+            _make_closeout_ready_task(self.cli, Path(real_root), "dt-task")
+            sync = _run_cli(
+                self.cli, "sync-pointer", "--launch", str(launch_root),
+                "--task-id", "dt-task", "--root", str(real_root),
+                "--at", "2026-08-14T00:00:00Z", root=Path(real_root),
+            )
+            self.assertEqual(0, sync.returncode, sync.stderr)
+            # launch root has NO task-state.json, only a DIRECT_TO pointer
+            self.assertFalse(
+                (Path(launch_root) / ".state" / "dt-task" / "task-state.json").exists()
+            )
+            result = adapter.closeout_task(
+                task_id="dt-task", root=str(launch_root), cli=self.cli,
+            )
+            self.assertEqual("done", result.status, result.to_compact_json())
+            self.assertTrue(result.verified)
+
+    def test_done_result_compact_json_keeps_verified_flag(self) -> None:
+        """Regression (host-review P1-1): compact JSON used to drop
+        ``verified=false``. A done result must surface ``verified: true``."""
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            _make_closeout_ready_task(self.cli, root_path, "json-task")
+            result = adapter.closeout_task(
+                task_id="json-task", root=str(root_path), cli=self.cli,
+            )
+            self.assertEqual("done", result.status)
+            compact = result.to_compact_json()
+            self.assertIn('"verified": true', compact)
+            self.assertIn('"completion_ref"', compact)
+        # and a non-done result must still surface verified:false explicitly
+        blocked = adapter.CloseoutResult(status="missing_task_id")
+        self.assertIn('"verified": false', blocked.to_compact_json())
+
 
 class CloseoutBoundaryStaticTests(unittest.TestCase):
     """Static + behavioral invariants that prove the binding is opt-in only and
@@ -239,6 +300,20 @@ class CloseoutBoundaryStaticTests(unittest.TestCase):
         for forbidden in ("transcript", "chat_history", "messages", "prompt"):
             self.assertNotIn(forbidden, src,
                              f"adapter must not parse {forbidden} (no chat-text guessing)")
+
+    # ── P1-1: no verify escape hatch (done must always read-back completion_ref) ──
+    def test_binding_rejects_no_verify_flag(self) -> None:
+        """--no-verify must not exist on the formal mms closeout binding."""
+        import inspect
+        # the library function has no verify parameter at all
+        self.assertNotIn("verify", inspect.signature(adapter.closeout_task).parameters)
+        # the binding parser rejects --no-verify
+        with self.assertRaises(SystemExit):
+            adapter.handle_closeout_command(
+                ["--task-id", "t", "--root", "/tmp/x", "--no-verify"],
+                command_name="mms",
+            )
+
 
 
 class PickupPointerResolutionTests(unittest.TestCase):

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -297,6 +297,37 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         self.assertEqual("done_gate_blockers", reason)
         self.assertEqual(["missing alpha, beta"], blockers)
 
+    def test_path_marker_text_inside_real_blocker_remains_blocked(self) -> None:
+        marker_details = (
+            "pointer target does not exist: /tmp/x",
+            "pointer DIRECT_TO at /tmp/x has empty target",
+            "pointer chain detected at /tmp/x — corruption",
+            "corruption: both task-state.json and pointer exist at /tmp/x",
+        )
+        for detail in marker_details:
+            with self.subTest(detail=detail):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    f"error: cannot reach done; blockers: ['{detail}']"
+                )
+                self.assertEqual("blocked", status)
+                self.assertEqual("done_gate_blockers", reason)
+                self.assertEqual([detail], blockers)
+
+    def test_canonical_pointer_errors_match_only_full_stderr_lines(self) -> None:
+        errors = (
+            "error: pointer target does not exist: /tmp/x/task-state.json "
+            "(from DIRECT_TO at /tmp/launch)",
+            "error: pointer DIRECT_TO at /tmp/launch has empty target",
+            "error: pointer chain detected at /tmp/x — corruption",
+            "error: corruption: both task-state.json and pointer exist at /tmp/x",
+        )
+        for stderr in errors:
+            with self.subTest(stderr=stderr):
+                status, reason, blockers = adapter._classify_closeout_failure(stderr)
+                self.assertEqual("error", status)
+                self.assertEqual("task_or_root_unresolved", reason)
+                self.assertEqual([], blockers)
+
     def test_unanchored_blocker_keyword_is_unknown_error(self) -> None:
         status, reason, blockers = adapter._classify_closeout_failure(
             "unexpected wrapper failure blockers: ['not authoritative']"

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -229,7 +229,13 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         """Exit 0 alone is not proof: the read-back payload must bind the
         requested task and the exact completion receipt and explicitly pass."""
         ref = "completion:sha256:" + "a" * 64
-        close_payload = json.dumps({"completion_ref": ref})
+        close_payload = json.dumps({
+            "status": "done",
+            "task_id": "task-a",
+            "completion_ref": ref,
+            "revision_sha256": "c" * 64,
+            "state_path": "/tmp/root/.state/task-a/task-state.json",
+        })
         invalid_verify_payloads = {
             "empty": "",
             "malformed": "not-json",
@@ -246,6 +252,21 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 "status": "passed", "task_id": "task-a",
                 "completion_ref": "completion:sha256:" + "b" * 64,
                 "errors": [],
+            }),
+            "missing-errors": json.dumps({
+                "status": "passed", "task_id": "task-a", "completion_ref": ref,
+            }),
+            "null-errors": json.dumps({
+                "status": "passed", "task_id": "task-a",
+                "completion_ref": ref, "errors": None,
+            }),
+            "scalar-errors": json.dumps({
+                "status": "passed", "task_id": "task-a",
+                "completion_ref": ref, "errors": "none",
+            }),
+            "mixed-errors": json.dumps({
+                "status": "passed", "task_id": "task-a",
+                "completion_ref": ref, "errors": [7],
             }),
         }
         for label, verify_stdout in invalid_verify_payloads.items():
@@ -274,6 +295,70 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         self.assertEqual("error", result.status)
         self.assertEqual("invalid_closeout_stdout", result.reason)
         self.assertFalse(result.verified)
+
+    def test_closeout_exit_zero_requires_full_receipt_payload_contract(self) -> None:
+        ref = "completion:sha256:" + "a" * 64
+        base = {
+            "status": "done",
+            "task_id": "task-a",
+            "completion_ref": ref,
+            "revision_sha256": "c" * 64,
+            "state_path": "/tmp/root/.state/task-a/task-state.json",
+        }
+        invalid_payloads = []
+        for key, value in (
+            ("status", "failed"),
+            ("task_id", "task-b"),
+            ("completion_ref", "completion:sha256:short"),
+            ("revision_sha256", "short"),
+            ("state_path", ""),
+        ):
+            payload = dict(base)
+            payload[key] = value
+            invalid_payloads.append(payload)
+        for missing in tuple(base):
+            payload = dict(base)
+            del payload[missing]
+            invalid_payloads.append(payload)
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                with mock.patch.object(
+                    adapter,
+                    "_run_cli",
+                    return_value=subprocess.CompletedProcess(
+                        [], 0, json.dumps(payload), ""
+                    ),
+                ):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("error", result.status)
+                self.assertEqual("closeout_payload_contract_failed", result.reason)
+                self.assertFalse(result.verified)
+
+    def test_nonzero_verify_with_malformed_errors_never_crashes_or_splits(self) -> None:
+        ref = "completion:sha256:" + "a" * 64
+        close_payload = json.dumps({
+            "status": "done", "task_id": "task-a", "completion_ref": ref,
+            "revision_sha256": "c" * 64,
+            "state_path": "/tmp/root/.state/task-a/task-state.json",
+        })
+        for errors in (None, "failure", 7, {"detail": "failure"}, [7]):
+            with self.subTest(errors=errors):
+                calls = [
+                    subprocess.CompletedProcess([], 0, close_payload, ""),
+                    subprocess.CompletedProcess(
+                        [], 1, json.dumps({"status": "failed", "errors": errors}), ""
+                    ),
+                ]
+                with mock.patch.object(adapter, "_run_cli", side_effect=calls):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("verify_failed", result.status)
+                self.assertEqual(
+                    ["verify-completion returned non-zero"], result.blockers
+                )
 
     def test_failure_classifier_does_not_trust_keywords_inside_missing_path(self) -> None:
         malicious_paths = (
@@ -335,6 +420,19 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         self.assertEqual("error", status)
         self.assertEqual("cli_rejected_unknown", reason)
         self.assertTrue(blockers)
+
+    def test_multiline_wrapper_failure_cannot_become_business_blocked(self) -> None:
+        for gate_line in (
+            "error: cannot reach done from intake; transition to verifying first",
+            "error: cannot reach done; blockers: ['missing evidence']",
+        ):
+            with self.subTest(gate_line=gate_line):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    "fatal: wrapper transport failed\n" + gate_line
+                )
+                self.assertEqual("error", status)
+                self.assertEqual("cli_rejected_unknown", reason)
+                self.assertTrue(blockers)
 
 
 class CloseoutBoundaryStaticTests(unittest.TestCase):

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -434,6 +434,41 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 self.assertEqual("cli_rejected_unknown", reason)
                 self.assertTrue(blockers)
 
+    def test_phase_rejection_accepts_only_canonical_nonverifying_phases(self) -> None:
+        for phase in ("intake", "scoped", "executing", "blocked"):
+            status, reason, blockers = adapter._classify_closeout_failure(
+                f"error: cannot reach done from {phase}; transition to verifying first"
+            )
+            self.assertEqual("blocked", status)
+            self.assertEqual("phase_not_verifying", reason)
+            self.assertEqual([], blockers)
+        for phase in ("banana", "verifying", "done", "intake injected"):
+            with self.subTest(phase=phase):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    f"error: cannot reach done from {phase}; transition to verifying first"
+                )
+                self.assertEqual("error", status)
+                self.assertEqual("cli_rejected_unknown", reason)
+                self.assertTrue(blockers)
+
+    def test_malformed_blocker_suffix_is_unknown_error_not_business_blocked(self) -> None:
+        malformed = (
+            "[]",
+            "['']",
+            "[7]",
+            "'scalar'",
+            "{'detail': 'x'}",
+            "['unterminated'",
+        )
+        for suffix in malformed:
+            with self.subTest(suffix=suffix):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    f"error: cannot reach done; blockers: {suffix}"
+                )
+                self.assertEqual("error", status)
+                self.assertEqual("cli_rejected_unknown", reason)
+                self.assertTrue(blockers)
+
 
 class CloseoutBoundaryStaticTests(unittest.TestCase):
     """Static + behavioral invariants that prove the binding is opt-in only and

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -1,0 +1,264 @@
+"""TB-46: cross-runner compliance test skeleton for the MMS state-core closeout
+reference binding.
+
+These cases are intentionally written against the runner-neutral adapter
+(``mms_state_core_closeout``) so that future harness bindings (Claude / Codex /
+OpenCode) reuse the **same contract suite** before being called parity-complete.
+
+What is frozen here (mirrors ``docs/runner-adapter-hooks.md`` Required Invariants):
+- explicit finish only: ordinary Stop / turn end never triggers closeout;
+- success path verifies ``completion_ref`` via read-back;
+- rejection path preserves phase and surfaces blockers;
+- task id / root missing → fail closed (no guessing);
+- adapter performs no direct ``task-state.json`` write and never calls
+  ``set --next-action/--runner/--owner``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import mms_state_core_closeout as adapter
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+
+def _resolve_cli() -> Path:
+    cli = adapter.resolve_state_core_cli()
+    if cli is None:
+        raise unittest.SkipTest("state-core src/cli.py not resolvable in this layout")
+    return cli
+
+
+def _code_without_module_docstring(path: Path) -> str:
+    """Return the module source with only the top-level docstring stripped, so
+    static assertions can target executable code (not the prose that documents
+    the forbidden actions)."""
+    import ast
+    tree = ast.parse(path.read_text("utf-8"))
+    if (
+        tree.body
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    ):
+        tree.body.pop(0)
+    return ast.unparse(tree)
+
+
+def _run_cli(cli: Path, *args: str, root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(cli), *args, "--root", str(root)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _make_closeout_ready_task(cli: Path, root: Path, task_id: str) -> None:
+    """Create a task and advance it to `verifying` so closeout can succeed."""
+    created = _run_cli(cli, "new", "--task-id", task_id, "--intent", "close it", root=root)
+    assert created.returncode == 0, created.stderr
+    advanced = _run_cli(cli, "advance", "--task-id", task_id, "--phase", "verifying", root=root)
+    assert advanced.returncode == 0, advanced.stderr
+
+
+class CloseoutAdapterContractTests(unittest.TestCase):
+    """Contract cases shared across all future runner bindings."""
+
+    def setUp(self) -> None:
+        self.cli = _resolve_cli()
+
+    # ── success path ────────────────────────────────────────────────────────
+    def test_explicit_finish_closeout_succeeds_and_verifies_completion_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            _make_closeout_ready_task(self.cli, root_path, "ok-task")
+            result = adapter.closeout_task(
+                task_id="ok-task", root=str(root_path), cli=self.cli, actor="codex",
+            )
+            self.assertEqual("done", result.status, result.to_compact_json())
+            self.assertTrue(result.completion_ref.startswith("completion:sha256:"))
+            self.assertTrue(result.verified)
+            # task is now canonical done with a real receipt
+            state = json.loads(
+                (root_path / ".state" / "ok-task" / "task-state.json").read_text("utf-8")
+            )
+            self.assertEqual("done", state["phase"])
+            self.assertEqual(
+                result.completion_ref, state["completion"]["completion_ref"]
+            )
+
+    # ── rejection paths (phase preserved, blockers visible) ─────────────────
+    def test_closeout_rejects_when_phase_not_verifying(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            created = _run_cli(self.cli, "new", "--task-id", "early", "--intent", "x", root=root_path)
+            self.assertEqual(0, created.returncode, created.stderr)
+            result = adapter.closeout_task(task_id="early", root=str(root_path), cli=self.cli)
+            self.assertEqual("blocked", result.status)
+            self.assertEqual("phase_not_verifying", result.reason)
+            self.assertNotEqual(0, result.exit_code())
+            # phase preserved: still intake, no completion receipt
+            state = json.loads(
+                (root_path / ".state" / "early" / "task-state.json").read_text("utf-8")
+            )
+            self.assertEqual("intake", state["phase"])
+            self.assertNotIn("completion", state)
+
+    def test_closeout_rejects_done_gate_blockers_and_preserves_phase(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root_path = Path(root)
+            _run_cli(self.cli, "new", "--task-id", "gated", "--intent", "x", root=root_path)
+            _run_cli(self.cli, "advance", "--task-id", "gated", "--phase", "verifying", root=root_path)
+            # an unresolved blocker is a deterministic done-gate content blocker
+            _run_cli(
+                self.cli, "add-blocker", "--task-id", "gated",
+                "--source", "audit", "--detail", "missing evidence", root=root_path,
+            )
+            before = (root_path / ".state" / "gated" / "task-state.json").read_text("utf-8")
+            result = adapter.closeout_task(task_id="gated", root=str(root_path), cli=self.cli)
+            self.assertEqual("blocked", result.status, result.to_compact_json())
+            self.assertEqual("done_gate_blockers", result.reason)
+            self.assertTrue(result.blockers, "blockers must be visible on rejection")
+            self.assertNotEqual(0, result.exit_code())
+            # phase preserved AND task-state.json byte-identical (adapter wrote nothing)
+            after = (root_path / ".state" / "gated" / "task-state.json").read_text("utf-8")
+            self.assertEqual(before, after)
+            state = json.loads(after)
+            self.assertEqual("verifying", state["phase"])
+            self.assertNotIn("completion", state)
+
+    # ── fail closed ──────────────────────────────────────────────────────────
+    def test_missing_task_id_fails_closed(self) -> None:
+        rc = adapter.handle_closeout_command(
+            ["--root", "/tmp/does-not-matter", "--pickup", "/no/such/pickup.json"],
+            command_name="mms",
+        )
+        self.assertEqual(adapter.EXIT_MISSING_SLOT, rc)
+
+    def test_missing_root_fails_closed(self) -> None:
+        # task_id resolvable via env, root deliberately absent
+        self.assertEqual(
+            "orphan", adapter.resolve_task_id(env={"STATE_CORE_TASK_ID": "orphan"})
+        )
+        rc = adapter.handle_closeout_command(
+            ["--task-id", "orphan", "--pickup", "/no/such/pickup.json"],
+            command_name="mms",
+        )
+        self.assertEqual(adapter.EXIT_MISSING_SLOT, rc)
+
+    def test_cli_unavailable_reports_distinct_status(self) -> None:
+        rc = adapter.handle_closeout_command(
+            ["--task-id", "t", "--root", "/tmp/x", "--state-core-root", "/no/such/state-core"],
+            command_name="mms",
+        )
+        self.assertEqual(adapter.EXIT_CLI_UNAVAILABLE, rc)
+
+
+class CloseoutBoundaryStaticTests(unittest.TestCase):
+    """Static + behavioral invariants that prove the binding is opt-in only and
+    does not bypass the done-gate. These run without state-core."""
+
+    def test_adapter_never_directly_writes_task_state_json(self) -> None:
+        """The only state mutation is state-core's own ``closeout`` via subprocess.
+        The adapter must not open or write any JSON file itself."""
+        code = _code_without_module_docstring(REPO_ROOT / "mms_state_core_closeout.py")
+        for prim in ("open(", ".write_text(", ".write_bytes(", "json.dump("):
+            self.assertNotIn(prim, code, f"adapter must not use file-write primitive {prim!r}")
+        # the only state write is via shelling out to the CLI's own closeout
+        self.assertIn("closeout", code)
+        self.assertIn("verify-completion", code)
+
+    def test_adapter_never_calls_forbidden_set_commands(self) -> None:
+        code = _code_without_module_docstring(REPO_ROOT / "mms_state_core_closeout.py")
+        # no subprocess arg list may build a forbidden `set` command
+        self.assertNotIn("'set'", code)
+        self.assertNotIn('"set"', code)
+        for forbidden in ("set --next-action", "set --runner", "set --owner"):
+            self.assertNotIn(forbidden, code,
+                             f"adapter must not call forbidden state-core command: {forbidden}")
+
+    def test_no_stop_or_sessionend_hook_is_wired_to_closeout(self) -> None:
+        """The reference binding must be explicit-only. No event hook
+        (Stop / SessionEnd / turn end) may invoke the closeout adapter."""
+        self.assertTrue(HOOKS_DIR.is_dir(), "hooks/ dir expected at repo root")
+        offenders: list[str] = []
+        for hook in HOOKS_DIR.iterdir():
+            if not hook.is_file():
+                continue
+            try:
+                text = hook.read_text("utf-8", errors="ignore")
+            except OSError:
+                continue
+            if "state_core_closeout" in text or "mms closeout" in text or "closeout_task" in text:
+                offenders.append(str(hook))
+        self.assertFalse(
+            offenders,
+            "closeout adapter must not be referenced by any event hook (explicit-only): "
+            + ", ".join(offenders),
+        )
+
+    def test_binding_is_dispatched_only_on_explicit_closeout_command(self) -> None:
+        core = (REPO_ROOT / "mms_core.py").read_text("utf-8")
+        # exactly one dispatch branch for the explicit command
+        self.assertIn('command == "closeout"', core)
+        self.assertIn("handle_closeout_command", core)
+        # and it must not be wired into any Stop/SessionEnd handling
+        for forbidden in ("SessionEnd", "on_stop", "Stop hook"):
+            self.assertNotIn(f'{forbidden}"', core)
+
+    def test_resolution_priority_argv_env_pickup(self) -> None:
+        # argv beats env beats pickup
+        self.assertEqual(
+            "argv", adapter.resolve_task_id(argv_value="argv", env={"STATE_CORE_TASK_ID": "env"}),
+        )
+        self.assertEqual(
+            "env",
+            adapter.resolve_task_id(argv_value=None, env={"STATE_CORE_TASK_ID": "env"}),
+        )
+        self.assertEqual(
+            "pickup",
+            adapter.resolve_task_id(
+                argv_value=None, env={}, pickup={"active": {"task_id": "pickup"}},
+            ),
+        )
+        self.assertIsNone(adapter.resolve_task_id(argv_value=None, env={}, pickup=None))
+
+    def test_resolution_never_uses_chat_text(self) -> None:
+        # adapter has no chat/transcript parsing surface at all
+        src = (REPO_ROOT / "mms_state_core_closeout.py").read_text("utf-8")
+        for forbidden in ("transcript", "chat_history", "messages", "prompt"):
+            self.assertNotIn(forbidden, src,
+                             f"adapter must not parse {forbidden} (no chat-text guessing)")
+
+
+class PickupPointerResolutionTests(unittest.TestCase):
+    def test_pickup_active_task_id_and_root_extracted(self) -> None:
+        pickup = {
+            "schema": "agent.continuity.pickup.v1",
+            "root": "/repo/x",
+            "active": {"task_id": "task-7", "status": "active"},
+            "checkpoint": {"task_id": "task-7"},
+        }
+        self.assertEqual("task-7", adapter.resolve_task_id(argv_value=None, env={}, pickup=pickup))
+        self.assertEqual("/repo/x", adapter.resolve_root(argv_value=None, env={}, pickup=pickup))
+
+    def test_pickup_checkpoint_task_id_fallback(self) -> None:
+        pickup = {"root": "/repo/y", "active": {}, "checkpoint": {"task_id": "task-9"}}
+        self.assertEqual("task-9", adapter.resolve_task_id(argv_value=None, env={}, pickup=pickup))
+
+    def test_pickup_missing_returns_none(self) -> None:
+        self.assertIsNone(adapter.resolve_task_id(argv_value=None, env={}, pickup={}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -16,6 +16,7 @@ What is frozen here (mirrors ``docs/runner-adapter-hooks.md`` Required Invariant
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -29,6 +30,12 @@ import mms_state_core_closeout as adapter
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS_DIR = REPO_ROOT / "hooks"
+
+
+def _completion_ref(task_id: str, revision_sha256: str) -> str:
+    return "completion:sha256:" + hashlib.sha256(
+        f"{task_id}:{revision_sha256}".encode("utf-8")
+    ).hexdigest()
 
 
 def _resolve_cli() -> Path:
@@ -89,6 +96,8 @@ class CloseoutAdapterContractTests(unittest.TestCase):
             self.assertEqual("done", result.status, result.to_compact_json())
             self.assertTrue(result.completion_ref.startswith("completion:sha256:"))
             self.assertTrue(result.verified)
+            self.assertIsNone(result.state_path)
+            self.assertNotIn('"state_path"', result.to_compact_json())
             # task is now canonical done with a real receipt
             state = json.loads(
                 (root_path / ".state" / "ok-task" / "task-state.json").read_text("utf-8")
@@ -228,12 +237,13 @@ class CloseoutAdapterContractTests(unittest.TestCase):
     def test_verify_exit_zero_requires_full_success_payload_contract(self) -> None:
         """Exit 0 alone is not proof: the read-back payload must bind the
         requested task and the exact completion receipt and explicitly pass."""
-        ref = "completion:sha256:" + "a" * 64
+        revision = "c" * 64
+        ref = _completion_ref("task-a", revision)
         close_payload = json.dumps({
             "status": "done",
             "task_id": "task-a",
             "completion_ref": ref,
-            "revision_sha256": "c" * 64,
+            "revision_sha256": revision,
             "state_path": "/tmp/root/.state/task-a/task-state.json",
         })
         invalid_verify_payloads = {
@@ -297,12 +307,13 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         self.assertFalse(result.verified)
 
     def test_closeout_exit_zero_requires_full_receipt_payload_contract(self) -> None:
-        ref = "completion:sha256:" + "a" * 64
+        revision = "c" * 64
+        ref = _completion_ref("task-a", revision)
         base = {
             "status": "done",
             "task_id": "task-a",
             "completion_ref": ref,
-            "revision_sha256": "c" * 64,
+            "revision_sha256": revision,
             "state_path": "/tmp/root/.state/task-a/task-state.json",
         }
         invalid_payloads = []
@@ -336,11 +347,91 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 self.assertEqual("closeout_payload_contract_failed", result.reason)
                 self.assertFalse(result.verified)
 
+    def test_closeout_receipt_fields_are_cross_bound_and_strict(self) -> None:
+        revision = "c" * 64
+        valid = {
+            "status": "done",
+            "task_id": "task-a",
+            "completion_ref": _completion_ref("task-a", revision),
+            "revision_sha256": revision,
+            "state_path": "/tmp/root/.state/task-a/task-state.json",
+        }
+        mismatched_ref = dict(valid)
+        mismatched_ref["completion_ref"] = _completion_ref("task-a", "d" * 64)
+        extra_errors = dict(valid)
+        extra_errors["errors"] = []
+        for label, payload in (
+            ("ref-revision-mismatch", mismatched_ref),
+            ("extra-contradictory-field", extra_errors),
+        ):
+            with self.subTest(label=label):
+                with mock.patch.object(
+                    adapter,
+                    "_run_cli",
+                    return_value=subprocess.CompletedProcess(
+                        [], 0, json.dumps(payload), ""
+                    ),
+                ):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("error", result.status)
+                self.assertEqual("closeout_payload_contract_failed", result.reason)
+                self.assertFalse(result.verified)
+
+    def test_exit_zero_with_any_stderr_fails_closed(self) -> None:
+        revision = "c" * 64
+        ref = _completion_ref("task-a", revision)
+        close_payload = json.dumps({
+            "status": "done",
+            "task_id": "task-a",
+            "completion_ref": ref,
+            "revision_sha256": revision,
+            "state_path": "/tmp/root/.state/task-a/task-state.json",
+        })
+        verify_payload = json.dumps({
+            "status": "passed",
+            "task_id": "task-a",
+            "completion_ref": ref,
+            "errors": [],
+        })
+        for stderr in (
+            "fatal: wrapper failed",
+            "error: cannot reach done; blockers: ['missing evidence']",
+            "warning\nfatal: multiline",
+        ):
+            with self.subTest(stage="closeout", stderr=stderr):
+                with mock.patch.object(
+                    adapter,
+                    "_run_cli",
+                    return_value=subprocess.CompletedProcess([], 0, close_payload, stderr),
+                ):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("error", result.status)
+                self.assertEqual("closeout_success_stderr", result.reason)
+                self.assertFalse(result.verified)
+
+            with self.subTest(stage="verify", stderr=stderr):
+                calls = [
+                    subprocess.CompletedProcess([], 0, close_payload, ""),
+                    subprocess.CompletedProcess([], 0, verify_payload, stderr),
+                ]
+                with mock.patch.object(adapter, "_run_cli", side_effect=calls):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("verify_failed", result.status)
+                self.assertEqual("verify_success_stderr", result.reason)
+                self.assertFalse(result.verified)
+
     def test_nonzero_verify_with_malformed_errors_never_crashes_or_splits(self) -> None:
-        ref = "completion:sha256:" + "a" * 64
+        revision = "c" * 64
+        ref = _completion_ref("task-a", revision)
         close_payload = json.dumps({
             "status": "done", "task_id": "task-a", "completion_ref": ref,
-            "revision_sha256": "c" * 64,
+            "revision_sha256": revision,
             "state_path": "/tmp/root/.state/task-a/task-state.json",
         })
         for errors in (None, "failure", 7, {"detail": "failure"}, [7]):
@@ -461,6 +552,22 @@ class CloseoutAdapterContractTests(unittest.TestCase):
             "['unterminated'",
         )
         for suffix in malformed:
+            with self.subTest(suffix=suffix):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    f"error: cannot reach done; blockers: {suffix}"
+                )
+                self.assertEqual("error", status)
+                self.assertEqual("cli_rejected_unknown", reason)
+                self.assertTrue(blockers)
+
+    def test_noncanonical_equivalent_blocker_literals_are_unknown_errors(self) -> None:
+        noncanonical = (
+            "['missing evidence'] # wrapper fatal",
+            "['missing evidence',]",
+            "['missing ' 'evidence']",
+            '["missing evidence"]',
+        )
+        for suffix in noncanonical:
             with self.subTest(suffix=suffix):
                 status, reason, blockers = adapter._classify_closeout_failure(
                     f"error: cannot reach done; blockers: {suffix}"

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -278,6 +278,10 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 "status": "passed", "task_id": "task-a",
                 "completion_ref": ref, "errors": [7],
             }),
+            "extra-field": json.dumps({
+                "status": "passed", "task_id": "task-a",
+                "completion_ref": ref, "errors": [], "warning": "hidden",
+            }),
         }
         for label, verify_stdout in invalid_verify_payloads.items():
             with self.subTest(label=label):
@@ -399,6 +403,9 @@ class CloseoutAdapterContractTests(unittest.TestCase):
             "fatal: wrapper failed",
             "error: cannot reach done; blockers: ['missing evidence']",
             "warning\nfatal: multiline",
+            " ",
+            "\n",
+            "\t\r\n",
         ):
             with self.subTest(stage="closeout", stderr=stderr):
                 with mock.patch.object(
@@ -425,6 +432,75 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 self.assertEqual("verify_failed", result.status)
                 self.assertEqual("verify_success_stderr", result.reason)
                 self.assertFalse(result.verified)
+
+    def test_duplicate_json_members_fail_closed_in_both_success_payloads(self) -> None:
+        revision = "c" * 64
+        ref = _completion_ref("task-a", revision)
+        close_pairs = [
+            ("status", "done"),
+            ("task_id", "task-a"),
+            ("completion_ref", ref),
+            ("revision_sha256", revision),
+            ("state_path", "/tmp/root/.state/task-a/task-state.json"),
+        ]
+        close_conflicts = {
+            "status": "failed",
+            "task_id": "task-b",
+            "completion_ref": _completion_ref("task-a", "d" * 64),
+            "revision_sha256": "d" * 64,
+        }
+
+        def raw_object(pairs: list[tuple[str, object]]) -> str:
+            return "{" + ",".join(
+                f"{json.dumps(key)}:{json.dumps(value)}" for key, value in pairs
+            ) + "}"
+
+        for key, conflict in close_conflicts.items():
+            for order in ("before", "after"):
+                with self.subTest(stage="closeout", key=key, order=order):
+                    duplicate = [(key, conflict)]
+                    pairs = duplicate + close_pairs if order == "before" else close_pairs + duplicate
+                    with mock.patch.object(
+                        adapter,
+                        "_run_cli",
+                        return_value=subprocess.CompletedProcess(
+                            [], 0, raw_object(pairs), ""
+                        ),
+                    ):
+                        result = adapter.closeout_task(
+                            task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                        )
+                    self.assertEqual("error", result.status)
+                    self.assertEqual("invalid_closeout_stdout", result.reason)
+
+        close_payload = raw_object(close_pairs)
+        verify_pairs = [
+            ("status", "passed"),
+            ("task_id", "task-a"),
+            ("completion_ref", ref),
+            ("errors", []),
+        ]
+        verify_conflicts = {
+            "status": "failed",
+            "task_id": "task-b",
+            "completion_ref": _completion_ref("task-a", "d" * 64),
+            "errors": ["fatal"],
+        }
+        for key, conflict in verify_conflicts.items():
+            for order in ("before", "after"):
+                with self.subTest(stage="verify", key=key, order=order):
+                    duplicate = [(key, conflict)]
+                    pairs = duplicate + verify_pairs if order == "before" else verify_pairs + duplicate
+                    calls = [
+                        subprocess.CompletedProcess([], 0, close_payload, ""),
+                        subprocess.CompletedProcess([], 0, raw_object(pairs), ""),
+                    ]
+                    with mock.patch.object(adapter, "_run_cli", side_effect=calls):
+                        result = adapter.closeout_task(
+                            task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                        )
+                    self.assertEqual("verify_failed", result.status)
+                    self.assertEqual("invalid_verify_stdout", result.reason)
 
     def test_nonzero_verify_with_malformed_errors_never_crashes_or_splits(self) -> None:
         revision = "c" * 64
@@ -572,6 +648,24 @@ class CloseoutAdapterContractTests(unittest.TestCase):
                 status, reason, blockers = adapter._classify_closeout_failure(
                     f"error: cannot reach done; blockers: {suffix}"
                 )
+                self.assertEqual("error", status)
+                self.assertEqual("cli_rejected_unknown", reason)
+                self.assertTrue(blockers)
+
+    def test_whitespace_tainted_blocker_envelopes_are_unknown_errors(self) -> None:
+        canonical = "error: cannot reach done; blockers: ['missing evidence']"
+        tainted = (
+            "error: cannot reach done; blockers:  ['missing evidence']",
+            "error: cannot reach done; blockers: ['missing evidence'] ",
+            " " + canonical,
+            canonical + " ",
+            "\n" + canonical + "\n",
+            canonical + "\n\n",
+            "\u2003" + canonical,
+        )
+        for stderr in tainted:
+            with self.subTest(stderr=repr(stderr)):
+                status, reason, blockers = adapter._classify_closeout_failure(stderr)
                 self.assertEqual("error", status)
                 self.assertEqual("cli_rejected_unknown", reason)
                 self.assertTrue(blockers)

--- a/tests/test_state_core_closeout_binding.py
+++ b/tests/test_state_core_closeout_binding.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import mms_state_core_closeout as adapter
 
@@ -223,6 +224,86 @@ class CloseoutAdapterContractTests(unittest.TestCase):
         # and a non-done result must still surface verified:false explicitly
         blocked = adapter.CloseoutResult(status="missing_task_id")
         self.assertIn('"verified": false', blocked.to_compact_json())
+
+    def test_verify_exit_zero_requires_full_success_payload_contract(self) -> None:
+        """Exit 0 alone is not proof: the read-back payload must bind the
+        requested task and the exact completion receipt and explicitly pass."""
+        ref = "completion:sha256:" + "a" * 64
+        close_payload = json.dumps({"completion_ref": ref})
+        invalid_verify_payloads = {
+            "empty": "",
+            "malformed": "not-json",
+            "scalar": "[]",
+            "failed": json.dumps({
+                "status": "failed", "task_id": "task-a",
+                "completion_ref": ref, "errors": [],
+            }),
+            "task-mismatch": json.dumps({
+                "status": "passed", "task_id": "task-b",
+                "completion_ref": ref, "errors": [],
+            }),
+            "ref-mismatch": json.dumps({
+                "status": "passed", "task_id": "task-a",
+                "completion_ref": "completion:sha256:" + "b" * 64,
+                "errors": [],
+            }),
+        }
+        for label, verify_stdout in invalid_verify_payloads.items():
+            with self.subTest(label=label):
+                calls = [
+                    subprocess.CompletedProcess([], 0, close_payload, ""),
+                    subprocess.CompletedProcess([], 0, verify_stdout, ""),
+                ]
+                with mock.patch.object(adapter, "_run_cli", side_effect=calls):
+                    result = adapter.closeout_task(
+                        task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+                    )
+                self.assertEqual("verify_failed", result.status, result.to_compact_json())
+                self.assertNotEqual(0, result.exit_code())
+                self.assertFalse(result.verified)
+
+    def test_closeout_exit_zero_scalar_payload_fails_closed(self) -> None:
+        with mock.patch.object(
+            adapter,
+            "_run_cli",
+            return_value=subprocess.CompletedProcess([], 0, "[]", ""),
+        ):
+            result = adapter.closeout_task(
+                task_id="task-a", root="/tmp/root", cli=Path("/fake/cli.py")
+            )
+        self.assertEqual("error", result.status)
+        self.assertEqual("invalid_closeout_stdout", result.reason)
+        self.assertFalse(result.verified)
+
+    def test_failure_classifier_does_not_trust_keywords_inside_missing_path(self) -> None:
+        malicious_paths = (
+            "/tmp/.state/blockers: fake/task-state.json",
+            "/tmp/.state/cannot reach done from intake; transition to verifying first/task-state.json",
+        )
+        for path in malicious_paths:
+            with self.subTest(path=path):
+                status, reason, blockers = adapter._classify_closeout_failure(
+                    f"FileNotFoundError: [Errno 2] No such file or directory: '{path}'"
+                )
+                self.assertEqual("error", status)
+                self.assertEqual("task_or_root_unresolved", reason)
+                self.assertEqual([], blockers)
+
+    def test_blocker_detail_with_comma_remains_one_item(self) -> None:
+        status, reason, blockers = adapter._classify_closeout_failure(
+            "error: cannot advance to done; blockers: ['missing alpha, beta']"
+        )
+        self.assertEqual("blocked", status)
+        self.assertEqual("done_gate_blockers", reason)
+        self.assertEqual(["missing alpha, beta"], blockers)
+
+    def test_unanchored_blocker_keyword_is_unknown_error(self) -> None:
+        status, reason, blockers = adapter._classify_closeout_failure(
+            "unexpected wrapper failure blockers: ['not authoritative']"
+        )
+        self.assertEqual("error", status)
+        self.assertEqual("cli_rejected_unknown", reason)
+        self.assertTrue(blockers)
 
 
 class CloseoutBoundaryStaticTests(unittest.TestCase):


### PR DESCRIPTION
## TB-46 · MMS terminal closeout reference binding (P0)

接通已 ratify 的 `docs/runner-adapter-hooks.md` consume contract 到第一个 MMS-managed reference binding。state-core 仍唯一拥有 canonical state / done-gate / `completion_ref`;本 PR 不改 state-core 任何 schema/gate。

### 为什么是显式命令而不是 hook

当前 Claude/Codex/OpenCode harness **没有可靠的 explicit-finish 事件**:普通 `Stop` / `SessionEnd` / 进程退出都不等于任务完成。按工单红线「禁止把所有 `Stop` 接成 closeout」,本 binding 落成 **opt-in 显式子命令** `mms closeout`,由正式 finish 入口(work-done / 显式 human 指令)在 agent 明确宣布任务结束时调用。

### 变更

| 文件 | 作用 |
|---|---|
| `mms_state_core_closeout.py` | runner-neutral adapter(stdlib-only)。调 `closeout` → `verify-completion` read-back `completion_ref`;非零退出保留 phase 并输出 compact blockers。**不直接读写 task-state.json**,**不调** `set --next-action/--runner/--owner`。task_id/root 解析 argv > env > pickup 指针,fail closed。 |
| `mms_core.py` | 单一 `closeout` dispatch 分支(照搬 `review-dispatch` 模式)+ help 行。**无 global hook、无 auto-registration。** |
| `tests/test_state_core_closeout_binding.py` | 15 个 cross-runner compliance cases,后续新 harness binding 复用同一组 cases。 |
| `docs/STATE_CORE_CLOSEOUT_BINDING.md` | 何时触发 / 何时绝不触发 / fresh-session 生效边界 / 手工复核 `completion_ref`。 |

### 失败语义(确定性 exit)

`done` 0 · `blocked` 1(phase 不变、blockers 可见)· `verify_failed` 1 · `missing_task_id`/`missing_root` 2 · `cli_unavailable` 3 · `error` 4(timeout/crash 不推断 phase)。

### 必测用例对照(workorder)

- ✅ required slots 全满足:explicit finish → closeout 成功 → verify `completion_ref`(`test_explicit_finish_closeout_succeeds_and_verifies_completion_ref`)
- ✅ required slot 未满足:explicit finish → 非零 → blockers 可见 → phase 不变(`test_closeout_rejects_done_gate_blockers_and_preserves_phase`,断言 `task-state.json` 逐字节不变)
- ✅ 普通 `Stop`/turn end **不**触发 closeout(`test_no_stop_or_sessionend_hook_is_wired_to_closeout` 静态断言 hooks/ 零引用)
- ✅ task id/root 缺失:fail closed,不猜状态(`test_missing_task_id_fails_closed` / `test_missing_root_fails_closed`)
- ✅ phase≠verifying:不改 canonical phase(`test_closeout_rejects_when_phase_not_verifying`)
- ✅ 静态证明:无 direct state JSON write、无 `set --next-action/--runner/--owner`、无全量 state 注入 subagent

### 真实 CLI E2E(temporary state root)

```
# SUCCESS via mms entry
$ mms closeout --task-id real-ok --root <tmp> --actor codex
{"status":"done","completion_ref":"completion:sha256:d9f3...","verified":true}   # exit 0
# independent read-back matches

# REJECTION (phase not verifying)
$ mms closeout --task-id real-early --root <tmp>
{"status":"blocked","reason":"phase_not_verifying",...}   # exit 1, phase preserved intake
```

### 红线遵守

- 不做 auto-advance;不按聊天字样判断完成。
- 不把 state-core 变成 hook daemon;adapter 是 runner-side,stdlib-only。
- 不复用 NSR `Stop`;不修改其他 Map/Caveman/NSR hook 顺序或默认启用状态(install.sh / config 零引用,已静态验证)。

### 测试

```
$ python3 -m unittest tests.test_state_core_closeout_binding -v
Ran 15 tests in 0.6s — OK
$ python3 -m pytest tests/test_command_smoke.py -q   # 未破坏既有命令面
4 passed
```

**不自合**。merge 由 human/committee 决定。TB-49 只有在本 PR merge 且 fresh-session binding 验证生效后才可开工。

Workorder: `/Users/xin/issue-tracking/issues/auto-skills/workflow-reliability-batch9-20260814/WORKORDERS-TB46-49-20260814.md` (TB-46)
Evidence: 同目录 `tb-46/RESULT.md` + `tb-46/walls.md`

Agent-Model: glm-5.2
Agent-Family: zhipu
Agent-Session: 019ffe50-4d8a-71f0-ab3d-0925499e518c