### PR TITLE
停止安装 offduty/onduty 与 /nsr，并清理已装条目

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,72 +172,6 @@ ensure_install_ref_resolved() {
     fi
 }
 
-resolve_builtin_handover_root() {
-    local candidate
-    for candidate in \
-        "$MMS_HOME/vendor/handover"; do
-        if [ -f "$candidate/scripts/install_global_commands.py" ]; then
-            (cd "$candidate" 2>/dev/null && pwd -P)
-            return 0
-        fi
-    done
-    return 1
-}
-
-optional_handover_continuity_installed() {
-    local skill_dir
-    local command_dir
-    local handover_root
-    local expected_handover
-    local expected_offduty
-    local expected_onduty
-
-    handover_root="$(resolve_builtin_handover_root || true)"
-    [ -n "$handover_root" ] || return 1
-    expected_handover="$handover_root"
-    expected_offduty="$handover_root/aliases/offduty"
-    expected_onduty="$handover_root/aliases/onduty"
-
-    for skill_dir in \
-        "$REAL_HOME/.agents/skills" \
-        "$REAL_HOME/.claude/skills" \
-        "$REAL_HOME/.codex/skills" \
-        "$REAL_HOME/.config/opencode/skills" \
-        "$REAL_HOME/.opencode/skills"; do
-        [ -L "$skill_dir/handover" ] || return 1
-        [ -L "$skill_dir/offduty" ] || return 1
-        [ -L "$skill_dir/onduty" ] || return 1
-        [ "$(readlink "$skill_dir/handover")" = "$expected_handover" ] || return 1
-        [ "$(readlink "$skill_dir/offduty")" = "$expected_offduty" ] || return 1
-        [ "$(readlink "$skill_dir/onduty")" = "$expected_onduty" ] || return 1
-        [ -x "$skill_dir/offduty/offduty" ] || return 1
-        [ -x "$skill_dir/onduty/onduty" ] || return 1
-    done
-
-    for command_dir in \
-        "$REAL_HOME/.agents/commands" \
-        "$REAL_HOME/.claude/commands" \
-        "$REAL_HOME/.codex/commands" \
-        "$REAL_HOME/.config/opencode/commands" \
-        "$REAL_HOME/.opencode/commands"; do
-        [ ! -e "$command_dir/offduty.md" ] && [ ! -L "$command_dir/offduty.md" ] || return 1
-        [ ! -e "$command_dir/onduty.md" ] && [ ! -L "$command_dir/onduty.md" ] || return 1
-    done
-}
-
-optional_nsr_commands_installed() {
-    local command
-    for command in \
-        "$REAL_HOME/.agents/commands/nsr.md" \
-        "$REAL_HOME/.claude/commands/nsr.md" \
-        "$REAL_HOME/.codex/commands/nsr.md" \
-        "$REAL_HOME/.config/opencode/commands/nsr.md" \
-        "$REAL_HOME/.opencode/commands/nsr.md"; do
-        [ -f "$command" ] || return 1
-        grep -Fq "Managed by MMS builtin NSR" "$command" || return 1
-    done
-}
-
 bundled_session_asset_present() {
     local asset="$1"
     local assets_root="$MMS_HOME/assets/session-assets"
@@ -355,7 +289,6 @@ $(t "说明:" "Notes:")
   - $(t "MMS Web 在后台运行，安装进程随即退出；PATH 默认写入 shell 配置，--no-shell-rc 可关闭" "MMS Web runs in the background and the installer exits right after; PATH is written to your shell config by default and --no-shell-rc turns that off")
   - $(t "pi 是必装项，pilot web 端依赖它；缺失的 claude/codex/opencode 会自动补装，已安装的不会被改动" "pi is mandatory because the pilot web app depends on it; missing claude/codex/opencode are installed automatically while existing ones are left untouched")
   - $(t "内建能力（网页访问、浏览器自动化、省 token 工具、Caveman、NSR）随 MMS 一起安装，只在 MMS 启动的会话里生效" "Built-in tools (web access, browser automation, token savers, Caveman, NSR) ship with MMS and only apply inside sessions MMS starts")
-  - $(t "内置命令 offduty/onduty/nsr 会安装到 Claude、Codex、OpenCode，不注册自动 hook，不改全局配置" "The built-in offduty/onduty/nsr commands are installed for Claude, Codex and OpenCode without registering automatic hooks or changing global config")
   - $(t "--install-cli 可显式指定要补装的 CLI：claude/codex/opencode/pi（逗号分隔）；能用 npm 的 CLI 均走 npm package" "--install-cli explicitly selects which CLIs to install: claude/codex/opencode/pi (comma-separated); CLIs with npm packages are installed through npm")
   - $(t "默认安装 Fira Code 与 JetBrains Mono 到用户字体目录，供 Web 字体选择使用；已装则跳过，--no-coding-fonts 可关闭" "Fira Code and JetBrains Mono are installed into the user font directory for the Web font picker; already-installed families are skipped, and --no-coding-fonts turns this off")
   - $(t "--write-shell-rc 支持 bash/zsh/fish；Ghostty/iTerm/Terminal 重开 tab 后即可直接输入 mms" "--write-shell-rc supports bash/zsh/fish; reopen Ghostty/iTerm/Terminal tabs to type mms directly")
@@ -1959,18 +1892,6 @@ run_install_check() {
     print_cli_install_status
 
     print_bundled_session_asset_status
-
-    if optional_handover_continuity_installed; then
-        echo "✓ $(t "offduty/onduty skill 已安装（handover continuity）" "offduty/onduty skills installed (handover continuity)")"
-    else
-        echo "• $(t "offduty/onduty skill 未安装（内置自动安装；若缺失可重新运行 MMS 安装或升级）" "offduty/onduty skills not installed (built-in auto-install; rerun MMS install or upgrade if missing)")"
-    fi
-
-    if optional_nsr_commands_installed; then
-        echo "✓ $(t "/nsr 命令已安装（NSR）" "/nsr commands installed (NSR)")"
-    else
-        echo "• $(t "/nsr 命令未安装或被自定义覆盖（内置自动安装；若缺失可重新运行 MMS 安装或升级）" "/nsr commands missing or custom-overridden (built-in auto-install; rerun MMS install or upgrade if missing)")"
-    fi
 }
 
 
@@ -1988,7 +1909,6 @@ print_dry_run_plan() {
     if [ -n "$INSTALL_CLI_LIST" ]; then
         echo "• $(t "会安装 CLI" "would install CLI"): $INSTALL_CLI_LIST"
     fi
-    echo "• $(t "会安装内置命令 offduty/onduty/nsr 到 Claude、Codex、OpenCode，不写全局 hooks 或 config" "would install the built-in offduty/onduty/nsr commands for Claude, Codex and OpenCode without writing global hooks or config")"
     echo "• $(t "会预热 pi 运行时 cache" "would warm the pi runtime cache"): $MMS_HOME/.ai/cache/pi-npx"
     if [ "$WRITE_SHELL_RC" -eq 1 ]; then
         echo "• $(t "会把 ~/.local/bin 写入 shell PATH 配置" "would add ~/.local/bin to your shell PATH config")"
@@ -1998,7 +1918,7 @@ print_dry_run_plan() {
         never) echo "• $(t "不会启动 MMS Web" "would not start MMS Web")" ;;
         *) echo "• $(t "装完会询问是否打开 MMS Web；同意则后台启动并打开浏览器" "would ask whether to open MMS Web and, if accepted, start it in the background and open the browser")" ;;
     esac
-    echo "• $(t "会清理旧版本装过的 RTK、BrainKeeper、Map、CodeGraph、全局 token-saver/TOON、ops-env-safe、ECC/OMC" "would clean up RTK, BrainKeeper, Map, CodeGraph, the global token-saver/TOON packs, ops-env-safe, and ECC/OMC left by older versions")"
+    echo "• $(t "会清理旧版本装过的可选包，以及写进各 agent 目录的 offduty/onduty/nsr" "would clean up the optional packs older versions installed, plus the offduty/onduty/nsr entries written into each agent home")"
     echo "  $(t "仅备份移走有 MMS 来源凭据的条目，同名自定义内容和全局配置保留" "Only verified MMS entries are archived; same-name custom content and global settings are preserved")"
     if [ "$INSTALL_CODING_FONTS" = "1" ]; then
         echo "• $(t "会把 Fira Code 与 JetBrains Mono 安装到 $(user_font_dir)（已装则跳过，--no-coding-fonts 关闭）" "would install Fira Code and JetBrains Mono into $(user_font_dir); already-installed families are skipped, --no-coding-fonts turns this off")"
@@ -2272,6 +2192,27 @@ remove_retired_skill_entry() {
     return 0
 }
 
+# Drop a skill link MMS created that points anywhere inside its own install
+# root. The handover pack linked three names per host, so matching one exact
+# vendor path is not enough here.
+remove_retired_mms_symlink() {
+    local target="$1"
+    local link_target=""
+
+    [ -L "$target" ] || return 0
+    link_target="$(readlink "$target" 2>/dev/null || true)"
+    case "$link_target" in
+        "$MMS_HOME"/*)
+            archive_retired_entry "$target"
+            _note_retired_removal "$target"
+            ;;
+        *)
+            echo "  • $(t "非 MMS 链接，保留不动" "Not an MMS link, left unchanged"): $target"
+            ;;
+    esac
+    return 0
+}
+
 # Delete a directory MMS created inside its own install root.
 remove_retired_mms_dir() {
     local target="$1"
@@ -2296,7 +2237,8 @@ cleanup_retired_optional_packs() {
     local hook_dir="$REAL_HOME/.claude/hooks"
     local mirror_dir="$REAL_HOME/auto-skills/installed-skills"
     local wrapper=""
-    local hook_file=""
+    local agent_dir=""
+    local skill=""
 
     RETIRED_PACK_CLEANUP_COUNT=0
     mkdir -p "$MMS_HOME"
@@ -2338,6 +2280,22 @@ cleanup_retired_optional_packs() {
         rmdir "$MMS_HOME/agent-packs" 2>/dev/null || true
     fi
 
+    # offduty / onduty / handover and the /nsr command used to be written into
+    # every agent host's global directory. They are no longer installed, so an
+    # install also takes back what MMS itself wrote there.
+    for agent_dir in \
+        "$REAL_HOME/.agents" \
+        "$REAL_HOME/.claude" \
+        "$REAL_HOME/.codex" \
+        "$REAL_HOME/.config/opencode" \
+        "$REAL_HOME/.opencode"; do
+        for skill in handover offduty onduty; do
+            remove_retired_mms_symlink "$agent_dir/skills/$skill"
+        done
+        remove_retired_marked_file "$agent_dir/commands/nsr.md" \
+            "Managed by MMS builtin NSR"
+    done
+
     if [ -n "$RETIRED_PACK_BACKUP" ]; then
         echo "  $(t "原文件已备份到" "Original entries backed up to"): $RETIRED_PACK_BACKUP"
     fi
@@ -2348,96 +2306,6 @@ cleanup_retired_optional_packs() {
     else
         echo "✓ $(t "已清理旧可选包条目数" "Retired optional pack entries cleaned"): $RETIRED_PACK_CLEANUP_COUNT"
         echo "  $(t "第三方二进制（rtk / codegraph / brainkeeper / node / jq）未被卸载。" "Third-party binaries (rtk / codegraph / brainkeeper / node / jq) were not uninstalled.")"
-    fi
-
-    return 0
-}
-
-install_builtin_handover_continuity() {
-    local handover_root=""
-    local installer_script=""
-
-    echo ""
-    echo "$(t "正在安装内置命令..." "Installing built-in commands...")"
-
-    # Resolve handover root only from the installed MMS vendor pack. If the
-    # packaged vendor copy is missing, skip instead of pointing global skills at
-    # a developer checkout or temporary installer source directory.
-    handover_root="$(resolve_builtin_handover_root || true)"
-
-    if [ -z "$handover_root" ]; then
-        HANDOVER_CONTINUITY_INSTALL_STATUS="missing_source"
-        echo "⚠ $(t "未找到 vendor/handover，跳过 offduty/onduty skill 安装；请确认 MMS vendor 目录完整" "vendor/handover not found, skipping offduty/onduty skill install; verify the MMS vendor directory is complete")"
-        return 0
-    fi
-
-    installer_script="$handover_root/scripts/install_global_commands.py"
-
-    if HOME="$REAL_HOME" "$(_python_bin)" "$installer_script"; then
-        HANDOVER_CONTINUITY_INSTALL_STATUS="installed"
-        echo "✓ $(t "offduty/onduty skill 已安装（handover continuity）" "offduty/onduty skills installed (handover continuity)")"
-    else
-        HANDOVER_CONTINUITY_INSTALL_STATUS="partial"
-        echo "⚠ $(t "offduty/onduty skill 安装未完全成功，可重试或稍后手动安装" "offduty/onduty skill install did not fully succeed; retry or install manually later")"
-    fi
-
-    return 0
-}
-
-write_builtin_nsr_command_file() {
-    local target="$1"
-    local mode="$2"
-    local marker="Managed by MMS builtin NSR"
-    local tmp_file=""
-
-    mkdir -p "$(dirname "$target")"
-    if [ -f "$target" ] \
-        && ! grep -Fq "$marker" "$target" 2>/dev/null \
-        && ! { grep -Fq "# /nsr" "$target" 2>/dev/null && grep -Fq "Non-Stop-Run" "$target" 2>/dev/null && grep -Fq "nsrctl.py" "$target" 2>/dev/null; }; then
-        echo "⚠ $(t "检测到已有自定义 /nsr，跳过覆盖" "Detected custom /nsr command, skipping overwrite"): $target"
-        return 1
-    fi
-
-    tmp_file="$(mktemp "${TMPDIR:-/tmp}/mms-nsr-command.XXXXXX")"
-    cat > "$tmp_file" <<EOF
-<!-- $marker -->
-# /nsr
-
-Use the current task as a bounded manual work loop when explicitly requested.
-
-1. Keep the user objective, success criteria, current evidence and unresolved work in the original task.
-2. Implement one useful slice, then run relevant checks and inspect the actual result.
-3. Continue while useful work remains within the authorized scope. Stop on completion, repeated no-progress, a real blocker, user pause or a decision requiring the owner.
-4. Report what ran, what remains unknown and the next concrete action.
-
-Automatic Stop/compact hooks are retired. This command does not enable repo markers,
-register hooks, send another prompt, or delete existing NSR state. Explicit local
-nsrctl and diagnostic tools remain available when requested; they are not task gates.
-EOF
-
-    mv "$tmp_file" "$target"
-    chmod 644 "$target"
-    return 0
-}
-
-install_builtin_nsr_commands() {
-    local failures=0
-
-    echo ""
-    echo "$(t "正在安装内置命令（续）..." "Installing built-in commands (continued)...")"
-
-    write_builtin_nsr_command_file "$REAL_HOME/.agents/commands/nsr.md" "hook" || failures=$((failures + 1))
-    write_builtin_nsr_command_file "$REAL_HOME/.claude/commands/nsr.md" "hook" || failures=$((failures + 1))
-    write_builtin_nsr_command_file "$REAL_HOME/.codex/commands/nsr.md" "hook" || failures=$((failures + 1))
-    write_builtin_nsr_command_file "$REAL_HOME/.config/opencode/commands/nsr.md" "opencode" || failures=$((failures + 1))
-    write_builtin_nsr_command_file "$REAL_HOME/.opencode/commands/nsr.md" "opencode" || failures=$((failures + 1))
-
-    if [ "$failures" -eq 0 ]; then
-        NSR_COMMAND_INSTALL_STATUS="installed"
-        echo "✓ $(t "/nsr 命令已安装" "/nsr commands installed")"
-    else
-        NSR_COMMAND_INSTALL_STATUS="partial"
-        echo "⚠ $(t "/nsr 命令部分安装；已有自定义命令已保留" "/nsr commands partially installed; custom commands were preserved")"
     fi
 
     return 0
@@ -2669,14 +2537,6 @@ write_language_config
 # ── 清理已退休的可选包（从旧版本升级的机器）──
 cleanup_retired_optional_packs || true
 
-# ── 内置安装：handover continuity (offduty/onduty) ──
-HANDOVER_CONTINUITY_INSTALL_STATUS="not_run"
-install_builtin_handover_continuity
-
-# ── 内置安装：NSR slash commands ──
-NSR_COMMAND_INSTALL_STATUS="not_run"
-install_builtin_nsr_commands
-
 chmod +x "$MMS_HOME/mms"
 [ -f "$MMS_HOME/mms-web" ] && chmod +x "$MMS_HOME/mms-web"
 [ -f "$MMS_HOME/MMS Pilot.command" ] && chmod +x "$MMS_HOME/MMS Pilot.command"
@@ -2778,10 +2638,6 @@ if [ -x "$BIN_DIR/mms" ]; then
         else
             echo "  $(t "当前 shell 还未加载 ~/.local/bin；可先运行绝对路径，或重开 Ghostty/iTerm/Terminal tab 后输入 mms。" "Current shell has not loaded ~/.local/bin yet; run the absolute path now, or reopen your Ghostty/iTerm/Terminal tab and type mms.")"
         fi
-    fi
-    echo ""
-    if [ "$HANDOVER_CONTINUITY_INSTALL_STATUS" != "installed" ] || [ "$NSR_COMMAND_INSTALL_STATUS" != "installed" ]; then
-        echo "  $(t "部分内建命令（offduty/onduty、/nsr）未全部安装；已有自定义命令已保留，重跑安装器可修复。" "Some built-in commands (offduty/onduty, /nsr) were not fully installed; custom commands were preserved and rerunning the installer repairs them.")"
     fi
     echo ""
 

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -137,6 +137,11 @@ _SCENARIO_MATRIX = [
         "coverage": "install unbinds every MMS-written leftover, preserves user-owned lookalikes, backs up Claude settings, and uninstalls no third-party binary",
     },
     {
+        "id": "retired-builtin-commands",
+        "state": "a machine where an older version wrote offduty/onduty/handover and /nsr into all five agent homes",
+        "coverage": "a new install writes none of them and takes back the 20 entries MMS wrote, while same-named user files and foreign symlinks survive",
+    },
+    {
         "id": "one-question-install",
         "state": "installer run with no arguments, with and without a terminal",
         "coverage": "nothing that changes the install is asked; stable channel and shell PATH are the defaults; the only question offers to open MMS Web, which starts detached with a real config root, falls back off a taken port, reuses a running instance, and is skipped without a terminal",

--- a/tests/test_install_script_paths.py
+++ b/tests/test_install_script_paths.py
@@ -773,104 +773,6 @@ def test_install_script_removes_claude_agent_packs():
     assert 'remove_retired_mms_dir "$MMS_HOME/agent-packs/everything-claude-code"' in text
     assert 'remove_retired_mms_dir "$MMS_HOME/agent-packs/oh-my-claudecode"' in text
 
-def test_install_script_uses_bundled_handover_continuity_pack():
-    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
-
-    assert "install_builtin_handover_continuity" in text
-    assert "$MMS_HOME/vendor/handover" in text
-    assert 'HOME="$REAL_HOME" "$(_python_bin)" "$installer_script"' in text
-    assert "$SOURCE_DIR/vendor/handover" not in text
-    assert "$REAL_HOME/auto-skills/shared-skills/handover" not in text
-    assert (ROOT_DIR / "vendor" / "handover" / "scripts" / "install_global_commands.py").exists()
-
-
-# ─── M29: Builtin handover continuity (offduty/onduty) tests ───
-
-def test_install_script_defines_install_builtin_handover_continuity():
-    """install.sh defines install_builtin_handover_continuity function."""
-    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
-    assert "install_builtin_handover_continuity()" in text
-
-
-def test_install_builtin_handover_calls_shared_installer_via_python_bin():
-    """The builtin function calls shared install_global_commands.py via _python_bin."""
-    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
-    # Must reference the shared installer script
-    assert "install_global_commands.py" in text
-    # Must invoke it via _python_bin
-    assert '"$(_python_bin)" "$installer_script"' in text or '"$(_python_bin)" "$installer_script"' in text
-
-
-def test_install_builtin_handover_not_gated_by_brainkeeper_context():
-    """The call to install_builtin_handover_continuity in main flow is NOT gated by --install-brainkeeper-context."""
-    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
-
-    # Find the main-flow call
-    assert "install_builtin_handover_continuity" in text
-
-    # In the main install flow, the call should be unconditional (not inside a
-    # BRAINKEEPER_CONTEXT if-block).
-    # The main flow call appears right after prepare_source_dir and before chmod.
-    # We verify it's not wrapped by INSTALL_BRAINKEEPER_CONTEXT:
-    # Pattern: the function call should appear outside any brainkeeper conditional.
-    lines = text.splitlines()
-    found_call = False
-    for i, line in enumerate(lines):
-        # The main-flow call (not the function definition itself)
-        stripped = line.strip()
-        if "install_builtin_handover_continuity" in stripped and "()" not in stripped:
-            found_call = True
-            # Walk back ~10 lines to ensure no open brainkeeper if
-            context_start = max(0, i - 10)
-            context = "\n".join(lines[context_start:i + 1])
-            assert "INSTALL_BRAINKEEPER_CONTEXT" not in context, (
-                f"install_builtin_handover_continuity call at line {i+1} is gated by INSTALL_BRAINKEEPER_CONTEXT"
-            )
-    assert found_call, "Did not find a main-flow call to install_builtin_handover_continuity"
-
-
-def test_install_builtin_handover_does_not_reference_brainkeeper():
-    """The builtin handover function body does not reference BRAINKEEPER or INSTALL_BRAINKEEPER_CONTEXT."""
-    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
-    body = _extract_shell_function_body(text, "install_builtin_handover_continuity")
-
-    assert "BRAINKEEPER" not in body, (
-        "install_builtin_handover_continuity body references BRAINKEEPER"
-    )
-    assert "INSTALL_BRAINKEEPER_CONTEXT" not in body, (
-        "install_builtin_handover_continuity body references INSTALL_BRAINKEEPER_CONTEXT"
-    )
-def test_handover_installer_installs_skill_surfaces_without_commands(tmp_path):
-    completed = _run_handover_installer(tmp_path)
-
-    assert completed.returncode == 0, completed.stdout + completed.stderr
-    payload = json.loads(completed.stdout)
-    assert payload["ok"] is True
-
-    skill_roots = [
-        tmp_path / ".agents" / "skills",
-        tmp_path / ".claude" / "skills",
-        tmp_path / ".codex" / "skills",
-        tmp_path / ".config" / "opencode" / "skills",
-        tmp_path / ".opencode" / "skills",
-    ]
-    command_roots = [
-        tmp_path / ".agents" / "commands",
-        tmp_path / ".claude" / "commands",
-        tmp_path / ".codex" / "commands",
-        tmp_path / ".config" / "opencode" / "commands",
-        tmp_path / ".opencode" / "commands",
-    ]
-
-    for skill_root in skill_roots:
-        assert (skill_root / "handover").is_symlink()
-        assert (skill_root / "offduty").is_symlink()
-        assert (skill_root / "onduty").is_symlink()
-
-    for command_root in command_roots:
-        assert not (command_root / "offduty.md").exists()
-        assert not (command_root / "onduty.md").exists()
-
 
 def test_handover_public_docs_do_not_hardcode_developer_handover_path():
     """Public handover docs must not tell agents to run a developer checkout path."""
@@ -982,143 +884,6 @@ def test_handover_installer_preserves_unmanaged_command_files(tmp_path):
     assert skipped and skipped[0]["status"] == "skipped_existing_unmanaged"
     assert unmanaged.read_text(encoding="utf-8") == "# user owned\n"
     assert not unmanaged.is_symlink()
-
-
-def test_install_check_reports_handover_installed_when_all_skill_symlinks_present(tmp_path):
-    """--check reports installed only when all managed skill surfaces point to bundled vendor."""
-    home = tmp_path / "home"
-    skill_roots = [
-        home / ".agents" / "skills",
-        home / ".claude" / "skills",
-        home / ".codex" / "skills",
-        home / ".config" / "opencode" / "skills",
-        home / ".opencode" / "skills",
-    ]
-    handover_target = _install_handover_vendor_fixture(home)
-    offduty_target = handover_target / "aliases" / "offduty"
-    onduty_target = handover_target / "aliases" / "onduty"
-
-    for skill_dir in skill_roots:
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "handover").symlink_to(handover_target)
-        (skill_dir / "offduty").symlink_to(offduty_target)
-        (skill_dir / "onduty").symlink_to(onduty_target)
-
-    output = _run_install_check(
-        home=home,
-        extra_env={
-            "REAL_HOME": str(home),
-            "MMS_REAL_HOME": str(home),
-            "ORIGINAL_HOME": str(home),
-        },
-    )
-
-    assert ("offduty/onduty skill 已安装" in output) or ("offduty/onduty skills installed" in output)
-
-
-def test_install_check_reports_handover_missing_when_skill_symlinks_target_old_source(tmp_path):
-    """--check rejects stale handover symlinks even when all names exist."""
-    home = tmp_path / "home"
-    skill_roots = [
-        home / ".agents" / "skills",
-        home / ".claude" / "skills",
-        home / ".codex" / "skills",
-        home / ".config" / "opencode" / "skills",
-        home / ".opencode" / "skills",
-    ]
-    stale_root = tmp_path / "old-shared-skills" / "handover"
-    stale_offduty = stale_root / "aliases" / "offduty"
-    stale_onduty = stale_root / "aliases" / "onduty"
-    for target in (stale_root, stale_offduty, stale_onduty):
-        target.mkdir(parents=True, exist_ok=True)
-
-    for skill_dir in skill_roots:
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "handover").symlink_to(stale_root)
-        (skill_dir / "offduty").symlink_to(stale_offduty)
-        (skill_dir / "onduty").symlink_to(stale_onduty)
-
-    output = _run_install_check(
-        home=home,
-        extra_env={
-            "REAL_HOME": str(home),
-            "MMS_REAL_HOME": str(home),
-            "ORIGINAL_HOME": str(home),
-        },
-    )
-
-    assert ("offduty/onduty skill 未安装" in output) or ("offduty/onduty skills not installed" in output)
-
-
-def test_install_check_reports_handover_missing_when_legacy_commands_exist(tmp_path):
-    """--check rejects duplicate legacy command surfaces next to skill aliases."""
-    home = tmp_path / "home"
-    skill_roots = [
-        home / ".agents" / "skills",
-        home / ".claude" / "skills",
-        home / ".codex" / "skills",
-        home / ".config" / "opencode" / "skills",
-        home / ".opencode" / "skills",
-    ]
-    handover_target = _install_handover_vendor_fixture(home)
-    for skill_dir in skill_roots:
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "handover").symlink_to(handover_target)
-        (skill_dir / "offduty").symlink_to(handover_target / "aliases" / "offduty")
-        (skill_dir / "onduty").symlink_to(handover_target / "aliases" / "onduty")
-
-    commands_dir = home / ".codex" / "commands"
-    commands_dir.mkdir(parents=True)
-    (commands_dir / "offduty.md").symlink_to(handover_target / "commands" / "offduty.md")
-
-    output = _run_install_check(
-        home=home,
-        extra_env={
-            "REAL_HOME": str(home),
-            "MMS_REAL_HOME": str(home),
-            "ORIGINAL_HOME": str(home),
-        },
-    )
-
-    assert ("offduty/onduty skill 未安装" in output) or ("offduty/onduty skills not installed" in output)
-
-
-def test_install_check_reports_handover_missing_when_opencode_skill_symlinks_absent(tmp_path):
-    """--check stays missing when only Claude/Codex skill symlinks exist."""
-    home = tmp_path / "home"
-    claude_skills = home / ".claude" / "skills"
-    codex_skills = home / ".codex" / "skills"
-    claude_skills.mkdir(parents=True)
-    codex_skills.mkdir(parents=True)
-    handover_target = _install_handover_vendor_fixture(home)
-    offduty_target = handover_target / "aliases" / "offduty"
-    onduty_target = handover_target / "aliases" / "onduty"
-
-    for skill_dir in (claude_skills, codex_skills):
-        (skill_dir / "handover").symlink_to(handover_target)
-        (skill_dir / "offduty").symlink_to(offduty_target)
-        (skill_dir / "onduty").symlink_to(onduty_target)
-
-    output = _run_install_check(
-        home=home,
-        extra_env={
-            "REAL_HOME": str(home),
-            "MMS_REAL_HOME": str(home),
-            "ORIGINAL_HOME": str(home),
-        },
-    )
-
-    assert ("offduty/onduty skill 未安装" in output) or ("offduty/onduty skills not installed" in output)
-
-
-def test_install_check_reports_handover_missing_when_symlinks_absent(tmp_path):
-    """--check reports offduty/onduty missing when symlinks do not exist."""
-    home = tmp_path / "home"
-    home.mkdir()
-
-    output = _run_install_check(home=home)
-
-    assert ("offduty/onduty skill 未安装" in output) or ("offduty/onduty skills not installed" in output)
 
 
 def test_install_script_dry_run_mentions_offduty_onduty(tmp_path):
@@ -1569,3 +1334,66 @@ def test_installer_does_not_reuse_another_homes_web_instance(tmp_path):
         assert argv[argv.index('--port') + 1] == '18931'
     finally:
         _stop_fake_mms_web(first_home); _stop_fake_mms_web(second_home)
+
+
+def test_install_script_no_longer_installs_builtin_commands():
+    """offduty/onduty and /nsr are retired: nothing is written to agent homes."""
+    text = INSTALL_SCRIPT.read_text(encoding="utf-8")
+
+    assert "install_builtin_handover_continuity" not in text
+    assert "install_builtin_nsr_commands" not in text
+    assert "write_builtin_nsr_command_file" not in text
+    assert "install_global_commands.py" not in text
+    assert "HANDOVER_CONTINUITY_INSTALL_STATUS" not in text
+    assert "NSR_COMMAND_INSTALL_STATUS" not in text
+    # --check must not report on something the installer no longer manages
+    assert "optional_handover_continuity_installed" not in text
+    assert "optional_nsr_commands_installed" not in text
+
+
+def test_cleanup_takes_back_the_retired_builtin_commands(tmp_path):
+    home = tmp_path / "home"
+    vendor = home / ".mms" / "vendor" / "handover"
+    (vendor / "aliases" / "offduty").mkdir(parents=True)
+    (vendor / "aliases" / "onduty").mkdir(parents=True)
+    hosts = (".agents", ".claude", ".codex", ".config/opencode", ".opencode")
+    for host in hosts:
+        skills = home / host / "skills"
+        commands = home / host / "commands"
+        skills.mkdir(parents=True)
+        commands.mkdir(parents=True)
+        (skills / "handover").symlink_to(vendor)
+        (skills / "offduty").symlink_to(vendor / "aliases" / "offduty")
+        (skills / "onduty").symlink_to(vendor / "aliases" / "onduty")
+        (commands / "nsr.md").write_text(
+            "<!-- Managed by MMS builtin NSR -->\n", encoding="utf-8"
+        )
+
+    _run_retired_cleanup(home)
+
+    for host in hosts:
+        for skill in ("handover", "offduty", "onduty"):
+            assert not (home / host / "skills" / skill).is_symlink(), f"{host}/{skill}"
+        assert not (home / host / "commands" / "nsr.md").exists(), host
+
+
+def test_cleanup_keeps_user_owned_builtin_lookalikes(tmp_path):
+    home = tmp_path / "home"
+    vendor = home / ".mms" / "vendor" / "handover"
+    vendor.mkdir(parents=True)
+    skills = home / ".claude" / "skills"
+    commands = home / ".claude" / "commands"
+    skills.mkdir(parents=True)
+    commands.mkdir(parents=True)
+
+    # a link of the same name pointing somewhere else entirely
+    elsewhere = home / "elsewhere" / "handover"
+    elsewhere.mkdir(parents=True)
+    (skills / "handover").symlink_to(elsewhere)
+    # a hand-written command with the same name
+    (commands / "nsr.md").write_text("my own loop\n", encoding="utf-8")
+
+    _run_retired_cleanup(home)
+
+    assert (skills / "handover").is_symlink()
+    assert (commands / "nsr.md").read_text(encoding="utf-8") == "my own loop\n"


### PR DESCRIPTION
Closes #129

## 问题

安装器每次运行都会往 5 个 agent 目录写入 20 个条目：`handover` / `offduty` / `onduty` 三个 skill 软链，加一个 `nsr.md`。目标是 `~/.agents`、`~/.claude`、`~/.codex`、`~/.config/opencode`、`~/.opencode`。这些能力已经不是产品的一部分，不应该继续往用户全局配置里写。

顺带解决安装过程中间那一大段 JSON：它来自 `vendor/handover/scripts/install_global_commands.py`，安装器只看退出码没有拦截输出。不再调用它，噪音从源头消失。

## 改动

移除两个内置安装步骤、对应的状态变量、`--check` 里的两项报告，以及 usage 和 dry-run 中的相关说明。

退休清理新增这 20 个条目：软链按"指向 `~/.mms`"识别，`nsr.md` 按 `Managed by MMS builtin NSR` 标记识别。手写的同名命令和指向别处的同名软链都会保留。移除方式沿用现有的归档到备份目录，不直接删除。

编程字体安装保持不变。`vendor/handover` 和 NSR payload 仍随包携带，本次只停止写入 agent 目录。

## 验证

- fresh-user gate 通过，528 项。scenario matrix 新增 `retired-builtin-commands`。
- 10 个断言旧行为的测试替换为：不再安装、清理准确、诱饵文件不被误删。
- 手工在 fixture home 上跑了一遍清理：18 个条目移除，自定义 `nsr.md` 和指向别处的 `handover` 软链都保留。

## 已知项

`test_installer_does_not_reuse_another_homes_web_instance` 在本机单独运行时失败，改动前后都一样，完整套件里通过。属于既有问题，未处理。

https://claude.ai/code/session_01W8t8TPXNHeR4AhL5pL7G2k