### PR TITLE
fix(claude): use well-formed deny rule "Bash(rm -rf /*)"

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -2448,7 +2448,7 @@ _CLAUDE_DEFAULT_PERMISSION_ALLOW = [
 ]
 
 _CLAUDE_DEFAULT_PERMISSION_DENY = [
-    "Bash(rm -rf /)*",
+    "Bash(rm -rf /*)",
     "Bash(git push --force *)",
 ]
 

--- a/tests/test_claude_isolation.py
+++ b/tests/test_claude_isolation.py
@@ -2088,7 +2088,7 @@ def test_sanitize_account_claude_settings_payload_strips_session_env():
             },
             "hooks": {"preToolUse": [{"matcher": "*"}]},
             "statusLine": {"type": "command", "command": "/tmp/status.sh"},
-            "permissions": {"allow": ["Read"], "deny": ["Bash(rm -rf /)*"]},
+            "permissions": {"allow": ["Read"], "deny": ["Bash(rm -rf /*)"]},
         }
     )
 


### PR DESCRIPTION
## Summary

- Fix the malformed permission deny rule `"Bash(rm -rf /)*"` → `"Bash(rm -rf /*)"` in `_CLAUDE_DEFAULT_PERMISSION_DENY`; newer Claude Code (2.1.x) validates that rules end at the closing paren and silently skips malformed ones on every launch, so the deny protection was inactive and users hit a settings-fix prompt on each MMS-generated session.
- Sync the same fix in the `test_claude_isolation.py` fixture.

Closes #151

## Test plan

- [x] `python3 -m py_compile mms_launchers.py tests/test_claude_isolation.py`
- [x] `pytest tests/test_claude_isolation.py -k strip_claude` → 2 passed
- [x] Repo-wide grep: no remaining `Bash(rm -rf /)*` occurrences
- [ ] Committee review