### PR TITLE
MMS Web 版本提示与页面一键升级

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -342,6 +342,8 @@ No question in the install changes what gets installed: no UI language prompt, n
 
 Use `--launch-web` to open it without asking, `--no-launch-web` to skip it, and `--no-shell-rc` to leave your shell config alone.
 
+Upgrading does not send you back to the terminal. MMS Web checks for a newer release every six hours in the background and shows a badge in the top right when one exists. Upgrading from there installs the new version, restarts the local server and reloads the page. It refuses while sessions are still running, so end those first. Set `MMS_WEB_UPDATE_CHECK=0` to turn the check off; a source checkout is never prompted to upgrade.
+
 `pi` is mandatory because the pilot web app depends on it. It is installed globally from a pinned npm spec, and its runtime cache under `~/.mms/.ai/cache/pi-npx` is warmed during the install so the first pilot launch does not wait on a download. Missing `claude` / `codex` / `opencode` are installed automatically; already-installed CLIs are left untouched. Pass `--install-cli claude,codex` to control that list explicitly, and add `--dry-run` to preview the plan without writing files.
 
 The optional global packs are gone. RTK, BrainKeeper, Map, CodeGraph, global token-saver, global TOON, ops-env-safe, ECC, and OMC no longer have installer paths. Their `--install-*` and `--*-ref` flags print a notice and are ignored, so older scripts keep working.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 
 装完会问一句要不要打开 MMS Web。回车即可，浏览器自动弹出，服务在后台运行，安装进程随即退出。在页面里添加 provider 和 API Key 就能开始对话。
 
+后续升级不用回到终端。MMS Web 会在后台每 6 小时查一次最新 release，有新版本时右上角出现角标，点开可以直接升级：它会在后台装好新版本再重启本地服务，页面自动刷新。升级期间有会话在跑会被拦下，请先结束它们。不想让它查版本就设 `MMS_WEB_UPDATE_CHECK=0`，本地源码安装不会收到升级提示。
+
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,8 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 
 装完会问一句要不要打开 MMS Web。回车即可，浏览器自动弹出，服务在后台运行，安装进程随即退出。在页面里添加 provider 和 API Key 就能开始对话。
 
+后续升级不用回到终端。MMS Web 会在后台每 6 小时查一次最新 release，有新版本时右上角出现角标，点开可以直接升级：它会在后台装好新版本再重启本地服务，页面自动刷新。升级期间有会话在跑会被拦下，请先结束它们。不想让它查版本就设 `MMS_WEB_UPDATE_CHECK=0`，本地源码安装不会收到升级提示。
+
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。
 
 <details>

