### PR TITLE
Load global AGENTS in fresh isolated Pi sessions

### DIFF
--- a/docs/SESSION_ASSET_MANAGER.md
+++ b/docs/SESSION_ASSET_MANAGER.md
@@ -120,3 +120,11 @@ WebUI 是发现、理解和默认偏好草稿；TUI 是最终单次启动确认�
 ## 交互参考
 
 这一版更接近 MCP Inspector / Smithery 这类管理中心的信息层级：先显示可筛选能力和状态，把来源路径、协议细节或 CLI 细节折叠起来。
+
+## Pi 全局规则到达
+
+`mmf → pi` 使用每次启动的隔离 `PI_CODING_AGENT_DIR`。新隔离目录只从真实 `~/.pi/agent/` 复制首个存在的 `AGENTS.override.md`、`AGENTS.md`、`AGENTS.MD`，顺序与 Pi 的 AGENTS 选择一致；没有这些文件就保留原生无全局规则的行为。读取失败显式报错，不假装规则已加载。
+
+复制的是单个文本快照，不是到全局文件的 symlink；会话内修改不会回写宿主。已有隔离会话的 AGENTS 保留，宿主变更在下一次 fresh launch 生效。项目及祖先 AGENTS 仍由 Pi 自己按目录读取，不把全局政策提升到项目合同之上。auth、settings、SYSTEM、Claude 状态都不在此 allowlist，模型/source/effort 与现有 config 隔离不变。
+
+skills overlay 与 AGENTS 是两条独立路径。目录里有 SKILL.md 或宿主存在 AGENTS，不等于本会话已采用。`tests/test_pi_launcher.py` 的 policy 回归通过实际安装的 Pi `loadProjectContextFiles` 验证全局 + 项目内容；没有 Pi/Node 时明确 skip，不安装、不发模型请求。可用 `MMS_TEST_PI_RESOURCE_LOADER` 指向已安装 loader 做明确验证。

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -1325,6 +1325,35 @@ def _pi_link_shared_agent_bin(agent_dir):
         return
 
 
+def _pi_seed_agent_policy(agent_dir):
+    """Snapshot only the user's AGENTS policy into a fresh isolated Pi agentDir.
+
+    Pi discovers global context under PI_CODING_AGENT_DIR, not the real HOME.
+    Preserve an existing session policy and native AGENTS override precedence.
+    Do not link the global file: editing session context must not write home.
+    This allowlist intentionally excludes auth, settings and Claude state.
+    """
+    source_dir = Path(_real_user_path(".pi", "agent"))
+    target_dir = Path(agent_dir)
+    if target_dir.resolve() == source_dir.resolve():
+        raise ValueError("Pi policy requires an isolated agent directory")
+    names = ("AGENTS.override.md", "AGENTS.md", "AGENTS.MD")
+    if any((target_dir / name).is_file() for name in names):
+        return
+    for name in names:
+        source = source_dir / name
+        if source.is_file():
+            # An unreadable configured policy is an explicit startup error,
+            # not a silently policy-free launch or a global-account fallback.
+            try:
+                content = source.read_text(encoding="utf-8")
+                target_dir.mkdir(parents=True, exist_ok=True)
+                atomic_write_text(str(target_dir / name), content, mode=0o600)
+            except (OSError, UnicodeError) as error:
+                raise RuntimeError(f"Cannot load Pi agent policy: {source}") from error
+            return
+
+
 def _pi_gateway_env(runtime, model_info=None):
     runtime = runtime if isinstance(runtime, dict) else {}
     launchers = _launchers_module()
@@ -1349,6 +1378,7 @@ def _pi_gateway_env(runtime, model_info=None):
     env["MMS_PI_SOFT_HOME"] = "1"
 
     agent_dir = os.path.join(session_home, ".pi", "agent")
