### PR TITLE
增加 npx 安装入口：npx @ctrixin/mms

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -338,6 +338,14 @@ Open a terminal on a new machine and paste one line:
 curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash
 ```
 
+If the machine already has Node.js, this is shorter and does exactly the same thing:
+
+```bash
+npx @ctrixin/mms
+```
+
+Use the `curl` line on a bare machine: it prepares Node.js by itself, while `npx` needs Node.js to already be there.
+
 No question in the install changes what gets installed: no UI language prompt, no optional packs. It defaults to the stable channel and adds `~/.local/bin` to your shell PATH. The one question comes at the very end and only offers to open MMS Web. Accept it and the browser opens, the server keeps running in the background, and the installer exits. Add a provider and an API key on that page and you can start a conversation.
 
 Use `--launch-web` to open it without asking, `--no-launch-web` to skip it, and `--no-shell-rc` to leave your shell config alone.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ scripts/cleanup_merged_worktree.sh <branch-or-pr>
 curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash
 ```
 
+机器上已经有 Node.js 的话，这条更短，效果完全一样：
+
+```bash
+npx @ctrixin/mms
+```
+
+裸机请用上面那条 `curl`，它会在需要时自己准备 Node.js；`npx` 要求 Node.js 已经存在。
+
 装完会问一句要不要打开 MMS Web。回车即可，浏览器自动弹出，服务在后台运行，安装进程随即退出。在页面里添加 provider 和 API Key 就能开始对话。
 
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,14 @@ v4.0.0 是本地 Web 的首个大版本。下列 3.x 轨道为此前分支发布
 curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash
 ```
 
+机器上已经有 Node.js 的话，这条更短，效果完全一样：
+
+```bash
+npx @ctrixin/mms
+```
+
+裸机请用上面那条 `curl`，它会在需要时自己准备 Node.js；`npx` 要求 Node.js 已经存在。
+
 装完会问一句要不要打开 MMS Web。回车即可，浏览器自动弹出，服务在后台运行，安装进程随即退出。在页面里添加 provider 和 API Key 就能开始对话。
 
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。

--- a/packages/mms-install/README.md
+++ b/packages/mms-install/README.md
@@ -1,0 +1,49 @@
+# @ctrixin/mms
+
+One command to install [MMS](https://github.com/CtriXin/multi-model-switch) on a machine that already has Node.js:
+
+```bash
+npx @ctrixin/mms
+```
+
+It installs the latest MMS release, then offers to open MMS Web. Accept and the browser opens while the server keeps running in the background.
+
+## Which command should I use?
+
+This package is the shortcut for people who already have Node.js. On a bare machine use the primary installer instead, because it bootstraps Node.js by itself:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash
+```
+
+Both paths run the same installer and produce the same result.
+
+## Arguments
+
+Every argument is passed straight through to the installer:
+
+```bash
+npx @ctrixin/mms --channel dev        # the dev channel
+npx @ctrixin/mms --ref v4.3.0         # pin a release or branch
+npx @ctrixin/mms --no-launch-web      # do not open MMS Web at the end
+npx @ctrixin/mms --dry-run            # print the plan, write nothing
+npx @ctrixin/mms --help               # the installer's own help
+```
+
+`--channel` and `--ref` also decide which version of the installer itself is downloaded, so the script and the sources it installs always match.
+
+## What this package does
+
+It downloads `install.sh` from the repository over HTTPS and runs it with `bash`, forwarding your arguments. It contains no install logic of its own, which is why a cached copy still installs the current MMS.
+
+Because it downloads and executes a shell script, it is kept small and auditable: the source host is pinned to `raw.githubusercontent.com`, redirects off that host are refused, and the payload is checked before anything runs.
+
+Its own version number carries no meaning about which MMS you get. It always installs the latest release unless you pass `--ref` or `--channel`.
+
+## Requirements
+
+Node.js 18.17 or newer, and `bash`. macOS and Linux only. On Windows, run it from WSL.
+
+## License
+
+Apache-2.0

