### PR TITLE
fix(launch): let model_policy override the plain-k3 safe-base window guard

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -623,6 +623,21 @@ def _lookup_context_window(model_name, provider_id=None):
     if model_exact is not None:
         return model_exact
 
+    if has_1m_suffix:
+        suffixed_window = _ONE_M_SUFFIX_CONTEXT_WINDOWS.get(lower)
+        if suffixed_window is not None:
+            return suffixed_window
+
+    # User policy is the preferred surface for context size. It must win before
+    # the legacy k3/MiMo safe-base guards that otherwise cap plain model names.
+    policy_window = _capability_context_window(
+        clean,
+        provider_id=provider_id,
+        accepted_sources={"model_policy", "manual_override"},
+    )
+    if policy_window is not None:
+        return policy_window
+
     profile_safe_selector_window = None
     if not has_1m_suffix:
         profile_safe_selector_window = _plain_kimi_k3_profile_context_window(
@@ -631,21 +646,6 @@ def _lookup_context_window(model_name, provider_id=None):
         )
     if profile_safe_selector_window is not None:
         return profile_safe_selector_window
-
-    if has_1m_suffix:
-        suffixed_window = _ONE_M_SUFFIX_CONTEXT_WINDOWS.get(lower)
-        if suffixed_window is not None:
-            return suffixed_window
-
-    # User policy is the preferred surface for context size. It must win before
-    # the legacy MiMo safe-base guard that otherwise caps plain model names.
-    policy_window = _capability_context_window(
-        clean,
-        provider_id=provider_id,
-        accepted_sources={"model_policy", "manual_override"},
-    )
-    if policy_window is not None:
-        return policy_window
 
     if not has_1m_suffix:
         # Latest-approved capability facts are the WebUI/runtime truth after

--- a/tests/test_codex_reasoning_effort_launch.py
+++ b/tests/test_codex_reasoning_effort_launch.py
@@ -39,8 +39,21 @@ def test_claude_kimi_k3_context_env_uses_selector_window(monkeypatch):
 
     monkeypatch.setattr(mms_launchers, "_capability_context_window", fake_capability_context_window)
 
-    assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 262_144
+    assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 1_000_000
     assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_048_576
+
+
+def test_claude_kimi_k3_without_policy_keeps_safe_base_window(monkeypatch):
+    import mms_launchers
+
+    monkeypatch.setattr(
+        mms_launchers,
+        "_load_model_context_overrides",
+        lambda: {"models": {}, "provider_overrides": {}},
+    )
+    monkeypatch.setattr(mms_launchers, "_capability_context_window", lambda *_a, **_k: None)
+
+    assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 262_144
 
 
 def test_get_export_env_for_claude_kimi_k3_sets_effort_and_context(monkeypatch):


### PR DESCRIPTION
## Summary

- `_lookup_context_window` 里 plain-k3 256K profile guard(来自 #90)在 model_policy/manual_override 检查**之前**提前 return,导致 Web 模型页写入的 k3 context 覆盖被静默忽略:UI 显示 1M,launch env 实际拿到 262144(`CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144`)。
- 本 PR 把该 guard 移到 policy 检查之后:用户 policy 存在时优先生效;plain `k3` 仅在无任何 policy/approved facts 时保持 256K 保守默认(safe-base 语义不变)。
- 厂商事实复核(2026-09-10):Kimi Code docs 确认 `k3` 上限 1M、按套餐分档(Moderato 256K / Allegretto+ 1M),无独立 1M 模型 ID,官方建议第三方工具手动设 context window——即用户 policy 正是官方推荐的声明面。

Fixes #166

## Test plan

- [x] `python3 -m py_compile mms_launchers.py`
- [x] targeted pytest:`test_codex_reasoning_effort_launch.py`(翻转固化 bug 的断言 + 新增无 policy 保持 256K 的回归断言)、`test_mimo_1m_context.py`、`test_non_claude_1m_context.py`、`test_capability_resolver.py`、`test_provider_profiles.py`、`test_open_source_hardening.py` — 57 passed;3 个失败经 stash 对照确认在干净 dev 上同样失败(mimo lambda 签名 / capability_resolver fallback / provider_profiles overlay),为存量问题,非本 PR 引入
- [x] 真实配置端到端(model-policy.json 含 k3=1048576):`k3` → `CLAUDE_CODE_MAX_CONTEXT_TOKENS=1048576`、`CLAUDE_CODE_AUTO_COMPACT_WINDOW=1048576`、`CLAUDE_CODE_EFFORT_LEVEL=max`
- [x] 干净环境(无 MMS_CONFIG_ROOT、临时 HOME)无 policy:plain `k3` 仍 262144,`k3[1m]` 仍 1048576,`mimo-v2.5` 仍 262144
- [x] 其他家族回归:`glm-5.2`=1000000、`qwen3-max`=262144 不变
- [x] `scripts/regression_fresh_user_gate.py --quick`:pilot fresh root mismatch 在干净 dev 同样复现,存量问题(关联 #161),非本 PR 引入

## 改动边界

- 只动 `_lookup_context_window` 内部两段 guard 的先后顺序 + 对应测试断言;不碰 model 列表来源、bridge 路由、协议假设、sticky key、TUI 返回结构。
- `k3[1m]` / `kimi-k3` / MiMo plain/suffix 行为全部不变(测试覆盖)。