### PR TITLE
fix(claude): seed new 2.1.x upsell/dismissal state keys into sessions

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -2351,6 +2351,18 @@ _CLAUDE_OAUTH_UI_STATE_SEED_KEYS = (
     "opusProMigrationComplete",
     "sonnet1m45MigrationComplete",
     "voiceNoticeSeenCount",
+    "autoModeOptInDismissed",
+    "daemonInstallPromptDismissed",
+    "experimentNoticesSeenCount",
+    "fullscreenDownsellSeenCount",
+    "fullscreenUpsellSeenCount",
+    "passesUpsellSeenCount",
+    "projectOnboardingSeenCount",
+    "pushNotifUpsellSeenCount",
+    "rcLongTurnNudgeSeenCount",
+    "remoteControlUpsellSeenCount",
+    "transcriptShareDismissed",
+    "voiceFooterHintSeenCount",
 )
 _CLAUDE_OAUTH_STATE_SCALAR_DICT_ALLOWLIST = ("tipsHistory",)
 _CLAUDE_OAUTH_ACCOUNT_ALLOWLIST = (


### PR DESCRIPTION
## Summary

- 修复 #160：`_CLAUDE_OAUTH_UI_STATE_SEED_KEYS` 补齐 Claude Code 2.1.x 新增的 12 个 UI-state key（`fullscreenUpsellSeenCount`、`fullscreenDownsellSeenCount`、`experimentNoticesSeenCount`、`passesUpsellSeenCount`、`pushNotifUpsellSeenCount`、`remoteControlUpsellSeenCount`、`rcLongTurnNudgeSeenCount`、`projectOnboardingSeenCount`、`voiceFooterHintSeenCount`、`autoModeOptInDismissed`、`daemonInstallPromptDismissed`、`transcriptShareDismissed`）
- 现象：MMS 隔离 session 每次启动都重弹 "Try the new fullscreen renderer?" 等新功能提示，session 内 dismiss 不回写真实 home，计数永远从 0 开始
- 改动范围：仅 allowlist 追加 12 个字符串，seed/sanitize/merge 逻辑零改动

## 验证

- `python3 -m py_compile mms_launchers.py` 通过
- `tests/test_claude_hardening_regressions.py` 中 ui_state/seed 相关 3 个测试通过
- 存量失败已做基线比对：`test_claude_isolation.py` 5 个失败 + `test_codex_gateway_env_seeds_plugin_marketplace_cache` 1 个失败在未改动的 f17b11eb 上同样失败，与本改动无关

## 用户侧注意

合并后如果真实 `~/.claude.json` 里对应 key 仍为 0/缺失，需要先在原生 claude dismiss 一次对应提示，之后 mms session 才会继承计数。