--- a/apps/mms-web/src/App.tsx
+++ b/apps/mms-web/src/App.tsx
@@ -3,6 +3,7 @@ import {
   ArrowDown,
   ArrowRight,
   ArrowUpRight,
+  ArrowUpCircle,
   Check,
   ChevronRight,
   CircleAlert,
@@ -21,8 +22,23 @@ import {
   ChevronDown,
   X,
 } from "lucide-react";
-import type { Bootstrap, Page, SessionDetail, FileSelection } from "./types";
-import { bootstrap, getSession, listSessions, isPreview, mutate } from "./api";
+import type {
+  Bootstrap,
+  Page,
+  SessionDetail,
+  FileSelection,
+  UpdateStatus,
+} from "./types";
+import {
+  bootstrap,
+  getSession,
+  listSessions,
+  isPreview,
+  mutate,
+  checkForUpdate,
+  startUpgrade,
+  waitForRestart,
+} from "./api";
 import {
   Composer,
   Dialog,
@@ -95,6 +111,12 @@ export function App() {
     readSetting("mms-web-preset", ""),
   );
   const [settingsEdit, setSettingsEdit] = useState({dirty: false, busy: false});
+  const [update, setUpdate] = useState<UpdateStatus | null>(null);
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const [upgradePhase, setUpgradePhase] = useState<
+    "idle" | "starting" | "running" | "failed"
+  >("idle");
+  const [upgradeNote, setUpgradeNote] = useState("");
   const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
   const [search, setSearch] = useState(false);
   const [query, setQuery] = useState("");
@@ -138,6 +160,7 @@ export function App() {
       const result = await bootstrap(signal);
       if (signal?.aborted) return;
       setData(result);
+      setUpdate(result.update || null);
       setConnected(true);
       setError("");
       setWorkspaceId((old) =>
@@ -177,6 +200,36 @@ export function App() {
     if (id) openSession(id);
     // Recover the same conversation on a browser refresh.
   }, []);
+  const runUpgrade = useCallback(async () => {
+    setUpgradePhase("starting");
+    setUpgradeNote("");
+    try {
+      const result = await startUpgrade();
+      if (!result.started) {
+        setUpgradePhase("failed");
+        setUpgradeNote(result.reason || "升级没有开始。");
+        return;
+      }
+      // The server is about to replace itself, so from here the page can only
+      // watch the port and wait for the new one to answer.
+      setUpgradePhase("running");
+      setConnected(false);
+      if (await waitForRestart()) {
+        location.reload();
+        return;
+      }
+      setUpgradePhase("failed");
+      setUpgradeNote(
+        `新版本没有在预期时间内启动。日志在 ${result.logPath || update?.logPath || "~/.local/share/mms-web/upgrade.log"}`,
+      );
+    } catch (error) {
+      setUpgradePhase("failed");
+      setUpgradeNote(
+        error instanceof Error ? error.message : "升级请求失败，请稍后重试。",
+      );
+    }
+  }, [update]);
+
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     saveSetting("mms-web-theme", theme);
@@ -686,6 +739,16 @@ export function App() {
             </strong>
           </div>
           <div className="topbar-actions">
+            {update?.updateAvailable && (
+              <button
+                className="update-badge"
+                onClick={() => setUpdateOpen(true)}
+                title={`有新版本 ${update.latest}`}
+              >
+                <ArrowUpCircle size={15} />
+                <span>{update.latest}</span>
+              </button>
+            )}
             {detail && (
               <Status
                 session={detail.session}
@@ -1282,6 +1345,65 @@ export function App() {
           </div>
           <div className="search-footer">
             <Command size={12} /> K 打开搜索 <span>Esc 关闭</span>
+          </div>
+        </Dialog>
+      )}
+      {updateOpen && update && (
+        <Dialog
+          title={upgradePhase === "running" ? "正在升级" : "有新版本"}
+          dismissible={upgradePhase !== "running"}
+          close={() => {
+            if (upgradePhase === "running") return;
+            setUpdateOpen(false);
+            setUpgradePhase("idle");
+            setUpgradeNote("");
+          }}
+        >
+          <dl className="update-versions">
+            <div>
+              <dt>当前版本</dt>
+              <dd>{update.installed.version || update.installed.ref || "未知"}</dd>
+            </div>
+            <div>
+              <dt>最新版本</dt>
+              <dd>{update.latest}</dd>
+            </div>
+          </dl>
+          {upgradePhase === "running" ? (
+            <p role="status">
+              正在安装新版本，本地服务会重启一次。请保持这个页面打开，装好后会自动刷新。
+            </p>
+          ) : (
+            <p>升级会重启本地服务。进行中的会话会被中断，请先确认没有正在跑的任务。</p>
+          )}
+          {upgradePhase === "failed" && (
+            <p className="update-error" role="alert">
+              {upgradeNote}
+            </p>
+          )}
+          {update.blockedReason && upgradePhase === "idle" && (
+            <p className="update-error">{update.blockedReason}</p>
+          )}
+          <div className="dialog-actions">
+            {upgradePhase !== "running" && (
+              <button
+                className="text-button"
+                onClick={() => {
+                  setUpdateOpen(false);
+                  setUpgradePhase("idle");
+                  setUpgradeNote("");
+                }}
+              >
+                以后再说
+              </button>
+            )}
+            <button
+              className="button primary"
+              disabled={!update.canUpgrade || upgradePhase !== "idle"}
+              onClick={() => void runUpgrade()}
+            >
+              {upgradePhase === "idle" ? "现在升级" : "升级中…"}
+            </button>
           </div>
         </Dialog>
       )}

--- a/apps/mms-web/src/api.ts
+++ b/apps/mms-web/src/api.ts
@@ -1,4 +1,10 @@
-import type { Bootstrap, Session, SessionDetail } from "./types";
+import type {
+  Bootstrap,
+  Session,
+  SessionDetail,
+  UpdateStatus,
+  UpgradeStart,
+} from "./types";
 import { previewBootstrap, previewDetails } from "./preview";
 
 export const isPreview =
@@ -80,6 +86,27 @@ export async function bootstrap(signal?: AbortSignal): Promise<Bootstrap> {
   }
   csrfToken = data.csrfToken;
   return data;
+}
+export async function checkForUpdate(): Promise<UpdateStatus> {
+  return request<UpdateStatus>("/update/check", {});
+}
+export async function startUpgrade(): Promise<UpgradeStart> {
+  return request<UpgradeStart>("/update/start", {});
+}
+/** The server restarts during an upgrade, so a plain fetch is expected to fail
+ *  for a while. Resolves once it answers again. */
+export async function waitForRestart(timeoutMs = 300_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    try {
+      const response = await fetch("/api/update", { cache: "no-store" });
+      if (response.ok) return true;
+    } catch {
+      // still down; keep waiting
+    }
+  }
+  return false;
 }
 export async function listSessions(signal?: AbortSignal): Promise<Session[]> {
   if (isPreview) return structuredClone(sampleBootstrap.sessions);

--- a/apps/mms-web/src/styles.css
+++ b/apps/mms-web/src/styles.css
@@ -3319,3 +3319,38 @@ dialog:has(.model-explorer) .dialog-body > header {
     opacity: 0.3;
   }
 }
+
+.update-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--accent);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.update-badge:hover {
+  border-color: var(--accent);
+}
+.update-versions {
+  display: flex;
+  gap: 28px;
+  margin: 4px 0 14px;
+}
+.update-versions dt {
+  color: var(--muted);
+  font-size: 11px;
+  margin-bottom: 4px;
+}
+.update-versions dd {
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+}
+.update-error {
+  margin-top: 10px;
+  color: var(--danger);
+  font-size: 12px;
+}

--- a/apps/mms-web/src/types.ts
+++ b/apps/mms-web/src/types.ts
@@ -195,6 +195,27 @@ export interface Bootstrap {
   presets: Preset[];
   sessions: Session[];
   diagnostics: { code: string; message: string }[];
+  update?: UpdateStatus;
+}
+export interface UpdateStatus {
+  installed: { ref: string; version: string; channel: string; installedAt: string };
+  latest: string;
+  checkedAt: number;
+  checkEnabled: boolean;
+  comparable: boolean;
+  updateAvailable: boolean;
+  upgradeRunning: boolean;
+  canUpgrade: boolean;
+  blockedReason: string;
+  logPath: string;
+  error: string;
+}
+export interface UpgradeStart {
+  started: boolean;
+  reason?: string;
+  target?: string;
+  port?: number;
+  logPath?: string;
 }
 export interface ConfigPreview {
   revision: string;

--- a/mms_web/__main__.py
+++ b/mms_web/__main__.py
@@ -29,6 +29,10 @@ def main(argv=None):
         parser.error("Web assets are missing. Reinstall MMS v4, or run npm run build --workspace @mms/web in the source checkout.")
     app = WebApplication(state_root=root, config_root=args.config_root)
     server = create_server(app, args.static_root, args.port)
+    # The upgrade helper restarts the server, so it needs the port that was
+    # actually bound, not the one that was requested.
+    app.upgrade.port = server.server_address[1]
+    app.upgrade.start_background_refresh()
     address = f"http://127.0.0.1:{server.server_address[1]}"
     print(f"MMS Web: {address}", flush=True)
     if args.open:

--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -29,9 +29,11 @@ class WebApplication:
     def __init__(self, *, state_root: Path, config_root: Path | None = None):
         from .runtime import require_private_root
         state_root = require_private_root(state_root)
+        real_config_root = config_root is not None
         if config_root is None:
             config_root = state_root / "config"
         self.state_root = state_root
+        self.config_root = config_root
         self.csrf_token = secrets.token_urlsafe(32)
         self.catalog = _adapter(
             "mms_web.catalog", "CatalogService",
@@ -41,6 +43,13 @@ class WebApplication:
             "mms_web.sessions", "SessionService",
             config_root=config_root, state_root=state_root, catalog=self.catalog, real_launch=config_root is not None,
         ) if self.catalog else None
+        from .upgrade import UpgradeService
+        self.upgrade = UpgradeService(
+            state_root=state_root,
+            # An explicit config root is what makes this a real install rather
+            # than a preview, and only a real install can be upgraded.
+            config_root=config_root if real_config_root else None,
+        )
 
     def _model_settings(self):
         if not hasattr(self, "model_settings"):
@@ -89,6 +98,7 @@ class WebApplication:
             **snapshot, "version": "1", "mode": "live",
             "capabilities": capabilities, "csrfToken": self.csrf_token,
             "sessions": self.sessions.list_sessions() if self.sessions else [],
+            "update": self.upgrade.status(),
         }
 
     def get(self, parts: list[str]) -> dict:
@@ -105,6 +115,8 @@ class WebApplication:
                 return self._sessions().runtime_view(parts[1])
             if parts[2] == "commands":
                 return self._sessions().command_catalog(parts[1])
+        if parts == ["update"]:
+            return self.upgrade.status()
         if parts == ["bootstrap"]:
             return self.bootstrap()
         if len(parts) == 2 and parts[0] == "sessions":
@@ -112,6 +124,11 @@ class WebApplication:
         raise WebError("NOT_FOUND", "找不到这个接口。", 404)
 
     def post(self, parts: list[str], payload: dict) -> dict:
+        if parts == ["update", "check"]:
+            return self.upgrade.refresh(force=True)
+        if parts == ["update", "start"]:
+            live = self.sessions.live_session_count() if self.sessions else 0
+            return self.upgrade.start(live_sessions=live)
         if len(parts) == 2 and parts[0] == "model-settings" and parts[1] in {"discover", "check", "preview", "apply"}:
             return getattr(self._model_settings(), parts[1])(payload)
         if parts == ["launch-options"]:

--- a/mms_web/sessions.py
+++ b/mms_web/sessions.py
@@ -315,6 +315,12 @@ class SessionService(SessionActions):
 
     # -- reads ---------------------------------------------------------
 
+    def live_session_count(self) -> int:
+        """Sessions with a running driver. An upgrade restarts the server, so
+        these have to be dealt with before one can start."""
+        with self._lock:
+            return sum(1 for session in self._sessions.values() if session.alive())
+
     def list_sessions(self) -> list[dict]:
         with self._lock:
             sessions = [session.session_view() for session in self._sessions.values()]

--- a/mms_web/upgrade.py
+++ b/mms_web/upgrade.py
@@ -1,0 +1,275 @@
+"""Version reporting and in-place upgrade for MMS Web.
+
+The upgrade replaces ~/.mms, which contains the code this server is running
+from, so it cannot be performed in-process. Instead a detached helper script
+runs the installer, stops this server and starts the new one on the same port.
+The page notices the gap by polling and reconnects on its own.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+RELEASES_URL = "https://api.github.com/repos/CtriXin/multi-model-switch/releases/latest"
+INSTALL_SCRIPT_URL = (
+    "https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh"
+)
+# GitHub allows 60 unauthenticated calls an hour per IP, shared with everything
+# else on this machine. One check every six hours is plenty for a release feed.
+MIN_CHECK_INTERVAL_SECONDS = 6 * 60 * 60
+NETWORK_TIMEOUT_SECONDS = 6
+TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+
+
+def _parse_tag(tag: str) -> tuple[int, int, int] | None:
+    match = TAG_PATTERN.match(str(tag or "").strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def _env_flag(name: str) -> bool | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    return str(raw).strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+class UpgradeService:
+    def __init__(self, *, state_root: Path, config_root: Path | None):
+        self._state_root = Path(state_root)
+        self._config_root = Path(config_root) if config_root else None
+        self._cache_path = self._state_root / "update-check.json"
+        self._log_path = self._state_root / "upgrade.log"
+        self._marker_path = self._state_root / "upgrade-running.json"
+        self.port: int | None = None
+
+    # ── installed side ────────────────────────────────────────────────────
+
+    def _version_metadata(self) -> dict:
+        if not self._config_root:
+            return {}
+        path = self._config_root / "version.json"
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def installed(self) -> dict:
+        meta = self._version_metadata()
+        return {
+            "ref": str(meta.get("installed_ref") or ""),
+            "version": str(meta.get("installed_version") or ""),
+            "channel": str(meta.get("install_channel") or ""),
+            "installedAt": str(meta.get("installed_at") or ""),
+        }
+
+    # ── remote side ───────────────────────────────────────────────────────
+
+    def _read_cache(self) -> dict:
+        try:
+            data = json.loads(self._cache_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write_cache(self, payload: dict) -> None:
+        try:
+            self._state_root.mkdir(parents=True, exist_ok=True)
+            self._cache_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+            )
+        except OSError:
+            pass
+
+    def _fetch_latest(self) -> tuple[str, str]:
+        """Return (tag, error). Network failures are reported, never raised."""
+        request = urllib.request.Request(
+            RELEASES_URL,
+            headers={"Accept": "application/vnd.github+json", "User-Agent": "mms-web"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=NETWORK_TIMEOUT_SECONDS) as response:
+                payload = json.load(response)
+        except urllib.error.HTTPError as error:
+            if error.code in {403, 429}:
+                return "", "GitHub 暂时限制了版本查询频率，稍后会自动重试。"
+            return "", f"版本查询失败（HTTP {error.code}）。"
+        except Exception:
+            return "", "无法连接到 GitHub，网络恢复后会自动重试。"
+        tag = str((payload or {}).get("tag_name") or "").strip()
+        if not _parse_tag(tag):
+            return "", "GitHub 返回的版本号无法识别。"
+        return tag, ""
+
+    def check_enabled(self) -> bool:
+        override = _env_flag("MMS_WEB_UPDATE_CHECK")
+        return True if override is None else override
+
+    # ── status ────────────────────────────────────────────────────────────
+
+    def refresh(self, *, force: bool = False) -> dict:
+        """Query GitHub when the cache is stale. Callers must not be serving a
+        page: this touches the network."""
+        if not self.check_enabled():
+            return self.status()
+        cache = self._read_cache()
+        checked_at = float(cache.get("checkedAt") or 0)
+        if not force and (time.time() - checked_at) < MIN_CHECK_INTERVAL_SECONDS:
+            return self.status()
+        latest, error = self._fetch_latest()
+        self._write_cache({"latest": latest, "checkedAt": time.time(), "error": error})
+        return self.status()
+
+    def start_background_refresh(self) -> None:
+        """One daemon thread, so the first page load never waits on GitHub."""
+        if not self.check_enabled():
+            return
+
+        def loop() -> None:
+            while True:
+                try:
+                    self.refresh()
+                except Exception:
+                    pass
+                time.sleep(MIN_CHECK_INTERVAL_SECONDS)
+
+        thread = threading.Thread(target=loop, name="mms-web-update-check", daemon=True)
+        thread.start()
+
+    # status() is served on the request path, so it only reads the cache.
+    def status(self) -> dict:
+        installed = self.installed()
+        cache = self._read_cache()
+        latest = str(cache.get("latest") or "")
+        checked_at = float(cache.get("checkedAt") or 0)
+        error = str(cache.get("error") or "")
+        if not self.check_enabled():
+            latest, error, checked_at = "", "", 0.0
+
+        installed_parts = _parse_tag(installed["version"])
+        latest_parts = _parse_tag(latest)
+        # A source checkout has no comparable version. Say nothing rather than
+        # nag a developer to "upgrade" over their own working tree.
+        comparable = bool(installed_parts and latest_parts)
+        update_available = bool(comparable and latest_parts > installed_parts)
+
+        blocked = self._upgrade_blocked_reason()
+        return {
+            "installed": installed,
+            "latest": latest,
+            "checkedAt": int(checked_at) if checked_at else 0,
+            "checkEnabled": self.check_enabled(),
+            "comparable": comparable,
+            "updateAvailable": update_available,
+            "upgradeRunning": self.upgrade_running(),
+            "canUpgrade": bool(update_available and not blocked),
+            "blockedReason": blocked,
+            "logPath": str(self._log_path),
+            "error": error,
+        }
+
+    # ── upgrade ───────────────────────────────────────────────────────────
+
+    def upgrade_running(self) -> bool:
+        try:
+            data = json.loads(self._marker_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return False
+        pid = int(data.get("pid") or 0)
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
+
+    def _upgrade_blocked_reason(self) -> str:
+        if not self._config_root:
+            return "这个 MMS Web 没有连接到 MMS 配置，无法升级。"
+        if not shutil.which("bash"):
+            return "找不到 bash，无法运行安装脚本。"
+        if not self.port:
+            return "还没拿到本地服务端口，稍后重试。"
+        return ""
+
+    def start(self, *, live_sessions: int) -> dict:
+        status = self.status()
+        if status["upgradeRunning"]:
+            return {"started": False, "reason": "升级已经在进行中。"}
+        if not status["updateAvailable"]:
+            return {"started": False, "reason": "当前已经是最新版本。"}
+        blocked = self._upgrade_blocked_reason()
+        if blocked:
+            return {"started": False, "reason": blocked}
+        if live_sessions > 0:
+            return {
+                "started": False,
+                "reason": f"还有 {live_sessions} 个会话在运行。升级会重启服务，请先结束它们。",
+            }
+
+        script = self._write_upgrade_script(status["latest"])
+        self._state_root.mkdir(parents=True, exist_ok=True)
+        log = open(self._log_path, "ab", buffering=0)  # noqa: SIM115 - handed to the child
+        try:
+            process = subprocess.Popen(
+                ["bash", str(script)],
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                start_new_session=True,
+                cwd=str(self._state_root),
+            )
+        finally:
+            log.close()
+        self._marker_path.write_text(
+            json.dumps({"pid": process.pid, "startedAt": int(time.time()), "target": status["latest"]})
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"started": True, "target": status["latest"], "port": self.port, "logPath": str(self._log_path)}
+
+    def _write_upgrade_script(self, target: str) -> Path:
+        """The upgrade cannot run in-process: the installer overwrites the code
+        this server is executing. The helper installs first, and only then
+        replaces the running server."""
+        scripts_dir = self._state_root / "upgrade"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        script = scripts_dir / "run-upgrade.sh"
+        web_command = shutil.which("mms-web") or str(Path.home() / ".local/bin/mms-web")
+        script.write_text(
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    "set -o pipefail",
+                    f'echo "=== upgrade to {target} at $(date -u +%FT%TZ) ==="',
+                    'installer="$(mktemp "${TMPDIR:-/tmp}/mms-upgrade.XXXXXX")"',
+                    f'if ! curl -fsSL "{INSTALL_SCRIPT_URL}" -o "$installer"; then',
+                    '  echo "download failed"; rm -f "$installer"; exit 1',
+                    "fi",
+                    # No shell rc writes and no launch prompt: this runs unattended.
+                    'if ! bash "$installer" --no-launch-web --no-shell-rc; then',
+                    '  echo "install failed"; rm -f "$installer"; exit 1',
+                    "fi",
+                    'rm -f "$installer"',
+                    f'kill {os.getpid()} 2>/dev/null || true',
+                    "sleep 2",
+                    f'exec "{web_command}" --config-root "{self._config_root}" --port {self.port}',
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        script.chmod(0o700)
+        return script

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -68,6 +68,7 @@ _PYTEST_TARGETS = [
     "tests/test_mms_resume_command.py",
     "tests/test_reset_mms_install.py",
     "tests/test_install_script_paths.py",
+    "tests/test_web_upgrade.py",
     "tests/test_nsr_bundled_wrapper.py",
     "tests/test_hook_retirement.py",
     "tests/test_owned_superset_hook.py",
@@ -133,6 +134,11 @@ _SCENARIO_MATRIX = [
         "id": "retired-optional-pack-cleanup",
         "state": "upgrade from a version that installed RTK/BrainKeeper/Map/CodeGraph/token-saver/TOON/ops-env-safe/ECC/OMC",
         "coverage": "install unbinds every MMS-written leftover, preserves user-owned lookalikes, backs up Claude settings, and uninstalls no third-party binary",
+    },
+    {
+        "id": "web-update-and-upgrade",
+        "state": "MMS Web on an install that is behind the latest release",
+        "coverage": "the version check stays off the request path and is rate limited and switchable off; a source checkout is never nagged; the upgrade refuses while sessions run, installs before replacing the running server, and leaves a log when it fails",
     },
     {
         "id": "one-question-install",

--- a/tests/test_web_upgrade.py
+++ b/tests/test_web_upgrade.py
@@ -1,0 +1,237 @@
+"""MMS Web version reporting and the in-place upgrade.
+
+No test here reaches the network: the GitHub call is always stubbed.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from mms_web.upgrade import MIN_CHECK_INTERVAL_SECONDS, UpgradeService
+
+
+def _service(tmp_path: Path, *, installed: str | None = "v4.2.0", config: bool = True):
+    state_root = tmp_path / "state"
+    state_root.mkdir(parents=True, exist_ok=True)
+    config_root = tmp_path / "config"
+    if config:
+        config_root.mkdir(parents=True, exist_ok=True)
+        if installed is not None:
+            (config_root / "version.json").write_text(
+                json.dumps(
+                    {
+                        "installed_ref": installed,
+                        "installed_version": installed if installed.count(".") == 2 else "",
+                        "install_channel": "stable",
+                        "installed_at": "2026-09-01T00:00:00Z",
+                    }
+                ),
+                encoding="utf-8",
+            )
+    service = UpgradeService(state_root=state_root, config_root=config_root if config else None)
+    service.port = 8765
+    return service
+
+
+def _stub_latest(service, monkeypatch, tag="v4.3.0", error=""):
+    monkeypatch.setattr(service, "_fetch_latest", lambda: (tag, error))
+
+
+def test_status_reports_an_available_update(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    _stub_latest(service, monkeypatch)
+
+    status = service.refresh(force=True)
+
+    assert status["installed"]["version"] == "v4.2.0"
+    assert status["latest"] == "v4.3.0"
+    assert status["updateAvailable"] is True
+    assert status["canUpgrade"] is True
+    assert status["error"] == ""
+
+
+def test_status_is_quiet_when_already_current(tmp_path, monkeypatch):
+    service = _service(tmp_path, installed="v4.3.0")
+    _stub_latest(service, monkeypatch)
+
+    status = service.refresh(force=True)
+
+    assert status["updateAvailable"] is False
+    assert status["canUpgrade"] is False
+
+
+def test_source_checkout_is_never_told_to_upgrade(tmp_path, monkeypatch):
+    """A developer's working tree has no comparable version."""
+    service = _service(tmp_path, installed="v3.5.0-140-gd5ef85f9")
+    _stub_latest(service, monkeypatch)
+
+    status = service.refresh(force=True)
+
+    assert status["comparable"] is False
+    assert status["updateAvailable"] is False
+
+
+def test_status_does_not_touch_the_network(tmp_path, monkeypatch):
+    """bootstrap() calls status(); a page load must never wait on GitHub."""
+    service = _service(tmp_path)
+
+    def explode():  # pragma: no cover - asserted by not being called
+        raise AssertionError("status() must not fetch")
+
+    monkeypatch.setattr(service, "_fetch_latest", explode)
+    status = service.status()
+
+    assert status["latest"] == ""
+    assert status["updateAvailable"] is False
+
+
+def test_check_is_rate_limited_between_refreshes(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    calls = []
+
+    def counted():
+        calls.append(1)
+        return "v4.3.0", ""
+
+    monkeypatch.setattr(service, "_fetch_latest", counted)
+
+    service.refresh()
+    service.refresh()
+    assert len(calls) == 1, "a fresh cache must not be refetched"
+
+    service.refresh(force=True)
+    assert len(calls) == 2, "an explicit check always refetches"
+
+
+def test_a_stale_cache_is_refreshed(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    _stub_latest(service, monkeypatch)
+    service._write_cache(
+        {"latest": "v4.0.0", "checkedAt": time.time() - MIN_CHECK_INTERVAL_SECONDS - 1, "error": ""}
+    )
+
+    assert service.refresh()["latest"] == "v4.3.0"
+
+
+def test_a_failed_check_is_reported_not_raised(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    _stub_latest(service, monkeypatch, tag="", error="无法连接到 GitHub，网络恢复后会自动重试。")
+
+    status = service.refresh(force=True)
+
+    assert status["updateAvailable"] is False
+    assert "GitHub" in status["error"]
+
+
+def test_the_check_can_be_switched_off(tmp_path, monkeypatch):
+    monkeypatch.setenv("MMS_WEB_UPDATE_CHECK", "0")
+    service = _service(tmp_path)
+
+    def explode():  # pragma: no cover - asserted by not being called
+        raise AssertionError("the check is disabled")
+
+    monkeypatch.setattr(service, "_fetch_latest", explode)
+    status = service.refresh(force=True)
+
+    assert status["checkEnabled"] is False
+    assert status["latest"] == ""
+
+
+def test_upgrade_refuses_while_sessions_are_running(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    _stub_latest(service, monkeypatch)
+    service.refresh(force=True)
+
+    result = service.start(live_sessions=2)
+
+    assert result["started"] is False
+    assert "2" in result["reason"]
+    assert not (service._state_root / "upgrade" / "run-upgrade.sh").exists()
+
+
+def test_upgrade_refuses_when_already_current(tmp_path, monkeypatch):
+    service = _service(tmp_path, installed="v4.3.0")
+    _stub_latest(service, monkeypatch)
+    service.refresh(force=True)
+
+    result = service.start(live_sessions=0)
+
+    assert result["started"] is False
+    assert "最新" in result["reason"]
+
+
+def test_upgrade_refuses_without_a_config_root(tmp_path, monkeypatch):
+    service = _service(tmp_path, config=False)
+    _stub_latest(service, monkeypatch)
+    service.refresh(force=True)
+
+    result = service.start(live_sessions=0)
+
+    assert result["started"] is False
+
+
+def test_upgrade_script_installs_before_replacing_the_server(tmp_path):
+    service = _service(tmp_path)
+    script = service._write_upgrade_script("v4.3.0")
+    body = script.read_text(encoding="utf-8")
+
+    lines = [line.strip() for line in body.splitlines()]
+    install_at = next(i for i, line in enumerate(lines) if "--no-launch-web" in line)
+    kill_at = next(i for i, line in enumerate(lines) if line.startswith("kill "))
+    restart_at = next(i for i, line in enumerate(lines) if line.startswith("exec "))
+
+    assert install_at < kill_at < restart_at, "the server must not die before the install works"
+    # an unattended upgrade must not rewrite the user's shell config
+    assert "--no-shell-rc" in body
+    # the replacement server comes back on the same port and config root
+    assert "--port 8765" in body
+    assert f'--config-root "{tmp_path / "config"}"' in body, "paths must stay quoted"
+    assert oct(script.stat().st_mode)[-3:] == "700"
+
+
+def test_upgrade_script_aborts_when_the_install_fails(tmp_path):
+    service = _service(tmp_path)
+    body = service._write_upgrade_script("v4.3.0").read_text(encoding="utf-8")
+
+    assert 'echo "install failed"; rm -f "$installer"; exit 1' in body
+    assert 'echo "download failed"; rm -f "$installer"; exit 1' in body
+
+
+def test_upgrade_marks_itself_running_and_reports_the_log(tmp_path, monkeypatch):
+    service = _service(tmp_path)
+    _stub_latest(service, monkeypatch)
+    service.refresh(force=True)
+
+    started = {}
+
+    class FakeProcess:
+        pid = 4242
+
+    def fake_popen(*args, **kwargs):
+        started["args"] = args[0]
+        started["session"] = kwargs.get("start_new_session")
+        return FakeProcess()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    result = service.start(live_sessions=0)
+
+    assert result["started"] is True
+    assert result["target"] == "v4.3.0"
+    assert result["logPath"].endswith("upgrade.log")
+    # detached, or it dies with the server it is replacing
+    assert started["session"] is True
+    assert started["args"][0] == "bash"
+
+    marker = json.loads((service._state_root / "upgrade-running.json").read_text(encoding="utf-8"))
+    assert marker["pid"] == 4242
+
+
+def test_a_dead_upgrade_marker_does_not_block_forever(tmp_path):
+    service = _service(tmp_path)
+    (service._state_root / "upgrade-running.json").write_text(
+        json.dumps({"pid": 999999999, "startedAt": 0}), encoding="utf-8"
+    )
+
+    assert service.upgrade_running() is False


### PR DESCRIPTION
Closes #123

> 叠在 #120 之上，base 是 `issue-117-installer-zero-prompt`，因为要用到那里新增的 `--no-launch-web` 和 `--no-shell-rc`。请先合 #120。

## 改动

**版本提示。** 后端比较 `~/.config/mms/version.json` 里的安装版本和 GitHub latest release，结果挂到 bootstrap 的 `update` 字段，前端右上角出角标。

查询跑在 daemon 线程上，不在请求路径上，所以页面加载不会等 GitHub。结果缓存到磁盘，最小间隔 6 小时，重启也不重查，远低于未认证接口每小时 60 次的限制。`MMS_WEB_UPDATE_CHECK=0` 可以关掉。本地源码安装的 `installed_version` 为空，不参与比较，不会被反复提示升级。

**一键升级。** 升级不能在进程内做，因为安装器会覆盖这个服务正在跑的代码。改成 detached 脚本：先装，装成功了才停掉旧服务并在同一端口和 config root 上起新服务。装失败则旧服务保持存活。页面轮询端口，新服务应答后自动刷新；一直不应答就给出日志路径。

有会话在跑时拒绝升级，因为重启会把它们切断。无人值守的这次运行传 `--no-launch-web` 和 `--no-shell-rc`，网页上的一次点击不会顺手改写 shell 配置或再弹一个浏览器。

不做自动升级。

## 验证

- fresh-user gate 通过，535 项。新增 `tests/test_web_upgrade.py` 15 项，覆盖版本比较、缓存下限、关闭开关、源码 checkout 沉默、网络失败、活跃会话拦截，以及生成的升级脚本里"先装后杀"的顺序。已纳入 gate 的 pytest target，scenario matrix 新增 `web-update-and-upgrade`。
- 后端集成实测：bootstrap 含 `update` 字段，`GET /update` 和 `POST /update/start` 行为正确。
- `tsc --noEmit` 在改动的前端文件上无报错。

## 已知项

`src/remarkReadable.ts` 有一个 `mdast` 类型缺失的报错，改动前就存在，未处理。`App.tsx` 和 `types.ts` 在改动前就没通过 prettier，所以没有格式化，避免产生大量无关 diff。

实际升级流程需要在发布后由人在真实环境验证一次，本 PR 未执行真实升级。

https://claude.ai/code/session_01W8t8TPXNHeR4AhL5pL7G2k