### PR TITLE
feat(pilot): 会话消息显示时间戳与回复用时

### DIFF
--- a/apps/mms-web/src/Transcript.tsx
+++ b/apps/mms-web/src/Transcript.tsx
@@ -55,7 +55,7 @@ function Turn({events, completed, forced, report, ...props}: Props & {
       {controls}
       <ProcessEvents {...props} events={collapsed ? pinned : process} />
     </div>}
-    {answer && <EventView {...props} event={{...answer, thinking: undefined}} />}
+    {answer && <EventView {...props} event={{...answer, thinking: undefined}} turnStartedAt={user?.createdAt} />}
     {after.map(event => <EventView key={event.id} {...props} event={event} />)}
     {answer && !!process.length && !collapsed && <div className="turn-process-footer">{controls}</div>}
   </section>;

--- a/apps/mms-web/src/components.tsx
+++ b/apps/mms-web/src/components.tsx
@@ -18,6 +18,7 @@ import { messageAnchor } from "./ConversationOutline";
 import { MessageActions } from "./SessionTools";
 import { AttachmentView } from "./MessageMedia";
 import { ContextUsage } from "./ContextUsage";
+import { formatEventTime, formatEventTimeTitle, turnDuration } from "./time";
 import type {
   Preset,
   SessionDetail,
@@ -247,10 +248,12 @@ export function EventView({
   disconnected = false,
   continuation = false,
   intermediate = false,
+  turnStartedAt,
 }: {
   continuation?: boolean;
   intermediate?: boolean;
   disconnected?: boolean;
+  turnStartedAt?: string;
   event: SessionEvent;
   action?: (
     path: string,
@@ -287,6 +290,14 @@ export function EventView({
     !event.thinking?.trim()
   )
     return null;
+  // The reply spans the whole turn: from the message that started it to the
+  // last update of the answer.
+  const duration =
+    event.kind === "assistant"
+      ? turnDuration(turnStartedAt || event.createdAt, event.updatedAt)
+      : "";
+  const clock = formatEventTime(event.createdAt);
+  const clockTitle = formatEventTimeTitle(event.createdAt);
   return (
     <article
       id={messageAnchor(event.id)}
@@ -303,6 +314,12 @@ export function EventView({
           {event.kind === "assistant" && (
             <span>{event.modelName || detail.session.modelName}</span>
           )}
+          {event.kind === "assistant" && !!clock && (
+            <time className="message-time" dateTime={event.createdAt} title={clockTitle}>
+              {clock}
+            </time>
+          )}
+          {!!duration && <span className="message-duration">用时 {duration}</span>}
         </div>
         {event.thinking && (
           <details className="thinking-block">
@@ -339,6 +356,11 @@ export function EventView({
         </blockquote>)}
         <RichText text={event.text} repair={event.kind === "assistant"} />
         {event.kind === "user" && <ContextUsage event={event} />}
+        {event.kind === "user" && !!clock && (
+          <div className="message-meta">
+            <time dateTime={event.createdAt} title={clockTitle}>{clock}</time>
+          </div>
+        )}
         {event.text && (
           <MessageActions
             detail={detail}

--- a/apps/mms-web/src/preview.ts
+++ b/apps/mms-web/src/preview.ts
@@ -1,6 +1,10 @@
 import type { Bootstrap, SessionDetail, SessionEvent } from "./types";
 
 const time = "2026-09-08T09:00:00Z";
+// Preview turns carry plausible clocks so the timestamp and reply duration
+// read the same way they do in a live session.
+const at = (seconds: number) =>
+  new Date(Date.parse(time) + seconds * 1000).toISOString();
 const event = (
   id: string,
   kind: SessionEvent["kind"],
@@ -40,23 +44,25 @@ export const previewDetails: Record<string, SessionDetail> = {
         "2",
         "assistant",
         "我先看了项目里现有的使用说明和配置流程。最需要减少的，是第一次启动前连续选择工具、服务商、模型和通道的过程。",
+        { createdAt: at(19), updatedAt: at(34) },
       ),
       event(
         "3",
         "tool",
         "README.md\ndocs/getting-started.md\ndocs/MODEL_CONFIG_CONTRACT.md",
-        { title: "阅读了 3 份项目文档", status: "done" },
+        { title: "阅读了 3 份项目文档", status: "done", createdAt: at(36), updatedAt: at(88) },
       ),
       event(
         "4",
         "assistant",
         "建议把第一次使用收敛成三个步骤：\n\n1. **连接自己的模型服务**，只填写必要信息。\n2. **选择工作文件夹**，明确 AI 在哪里工作。\n3. **说出想做的事**，复用一套可用的启动组合。\n\n流程草案已经放在右侧。高级设置保留在运行详情中，需要时再展开。",
+        { createdAt: at(90), updatedAt: at(133) },
       ),
       event(
         "5",
         "approval",
         "将首次使用流程保存到 docs/first-run.md，便于团队一起评审。",
-        { title: "写入一份项目文档", approvalId: "sample-write" },
+        { title: "写入一份项目文档", approvalId: "sample-write", createdAt: at(135) },
       ),
     ],
     artifacts: [
@@ -92,6 +98,7 @@ export const previewDetails: Record<string, SessionDetail> = {
         "2",
         "assistant",
         "已按上手、体验和稳定性整理成可讨论的清单。每个问题都保留了原始描述，便于团队核对。\n\n你可以在右侧阅读示例结果。",
+        { createdAt: at(14), updatedAt: at(47) },
       ),
     ],
     artifacts: [

--- a/apps/mms-web/src/styles.css
+++ b/apps/mms-web/src/styles.css
@@ -1121,6 +1121,25 @@ kbd {
   font-weight: 400;
   color: var(--muted);
 }
+.message-author .message-time,
+.message-author .message-duration {
+  font-size: max(11px, 0.7143rem);
+  font-weight: 400;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  margin-left: auto;
+}
+.message-author .message-time + .message-duration {
+  margin-left: 0;
+}
+.message-meta {
+  margin-top: 6px;
+  font-size: max(11px, 0.7143rem);
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
 .markdown {
   font-size: max(11px, 1.0000rem);
   line-height: 1.85;
@@ -1788,7 +1807,8 @@ dialog:has(.dialog-body.sheet) .dialog-body.sheet > header {
   .markdown {
     font-size: max(11px, 0.9286rem);
   }
-  .message-author span {
+  .message-author span,
+  .message-author .message-time {
     font-size: max(11px, 0.6429rem);
   }
   .approval-event,

--- a/apps/mms-web/src/time.ts
+++ b/apps/mms-web/src/time.ts
@@ -1,0 +1,52 @@
+// Message time and turn duration, shown in the transcript.
+// Durations climb through 秒 / 分 / 小时 / 天 so a long turn never reads as a
+// bare second count.
+
+const CLOCK: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", hour12: false };
+
+function parse(value?: string): Date | null {
+  if (!value) return null;
+  const at = new Date(value);
+  return Number.isNaN(at.getTime()) ? null : at;
+}
+
+/** Local clock time; older messages keep their date so the day stays clear. */
+export function formatEventTime(value?: string): string {
+  const at = parse(value);
+  if (!at) return "";
+  const now = new Date();
+  const clock = at.toLocaleTimeString("zh-CN", CLOCK);
+  if (at.toDateString() === now.toDateString()) return clock;
+  const date = at.toLocaleDateString("zh-CN", at.getFullYear() === now.getFullYear()
+    ? { month: "2-digit", day: "2-digit" }
+    : { year: "numeric", month: "2-digit", day: "2-digit" });
+  return `${date} ${clock}`;
+}
+
+/** Full timestamp for the hover title, so the short label stays short. */
+export function formatEventTimeTitle(value?: string): string {
+  const at = parse(value);
+  return at ? at.toLocaleString("zh-CN") : "";
+}
+
+/** Round a millisecond span to at most two units: 3 天 4 小时, 2 分 13 秒. */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "";
+  const total = Math.max(1, Math.round(ms / 1000));
+  const day = Math.floor(total / 86400);
+  const hour = Math.floor((total % 86400) / 3600);
+  const minute = Math.floor((total % 3600) / 60);
+  const second = total % 60;
+  if (day) return hour ? `${day} 天 ${hour} 小时` : `${day} 天`;
+  if (hour) return minute ? `${hour} 小时 ${minute} 分` : `${hour} 小时`;
+  if (minute) return second ? `${minute} 分 ${second} 秒` : `${minute} 分`;
+  return `${second} 秒`;
+}
+
+/** Time from the turn's start to the last update of the reply. */
+export function turnDuration(startedAt?: string, endedAt?: string): string {
+  const start = parse(startedAt);
+  const end = parse(endedAt);
+  if (!start || !end) return "";
+  return formatDuration(end.getTime() - start.getTime());
+}

--- a/apps/mms-web/src/transcript.css
+++ b/apps/mms-web/src/transcript.css
@@ -49,7 +49,8 @@
   margin-bottom: 8px;
   font-size: max(11px, 0.7857rem);
 }
-.conversation-content .message-author span {
+.conversation-content .message-author span,
+.conversation-content .message-author .message-time {
   font-size: max(11px, 0.7857rem);
 }
 .conversation-content .message.continuation {
@@ -106,6 +107,12 @@
   border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--line));
   border-radius: 16px 16px 4px 16px;
   background: color-mix(in srgb, var(--accent) 5%, var(--surface));
+}
+.conversation-content .message.user .message-meta {
+  font-size: max(11px, 0.7143rem);
+  color: var(--muted);
+  text-align: right;
+  margin-top: 4px;
 }
 .conversation-content .message.user.message-located .message-body {
   outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent);

--- a/apps/mms-web/src/types.ts
+++ b/apps/mms-web/src/types.ts
@@ -93,6 +93,7 @@ export interface SessionEvent {
   answer?: string;
   arguments?: Record<string, unknown>;
   createdAt: string;
+  updatedAt?: string;
   thinking?: string;
   skills?: { id: string; name: string; source: string }[];
   nativeEntryId?: string;

--- a/apps/mms-web/tests/time.test.mjs
+++ b/apps/mms-web/tests/time.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatDuration, turnDuration } from '../src/time.ts';
+
+test('durations climb through seconds, minutes, hours and days', () => {
+ assert.equal(formatDuration(7_000), '7 秒');
+ assert.equal(formatDuration(59_400), '59 秒');
+ assert.equal(formatDuration(133_000), '2 分 13 秒');
+ assert.equal(formatDuration(120_000), '2 分');
+ assert.equal(formatDuration(3_840_000), '1 小时 4 分');
+ assert.equal(formatDuration(7_200_000), '2 小时');
+ assert.equal(formatDuration(97_200_000), '1 天 3 小时');
+ assert.equal(formatDuration(172_800_000), '2 天');
+});
+test('a sub-second reply still reads as a duration, never as an empty label', () => {
+ assert.equal(formatDuration(120), '1 秒');
+ assert.equal(formatDuration(0), '1 秒');
+});
+test('a missing or unusable end time hides the duration instead of guessing', () => {
+ assert.equal(turnDuration('2026-09-10T04:00:00Z', undefined), '');
+ assert.equal(turnDuration(undefined, '2026-09-10T04:00:07Z'), '');
+ assert.equal(turnDuration('nonsense', '2026-09-10T04:00:07Z'), '');
+ assert.equal(formatDuration(-1_000), '');
+});
+test('a turn is measured from its first message to the last update of the reply', () => {
+ assert.equal(turnDuration('2026-09-10T04:00:00Z', '2026-09-10T04:02:13Z'), '2 分 13 秒');
+});

--- a/docs/mms-web/API.md
+++ b/docs/mms-web/API.md
@@ -15,11 +15,13 @@ interface Model { id: string; name: string; family: string; providerId: string; 
 interface Service { id: string; name: string; kind: string; status: 'configured'|'needs_key'|'error'; modelCount: number; detail: string }
 interface Preset { id: string; name: string; description: string; harness: Harness; modelId: string; providerId: string; channel: string; available: boolean; reason?: string }
 interface Session { id: string; title: string; workspaceId: string; harness: Harness; modelName: string; providerName: string; channel: string; state: State; activity?: Activity | null; updatedAt: string; owner: 'web'|'glint'|'external'; capabilities: {send: boolean; stop: boolean; approve: boolean}; summary?: string }
-interface Event { id: string; sequence: number; kind: 'user'|'assistant'|'tool'|'approval'|'notice'; text: string; title?: string; status?: 'running'|'done'|'error'; approvalId?: string; decision?: 'allow'|'deny'; createdAt: string }
+interface Event { id: string; sequence: number; kind: 'user'|'assistant'|'tool'|'approval'|'notice'; text: string; title?: string; status?: 'running'|'done'|'error'; approvalId?: string; decision?: 'allow'|'deny'; createdAt: string; updatedAt?: string }
 interface Artifact { id: string; name: string; kind: 'markdown'|'text'|'csv'|'html'|'image'; path: string; sha256: string; revision: number; versionCount: number; status: 'current'|'changed'|'missing'|'unavailable'; source: 'tool'|'observed'|'legacy' }
 interface SessionDetail { session: Session; events: Event[]; artifacts: Artifact[]; artifactNotice?: string }
 interface Diagnostic { code: string; message: string }
 ```
+
+Event.createdAt 是事件首次写入时间，updatedAt 是最后一次写入时间；界面用 updatedAt 与本轮首条 user 事件的 createdAt 计算回复用时，旧持久化记录没有 updatedAt 时不显示用时，也不回填猜测值。
 
 所有字段是普通文本，不渲染任意 HTML。id 必须稳定且不能包含 secret；model id 应区分同名不同 provider。available 表示当前 Web 路径可用，不是 provider 已实测连通；不能从有 Key 推导真实执行通过。Session state 来自进程/protocol，不能来自模型自述。列表可以包含非 Web owner，但不可给其伪造 send/stop 权限。
 

--- a/mms_web/sessions.py
+++ b/mms_web/sessions.py
@@ -133,6 +133,7 @@ class _LiveSession:
             "kind": str(fields.get("kind") or "notice"),
             "text": str(fields.get("text") or ""),
             "createdAt": now(),
+            "updatedAt": now(),
         }
         for key in ("title", "status", "approvalId", "decision", "arguments", "method", "options", "placeholder", "prefill", "answer", "thinking", "nativeTimestamp", "modelName", "usage", "attachments", "references", "skills", "fileSelections", "contextUsage"):
             if fields.get(key) is not None:
@@ -157,6 +158,8 @@ class _LiveSession:
                 existing[key] = fields[key]
         if fields.get("thinkingAppend") is not None:
             existing["thinking"] = str(existing.get("thinking") or "") + str(fields["thinkingAppend"])
+        # Last write wins as the event's end time; the reply duration reads it.
+        existing["updatedAt"] = now()
         self.updated_at = now()
         return existing
 


### PR DESCRIPTION
## 改动

Pilot 会话此前不显示任何时间。这个 PR 给用户消息和 AI 回复补上时刻，并给 AI 回复补上本轮用时。

- 用户消息在气泡右下角显示时刻；AI 回复在名称行右侧显示时刻和用时。
- 当天只显示时分，跨天带日期，悬停显示完整时间。
- 用时口径：从这一轮的用户消息，到该回复最后一次写入，包含中间的工具执行时间。
- 时长按秒/分/小时/天逐级进位，最多显示两级，例如 `7 秒`、`2 分 13 秒`、`1 小时 4 分`、`1 天 3 小时`，不再是纯秒数。

## 边界

- 事件新增 `updatedAt` 记录最后一次写入时间，作为用时的结束点；`createdAt` 语义不变。
- 旧持久化记录没有 `updatedAt` 时不显示用时，也不回填猜测值。
- 没有改动启动链路、provider/account 决策、bridge 或配置结构。`mms_core.py`、`mms_launchers.py`、`mms_tui.py`、`mms_bridge.py` 等受保护文件未触及。
- 没有重建 `mms_web_static` 发布包，按仓库惯例留给发版构建。

## 验证

- 隔离 Pilot 实例真实对话：用户消息显示 `12:00`，回复显示 `Pi · MiniMax-M2.7 · 12:00 · 用时 7 秒`。未触碰本机已有实例。
- 界面预览模式：显示 `09/08 17:00` 与 `用时 47 秒`。
- `node --test apps/mms-web/tests/*.test.mjs` 12 项通过，其中 4 项是本次新增的时长进位与缺失数据用例。
- `tsc --noEmit` 通过。
- `pytest tests/test_mms_web_sessions_service.py tests/test_mms_web_integration.py tests/test_mms_web_interactions.py` 31 项通过。
- 未跑 fresh-user gate：本次不涉及安装、session index、config root、resume、HOME/XDG 隔离或 wrapper 路径。

https://claude.ai/code/session_01R485qEyQxZRQfWFH9y9H5Z
