### PR TITLE
fix(opencode): deterministic vision fallback for attachment in fresh envs

### DIFF
--- a/mms_opencode_config.py
+++ b/mms_opencode_config.py
@@ -389,6 +389,20 @@ def _opencode_model_key(model_name):
     return normalized
 
 
+def _opencode_runtime_model_capability_entry(runtime, model_name):
+    """True when runtime model_capabilities carries an explicit entry for the model."""
+    caps_map = runtime.get("model_capabilities") if isinstance(runtime, dict) else None
+    if not isinstance(caps_map, dict):
+        return False
+    target = _opencode_model_key(model_name)
+    if not target:
+        return False
+    return any(
+        isinstance(value, dict) and _opencode_model_key(key) == target
+        for key, value in caps_map.items()
+    )
+
+
 def _opencode_is_kimi_k3_selector(model_name):
     leaf = str(model_name or "").strip().lower().rsplit("/", 1)[-1]
     return leaf in {"k3", "k3[1m]", "kimi-k3"}
@@ -923,6 +937,19 @@ def opencode_model_config(
             ),
         }
     supports_vision = opencode_capability_bool(runtime, model, "vision", "supports_vision")
+    if supports_vision is None and not _opencode_runtime_model_capability_entry(runtime, model):
+        # Fresh clones and isolated launch envs resolve to conservative_fallback
+        # facts (untrusted) or nothing at all; without a deterministic source the
+        # attachment decision silently depends on local approved-facts files
+        # (issue #58). Fall back to the launcher's static vision-model set, the
+        # same one route selection uses. An explicit runtime model_capabilities
+        # entry always wins: an entry without a vision bool stays text-only.
+        try:
+            from mms_core import _model_supports_vision
+
+            supports_vision = _model_supports_vision(model)
+        except ImportError:
+            pass
     if supports_vision is True or (supports_vision is None and model.lower() in OPENCODE_IMAGE_INPUT_MODELS):
         config["attachment"] = True
         config["modalities"] = {

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -807,6 +807,32 @@ def test_opencode_model_config_uses_runtime_model_capabilities_for_limits_and_vi
         assert "modalities" not in config
 
 
+def test_opencode_model_config_vision_falls_back_to_static_set_without_capability_data(monkeypatch):
+    """Fresh clones / isolated envs carry no capability snapshot (issue #58).
+
+    The attachment decision must not silently depend on local approved-facts
+    files: with no capability data at all it falls back to the static
+    vision-model set, so mimo-v2.5 stays image-capable and text-only models
+    stay text-only. Explicit runtime model_capabilities still win.
+    """
+    import mms_opencode_config
+
+    monkeypatch.setattr(
+        mms_opencode_config,
+        "opencode_model_capabilities",
+        lambda runtime, model_name, *args, **kwargs: {},
+    )
+
+    mimo = mms_opencode_config.opencode_model_config({}, "mimo-v2.5")
+    assert mimo["attachment"] is True
+    assert mimo["modalities"] == {"input": ["text", "image"], "output": ["text"]}
+
+    for model in ("mimo-v2.5-pro", "qwen3-coder-plus", "glm-5.1", "deepseek-v4-pro"):
+        config = mms_opencode_config.opencode_model_config({}, model)
+        assert "attachment" not in config
+        assert "modalities" not in config
+
+
 def test_core_opencode_prefers_mimo_openai_compatible_base_from_anthropic():
     import mms_core
 


### PR DESCRIPTION
Closes #58 · S13-b REWORK（MMS-01 #84 项的重做，base=dev）

## 根因

fresh clone / 隔离环境下，capability resolver 只能给出 `conservative_fallback` 事实（`supports_vision=false`、source 被 `_opencode_capability_source_allowed` 挡掉），`opencode_capability_bool(...,"vision")` 返回 None；`OPENCODE_IMAGE_INPUT_MODELS` 又是空集 → `opencode_model_config` 直接不设 `attachment`，roster 测试 `KeyError: 'attachment'`。此前的 S13 #84 closeout 声称“隔离环境绿”是错的（执行时环境里残留 `MMS_RESCUE_CONFIG_ROOT`/`MMS_REAL_HOME` 指向真实快照），本 PR 修正。

## 改了什么

`mms_opencode_config.py`：

- `opencode_model_config` 在 `opencode_capability_bool` 返回 None **且** runtime 没有该模型的显式 `model_capabilities` 条目时，回退到 launcher 静态 vision 模型集合（lazy `from mms_core import _model_supports_vision`，与 route selection 同源）。
- 显式 runtime caps 仍优先：条目存在但无 vision bool → 保持 text-only（现有单测契约不变，`MiniMax-M3` 等断言不受影响）。
- 新增 helper `_opencode_runtime_model_capability_entry`。

`tests/test_opencode_launcher.py`：

- 新增 `test_opencode_model_config_vision_falls_back_to_static_set_without_capability_data`：monkeypatch `opencode_model_capabilities` 返回空后，`mimo-v2.5` 仍得 `attachment=True` + modalities，`mimo-v2.5-pro`/`qwen3-coder-plus`/`glm-5.1`/`deepseek-v4-pro` 保持无 attachment。

## 验证（REWORK 验收：fresh clone 隔离环境绿）

隔离命令与输出（branch HEAD 1f2085bc，base=origin/dev eeb70893）：

```text
$ env -i PATH=/opt/homebrew/bin:/usr/bin:/bin HOME=/tmp/mms-iso-home2 PYTHONPATH=<worktree> \
  /opt/homebrew/bin/python3 -m pytest tests/test_opencode_launcher.py::test_core_opencode_lite_pro_builds_multi_model_roster -q
1 passed in 0.22s
```

- 全套 `tests/test_opencode_launcher.py` 同隔离环境：**120 passed**。
- 正常环境：launcher 120 passed；full suite 62 failed 与干净 dev 基线**逐条一致**（`diff` 为空，均环境相关既有红灯），本 PR 不新增失败。

## 边界

- 未改 provider/model 路由、未改 `opencode_capability_bool` 语义、未动 Python 启动链路。
- 静态集合与 `mms_launchers._runtime_model_capabilities` 已用的回退同源，不新增第二套硬编码清单。