+    _pi_seed_agent_policy(agent_dir)
     _pi_link_shared_agent_bin(agent_dir)
     session_dir = _pi_session_dir()
     models_path, provider_ref = _write_pi_models_config(agent_dir, runtime, model)

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -79,9 +79,17 @@ _QUICK_PYTEST_TARGETS = [
     "tests/test_nsr_bundled_wrapper.py",
     "tests/test_pi_launcher.py::test_glint_pi_bridge_requires_glint_pane_and_managed_extension",
     "tests/test_pi_launcher.py::test_launch_pi_adds_glint_bridge_as_explicit_extension",
+    "tests/test_pi_launcher.py::test_pi_isolated_gateway_loads_global_policy_and_project_context",
+    "tests/test_pi_launcher.py::test_pi_policy_missing_is_optional_and_global_override_wins",
+    "tests/test_pi_launcher.py::test_pi_policy_copy_fails_explicitly_and_cannot_target_global",
 ]
 
 _SCENARIO_MATRIX = [
+    {
+        "id": "pi-isolated-global-policy",
+        "state": "fresh isolated Pi agentDir, host AGENTS policy, project outside real HOME",
+        "coverage": "native Pi context loader receives global policy plus project context; auth is not inherited and session edits do not write home",
+    },
     {
         "id": "fresh-mmf-preview-root",
         "state": "empty HOME, no MMS env",

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -1718,3 +1718,133 @@ def test_preset_export_runtime_passes_pi_model_info(monkeypatch):
     assert captured["cli"] == "pi"
     assert captured["runtime"]["id"] == "relay-c"
     assert captured["model_info"] == {"model": "gpt-5.4"}
+
+
+@pytest.fixture
+def isolated_policy_gateway(monkeypatch, tmp_path):
+    """Exercise the real Pi gateway boundary without credentials or a model call."""
+    import mms_pi_support as pi
+
+    real_home = tmp_path / 'real-home'
+    real_home.mkdir()
+    gateway = tmp_path / 'isolated-gateway'
+    project = tmp_path / 'project-outside-home'
+    project.mkdir()
+    (project / 'AGENTS.md').write_text('Project scope: preserve this local contract.\n')
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(pi, '_real_user_path', lambda *parts: str(real_home.joinpath(*parts)))
+    monkeypatch.setattr(pi, '_pi_gateway_root', lambda: str(gateway))
+    monkeypatch.setattr(pi, '_pi_effective_selected_model', lambda runtime, model: model)
+    for name in (
+        '_cleanup_stale_sessions', '_inject_real_home_hints', '_inject_host_capability_hints',
+        '_inject_selected_model_name', '_set_session_home_hint',
+        '_apply_runtime_network_profile', '_apply_runtime_locale_profile',
+        '_apply_runtime_ip_stack_profile', '_install_session_command_wrappers',
+        '_install_session_packet_env', 'apply_pi_capture_proxy',
+    ):
+        monkeypatch.setattr(pi, name, lambda *args, **kwargs: None)
+    monkeypatch.setattr(pi, '_write_pi_models_config', lambda agent_dir, runtime, model: (
+        str(Path(agent_dir) / 'models.json'), 'synthetic-provider'))
+    monkeypatch.setattr(pi, '_write_pi_settings_config', lambda agent_dir: str(Path(agent_dir) / 'settings.json'))
+    monkeypatch.setattr(pi._launchers_module(), '_pi_wrapper_path', lambda: '/synthetic/pi')
+    return pi, real_home, project
+
+
+def _installed_pi_context_loader():
+    """Discover only an existing installation; never npx/install or start Pi."""
+    import shutil
+
+    override = os.environ.get('MMS_TEST_PI_RESOURCE_LOADER')
+    if override:
+        assert Path(override).is_file(), 'Explicit Pi resource-loader path is missing'
+        return Path(override)
+    binary = shutil.which('pi')
+    if binary:
+        for parent in Path(binary).resolve().parents:
+            loader = parent / 'dist/core/resource-loader.js'
+            if loader.is_file():
+                return loader
+    pytest.skip('Native Pi context loader not installed; no download attempted')
+
+
+def _read_native_pi_context(project, agent_dir):
+    import shutil
+
+    node = shutil.which('node')
+    if not node:
+        pytest.skip('Node is not installed; native Pi context probe not run')
+    loader = _installed_pi_context_loader()
+    script = f"""
+        import {{ loadProjectContextFiles }} from {json.dumps(loader.as_uri())};
+        const rows = loadProjectContextFiles({{
+            cwd: process.argv[1], agentDir: process.argv[2]
+        }});
+        process.stdout.write(JSON.stringify(rows));
+    """
+    result = subprocess.run([node, '--input-type=module', '-e', script, str(project), str(agent_dir)],
+                            text=True, capture_output=True, timeout=20, check=True)
+    return json.loads(result.stdout)
+
+
+def test_pi_isolated_gateway_loads_global_policy_and_project_context(isolated_policy_gateway):
+    pi, real_home, project = isolated_policy_gateway
+    global_dir = real_home / '.pi/agent'
+    global_dir.mkdir(parents=True)
+    policy_path = os.environ.get('MMS_TEST_GLOBAL_POLICY')
+    policy = (Path(policy_path).read_text() if policy_path else
+              'Global policy: preserve unrelated work; complete only the requested delivery boundary.\n')
+    (global_dir / 'AGENTS.md').write_text(policy)
+    # Deliberately adjacent auth/config must not be inherited by the policy loader.
+    (global_dir / 'auth.json').write_text('{"synthetic_secret":"never-copy"}')
+    (global_dir / 'settings.json').write_text('{"synthetic_setting":"never-copy"}')
+
+    env = pi._pi_gateway_env({'model': 'synthetic-model'})
+    isolated = Path(env['PI_CODING_AGENT_DIR'])
+    assert isolated != global_dir
+    rows = _read_native_pi_context(project, isolated)
+    assert [(Path(row['path']).name, row['content']) for row in rows] == [
+        ('AGENTS.md', policy), ('AGENTS.md', (project / 'AGENTS.md').read_text())]
+    assert not (isolated / 'auth.json').exists()
+    assert not (isolated / 'settings.json').exists()
+    assert not (isolated / 'AGENTS.md').is_symlink()
+    (isolated / 'AGENTS.md').write_text('Session-local edit\n')
+    assert (global_dir / 'AGENTS.md').read_text() == policy
+    pi._pi_gateway_env({'model': 'synthetic-model'})
+    assert (isolated / 'AGENTS.md').read_text() == 'Session-local edit\n'
+
+
+def test_pi_policy_missing_is_optional_and_global_override_wins(isolated_policy_gateway):
+    pi, real_home, project = isolated_policy_gateway
+    first = pi._pi_gateway_env({'model': 'synthetic-model'})
+    assert not (Path(first['PI_CODING_AGENT_DIR']) / 'AGENTS.md').exists()
+    global_dir = real_home / '.pi/agent'
+    global_dir.mkdir(parents=True)
+    (global_dir / 'AGENTS.md').write_text('Superseded global default\n')
+    (global_dir / 'AGENTS.override.md').write_text('Explicit global override\n')
+    second = pi._pi_gateway_env({'model': 'synthetic-model'})
+    isolated = Path(second['PI_CODING_AGENT_DIR'])
+    rows = _read_native_pi_context(project, isolated)
+    assert rows[0]['content'] == 'Explicit global override\n'
+    assert len(rows) == 2
+    assert not (isolated / 'AGENTS.md').exists()
+
+
+def test_pi_policy_copy_fails_explicitly_and_cannot_target_global(isolated_policy_gateway, monkeypatch):
+    pi, real_home, project = isolated_policy_gateway
+    global_dir = real_home / '.pi/agent'
+    global_dir.mkdir(parents=True)
+    source = global_dir / 'AGENTS.md'
+    source.write_text('Keep this source unchanged\n')
+    with pytest.raises(ValueError, match='isolated agent directory'):
+        pi._pi_seed_agent_policy(global_dir)
+    assert source.read_text() == 'Keep this source unchanged\n'
+    original_read = Path.read_text
+
+    def deny_policy(path, *args, **kwargs):
+        if path == source:
+            raise PermissionError('synthetic unreadable policy')
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'read_text', deny_policy)
+    with pytest.raises(RuntimeError, match='Cannot load Pi agent policy'):
+        pi._pi_gateway_env({'model': 'synthetic-model'})


### PR DESCRIPTION
MMF 的 PI_CODING_AGENT_DIR 是会话隔离目录，原先没有宿主 AGENTS，导致共享 skills 但全局政策未到达。fresh Pi 现在只复制 AGENTS allowlist 文本，遵守 override 优先，保留已存在 session 编辑，不复制账户或 settings。

验证：真实 Pi resource loader 3 cases；fresh-user quick gate 69 passed；Pi module 48 passed / 1 既有 Qwen maxTokens 失败，未改基线 ab1de2b0 可复现，未修改模型配置。
