### PR TITLE
两条安装命令输出对齐：按结果而不是按参数决定版本提示

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1753,15 +1753,31 @@ print_planned_version() {
 # A newcomer running the plain command does not need the channel/ref matrix;
 # one line saying what is being installed is enough. The full overview stays for
 # --version, --check, and anyone who picked a channel or ref explicitly.
+# Decide by outcome, not by arguments. Landing on the newest stable release is
+# the ordinary case and deserves one line, however the caller expressed it: the
+# npm wrapper resolves the release itself and pins --ref so the script and the
+# sources it installs cannot drift apart, and that pin must not be mistaken for
+# a user deliberately choosing an unusual version.
 print_install_headline() {
     local installed_ref=""
+    local stable_ref=""
 
-    if [ -n "$REQUESTED_INSTALL_CHANNEL" ] || [ -n "$INSTALL_REF" ]; then
-        print_version_overview
-        return 0
-    fi
+    case "$REQUESTED_INSTALL_CHANNEL" in
+        dev|canary)
+            print_version_overview
+            return 0
+            ;;
+    esac
 
     ensure_install_ref_resolved
+    if [ -n "$INSTALL_REF" ]; then
+        stable_ref="$(resolve_latest_release_tag || true)"
+        if [ -z "$stable_ref" ] || [ "$RESOLVED_INSTALL_REF" != "$stable_ref" ]; then
+            print_version_overview
+            return 0
+        fi
+    fi
+
     installed_ref="$(current_installed_ref || true)"
     if [ -z "$installed_ref" ]; then
         echo "$(t "安装最新版本" "Installing the latest version"): ${RESOLVED_INSTALL_REF:-local-source}"

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -161,6 +161,11 @@ _SCENARIO_MATRIX = [
         "coverage": "stable release resolution, parameter precedence, matching script/source refs, pinned downloads and temporary cleanup on success/failure",
     },
     {
+        "id": "install-entry-parity",
+        "state": "the same install reached by curl and by the npm wrapper, which pins --ref to the release it resolved",
+        "coverage": "both print the same one-line headline; a genuinely pinned older ref or a dev/canary channel still prints the full version overview",
+    },
+    {
         "id": "one-question-install",
         "state": "installer run with no arguments, with and without a terminal",
         "coverage": "nothing that changes the install is asked; stable channel and shell PATH are the defaults; the only question offers to open MMS Web, which starts detached with a real config root, falls back off a taken port, reuses a running instance, and is skipped without a terminal",

--- a/tests/test_install_script_paths.py
+++ b/tests/test_install_script_paths.py
@@ -1410,3 +1410,53 @@ def test_retired_skill_cleanup_preserves_custom_target_inside_install_root(tmp_p
     _run_retired_cleanup(home)
     assert (skills / "handover").resolve() == custom
     assert (skills / "offduty").read_text() == "user instructions"
+
+
+def _piped_dry_run(tmp_path, *args, stable_ref="v9.9.9"):
+    """Run the installer the way curl and npx do: piped, outside the repo."""
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.update(_version_env_overrides(stable_ref=stable_ref, latest_tag_ref=stable_ref))
+    for name in ("REAL_HOME", "MMS_REAL_HOME", "ORIGINAL_HOME", "MMS_CONFIG_ROOT"):
+        env.pop(name, None)
+    return subprocess.run(
+        ["bash", "-s", "--", "--lang", "en", *args, "--dry-run"],
+        cwd=tmp_path,
+        env=env,
+        input=INSTALL_SCRIPT.read_text(encoding="utf-8"),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def test_headline_is_one_line_for_the_bare_command(tmp_path):
+    out = _piped_dry_run(tmp_path)
+
+    assert "Installing the latest version: v9.9.9" in out
+    assert "Version overview" not in out
+
+
+def test_headline_is_one_line_when_the_wrapper_pins_the_latest_release(tmp_path):
+    """The npm wrapper resolves the release itself and pins --ref so the script
+    and the sources cannot drift. That pin must read like the bare command."""
+    out = _piped_dry_run(tmp_path, "--ref", "v9.9.9")
+
+    assert "Installing the latest version: v9.9.9" in out
+    assert "Version overview" not in out
+
+
+def test_overview_is_shown_when_an_older_version_is_pinned(tmp_path):
+    out = _piped_dry_run(tmp_path, "--ref", "v4.2.0")
+
+    assert "Version overview" in out
+    assert "Planned install ref: v4.2.0" in out
+
+
+def test_overview_is_shown_for_the_dev_and_canary_channels(tmp_path):
+    for channel in ("dev", "canary"):
+        out = _piped_dry_run(tmp_path, "--channel", channel)
+        assert "Version overview" in out, channel
+        assert f"Install channel: {channel}" in out, channel


### PR DESCRIPTION
Closes #146

## 问题

README 把 curl 和 `npx @ctrixin/mms` 描述为等价，实际输出不同。curl 打印一行，npx 打印 8 行版本概览，含 Dev ref、Canary ref、版本轨道、安装通道。这正是之前为新手收掉的噪音，而 npx 用户同样是新手。

## 不是 wrapper 的问题

wrapper 先解析最新 release，从该 tag 取 `install.sh`，再把 `--ref <tag>` 传下去。这一步必要：不传的话 install.sh 会独立再解析一次 stable，两次调用之间发新版就会出现"用旧脚本装新源码"。为了对齐输出去掉这个 pin，等于拿真实竞态换观感。

## 改动

`print_install_headline` 原本看"有没有传 ref/channel"，把 wrapper 的自动 pin 误判成用户主动指定。改成比较最终解析出的 ref 和最新 stable release：装到最新版就一行，装到别的版本才展开完整概览。显式 `--channel dev` / `--canary` 行为不变。

这个判断也更贴近读者关心的事，即将装到哪个版本，而不是请求是怎么写的。

不改 wrapper，因此不需要重新 npm publish。

## 验证

fresh-user gate 通过，630 项。新增 4 个用例覆盖裸命令、wrapper 的 pin、真的钉旧版、dev 与 canary。scenario matrix 新增 `install-entry-parity`。

四种输入也手工在仓库之外跑过一遍，因为本地 checkout 会用 git describe 覆盖解析出的 ref，在仓库内测不到这条路径：

| 输入 | 输出 |
|---|---|
| 裸命令 | `Installing the latest version: v4.10.0` |
| `--ref v4.10.0` | 同上 |
| `--ref v4.2.0` | 完整概览，pinned-ref |
| `--channel dev` | 完整概览，dev |

https://claude.ai/code/session_014SZMM8jTUdxh1C6YJo6wiZ