--- a/packages/mms-install/bin/mms-install.mjs
+++ b/packages/mms-install/bin/mms-install.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Thin forwarder: fetch the MMS installer and hand it to bash.
+//
+// This package downloads and executes a shell script, so it stays deliberately
+// small and auditable. The source host is pinned, redirects off that host are
+// refused, and the payload is checked before anything runs. It holds no install
+// logic of its own: everything lives in install.sh, which means a cached copy of
+// this wrapper still installs the current MMS.
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const RAW_HOST = "raw.githubusercontent.com";
+const REPO = "CtriXin/multi-model-switch";
+const DEFAULT_REF = "main";
+// Present in every version of the installer; a page that lacks it is not it.
+const PAYLOAD_MARKERS = ['REPO_NAME="multi-model-switch"', "#!/bin/bash"];
+
+function fail(message) {
+  console.error(`mms-install: ${message}`);
+  process.exit(1);
+}
+
+// The installer script and the source it installs must come from the same
+// place. Picking a channel or a ref moves both, or the user ends up running a
+// new script against old sources.
+function resolveRef(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--ref" && args[index + 1]) return args[index + 1];
+    if (arg.startsWith("--ref=")) return arg.slice("--ref=".length);
+    if (arg === "--channel" && args[index + 1]) return channelRef(args[index + 1]);
+    if (arg.startsWith("--channel=")) return channelRef(arg.slice("--channel=".length));
+    if (arg === "--dev") return "dev";
+    if (arg === "--canary") return "canary";
+  }
+  return DEFAULT_REF;
+}
+
+function channelRef(channel) {
+  if (channel === "dev" || channel === "canary") return channel;
+  return DEFAULT_REF;
+}
+
+async function download(ref) {
+  const url = `https://${RAW_HOST}/${REPO}/${encodeURIComponent(ref)}/install.sh`;
+  let response;
+  try {
+    response = await fetch(url, { redirect: "follow" });
+  } catch (error) {
+    fail(`could not reach ${RAW_HOST}: ${error.message}`);
+  }
+  if (!response.ok) {
+    fail(`could not download the installer for "${ref}" (HTTP ${response.status})`);
+  }
+  if (new URL(response.url).host !== RAW_HOST) {
+    fail(`refusing a redirect off ${RAW_HOST} to ${response.url}`);
+  }
+  const script = await response.text();
+  for (const marker of PAYLOAD_MARKERS) {
+    if (!script.includes(marker)) {
+      fail(`the downloaded file does not look like the MMS installer`);
+    }
+  }
+  return script;
+}
+
+async function main() {
+  if (process.platform === "win32") {
+    fail(
+      "Windows is not supported. The MMS installer needs bash, so run it from WSL or install on macOS/Linux.",
+    );
+  }
+
+  const args = process.argv.slice(2);
+  const ref = resolveRef(args);
+  const script = await download(ref);
+
+  const dir = mkdtempSync(join(tmpdir(), "mms-install-"));
+  const scriptPath = join(dir, "install.sh");
+  try {
+    writeFileSync(scriptPath, script, { mode: 0o700 });
+    // stdio is inherited, so the installer's closing question reaches the
+    // terminal directly instead of being swallowed the way `curl | bash` does.
+    const result = spawnSync("bash", [scriptPath, ...args], { stdio: "inherit" });
+    if (result.error) {
+      fail(`could not run bash: ${result.error.message}`);
+    }
+    process.exit(result.status === null ? 1 : result.status);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/packages/mms-install/package.json
+++ b/packages/mms-install/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@ctrixin/mms",
+  "version": "1.0.0",
+  "description": "One-command installer for MMS (multi-model-switch). Always installs the latest MMS release.",
+  "type": "module",
+  "bin": {
+    "mms-install": "bin/mms-install.mjs"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.17"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CtriXin/multi-model-switch.git",
+    "directory": "packages/mms-install"
+  },
+  "homepage": "https://github.com/CtriXin/multi-model-switch#readme",
+  "keywords": [
+    "mms",
+    "multi-model-switch",
+    "installer",
+    "claude",
+    "codex",
+    "opencode"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -68,6 +68,7 @@ _PYTEST_TARGETS = [
     "tests/test_mms_resume_command.py",
     "tests/test_reset_mms_install.py",
     "tests/test_install_script_paths.py",
+    "tests/test_npx_installer_package.py",
     "tests/test_nsr_bundled_wrapper.py",
     "tests/test_hook_retirement.py",
     "tests/test_owned_superset_hook.py",
@@ -83,6 +84,7 @@ _QUICK_PYTEST_TARGETS = [
     "tests/test_claude_hardening_regressions.py::test_claude_gateway_env_does_not_restore_cross_model_resume_pointer_on_new_launch",
     "tests/test_mms_resume_command.py::test_handle_resume_command_passes_claude_resume_args_and_project",
     "tests/test_install_script_paths.py",
+    "tests/test_npx_installer_package.py",
     "tests/test_nsr_bundled_wrapper.py",
     "tests/test_hook_retirement.py",
     "tests/test_owned_superset_hook.py",
@@ -133,6 +135,11 @@ _SCENARIO_MATRIX = [
         "id": "retired-optional-pack-cleanup",
         "state": "upgrade from a version that installed RTK/BrainKeeper/Map/CodeGraph/token-saver/TOON/ops-env-safe/ECC/OMC",
         "coverage": "install unbinds every MMS-written leftover, preserves user-owned lookalikes, backs up Claude settings, and uninstalls no third-party binary",
+    },
+    {
+        "id": "npx-install-entry",
+        "state": "a machine that already has Node.js, using the npx wrapper instead of curl",
+        "coverage": "the published wrapper carries no install logic, pins its source host, verifies the payload, keeps script and sources on one ref, and refuses Windows readably",
     },
     {
         "id": "one-question-install",

--- a/tests/test_npx_installer_package.py
+++ b/tests/test_npx_installer_package.py
@@ -1,0 +1,91 @@
+"""The npx wrapper is published to npm, so its shape is checked here rather
+than only at publish time. Nothing in this file reaches the network."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+PACKAGE_DIR = ROOT_DIR / "packages" / "mms-install"
+MANIFEST = PACKAGE_DIR / "package.json"
+ENTRY = PACKAGE_DIR / "bin" / "mms-install.mjs"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_package_is_publishable_as_a_public_scoped_package():
+    manifest = _manifest()
+
+    assert manifest["name"] == "@ctrixin/mms"
+    assert manifest["publishConfig"]["access"] == "public"
+    assert manifest["license"] == "Apache-2.0"
+    assert manifest["bin"] == {"mms-install": "bin/mms-install.mjs"}
+    assert "bin" in manifest["files"]
+    assert "README.md" in manifest["files"]
+    assert manifest["repository"]["directory"] == "packages/mms-install"
+
+
+def test_package_declares_the_platforms_it_can_actually_run_on():
+    manifest = _manifest()
+
+    # global fetch and the node: prefix both need a modern runtime
+    assert manifest["engines"]["node"] == ">=18.17"
+    assert manifest["os"] == ["darwin", "linux"]
+
+
+def test_entrypoint_is_executable_and_parses():
+    assert ENTRY.exists()
+    assert os.access(ENTRY, os.X_OK), "npm needs the bin file to be executable"
+    assert ENTRY.read_text(encoding="utf-8").startswith("#!/usr/bin/env node\n")
+
+    node = shutil.which("node")
+    if node is None:  # pragma: no cover - node is present in this repo's toolchain
+        return
+    subprocess.run([node, "--check", str(ENTRY)], check=True, capture_output=True)
+
+
+def test_wrapper_pins_the_source_host_and_verifies_the_payload():
+    text = ENTRY.read_text(encoding="utf-8")
+
+    assert 'const RAW_HOST = "raw.githubusercontent.com"' in text
+    assert 'const REPO = "CtriXin/multi-model-switch"' in text
+    # a redirect away from the pinned host must abort, not be followed silently
+    assert "refusing a redirect off" in text
+    # the payload is checked before it is executed
+    assert 'REPO_NAME="multi-model-switch"' in text
+    assert "does not look like the MMS installer" in text
+
+
+def test_wrapper_holds_no_install_logic_of_its_own():
+    """Install behavior belongs in install.sh so a cached wrapper stays correct."""
+    text = ENTRY.read_text(encoding="utf-8")
+
+    for leaked in ("~/.mms", "npm install -g", "pi-coding-agent", "MMS_CONFIG_ROOT"):
+        assert leaked not in text, leaked
+    assert len(text.splitlines()) < 140
+
+
+def test_wrapper_keeps_the_script_and_the_installed_sources_on_one_ref():
+    text = ENTRY.read_text(encoding="utf-8")
+
+    for flag in ("--ref", "--channel", "--dev", "--canary"):
+        assert flag in text, flag
+    assert "function resolveRef" in text
+
+
+def test_wrapper_refuses_windows_with_a_readable_message():
+    text = ENTRY.read_text(encoding="utf-8")
+
+    assert 'process.platform === "win32"' in text
+    assert "WSL" in text
+
+
+def test_package_is_part_of_the_repo_workspaces():
+    root_manifest = json.loads((ROOT_DIR / "package.json").read_text(encoding="utf-8"))
+
+    assert "packages/*" in root_manifest["workspaces"]
+    assert root_manifest.get("private") is True, "only the wrapper is published"


### PR DESCRIPTION
Closes #121

> 叠在 #120 之上。base 是 `issue-117-installer-zero-prompt`，请先合 #120。

## 改动

新增 `packages/mms-install`，发布为 `@ctrixin/mms`。已有 Node 的用户可以用 16 个字符代替 94 个字符的 curl：

```bash
npx @ctrixin/mms
```

curl 仍然是主入口，裸机必须走它，因为 `install.sh` 会在需要时自己用 nvm 准备 Node。npx 要求 Node 已经存在，所以它只能是二等入口。

## 设计

瘦转发包。它下载 `install.sh` 交给 bash 执行，参数原样透传，自身不含任何安装逻辑。这样即使用户 npx 缓存了旧 wrapper，装到的仍然是最新的 MMS，也就不需要为每次 MMS 发版跑一遍 npm publish。

因为它下载并执行远程 shell 脚本，所以保持极小可审计：source host 写死为 `raw.githubusercontent.com`，跳转到其他 host 直接中止，执行前检查内容确实是 MMS 安装器。

`--ref` 和 `--channel` 同时决定去哪个分支取 `install.sh`，避免出现"用新脚本装旧源码"。Windows 上给出指向 WSL 的明确提示，而不是抛 bash 报错。

包自身的版本号不代表装到哪个 MMS 版本，README 里写明了。

## 验证

- fresh-user gate 通过，528 项。新增 `tests/test_npx_installer_package.py` 已纳入 gate 的 pytest target，scenario matrix 新增 `npx-install-entry`。
- `npm pack --dry-run`：3 个文件，2.7 kB。
- wrapper 端到端跑过：`--ref issue-117-installer-zero-prompt --dry-run` 正确下载并执行；坏 ref 退出码 1 并给出可读信息。

## 需要人来做

npm publish 需要账号权限，我没有，也不应该有。scope `ctrixin` 在 npm 上已存在，包名 `@ctrixin/mms` 可用。合并后由人执行：

```bash
cd packages/mms-install && npm publish
```

https://claude.ai/code/session_01W8t8TPXNHeR4AhL5pL7G2k