### PR TITLE
fix(web): --listen all 模式下 Origin 校验与 Host 规则一致

### DIFF
--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -340,14 +340,16 @@ def create_server(app: WebApplication, static_root: Path, port: int = 8765):
 
         def _check_origin(self, *, mutation=False):
             expected_port = self.server.server_address[1]
-            hosts = app.access.allowed_hosts(expected_port)
             if not app.access.accepts(self.headers.get("Host"), expected_port):
                 raise WebError("INVALID_HOST", "只允许访问本机服务地址。", 403)
             origin = self.headers.get("Origin")
-            if origin is not None and origin not in {
-                f"{scheme}://{host}" for host in hosts for scheme in ("http", "https")
-            }:
-                raise WebError("INVALID_ORIGIN", "请在 MMS 本地页面中执行此操作。", 403)
+            if origin is not None:
+                # The page that issued this request must live on a host this
+                # server answers to, judged by the same rule as the Host
+                # header so "--listen all" accepts every interface it serves.
+                parts = urlsplit(origin)
+                if parts.scheme not in ("http", "https") or not app.access.accepts(parts.netloc, expected_port):
+                    raise WebError("INVALID_ORIGIN", "请在 MMS 本地页面中执行此操作。", 403)
             if self.headers.get("Sec-Fetch-Site") == "cross-site":
                 raise WebError("INVALID_ORIGIN", "不允许跨站访问本地服务。", 403)
             if mutation and not secrets.compare_digest(

--- a/tests/test_mms_web_remote_access.py
+++ b/tests/test_mms_web_remote_access.py
@@ -162,3 +162,36 @@ def test_a_tunnel_also_arrives_from_loopback_and_is_not_exempt(serve):
         request.add_header("Cookie", f"{COOKIE}={app.access.token}")
         with urllib.request.urlopen(request, timeout=10) as response:
             assert response.status == 200
+
+
+def _post(port, host, origin, token, csrf):
+    request = urllib.request.Request(f"http://127.0.0.1:{port}/api/v1/does-not-exist",
+                                     data=b"{}", method="POST")
+    request.add_header("Host", host)
+    request.add_header("Origin", origin)
+    request.add_header("X-MMS-CSRF", csrf)
+    request.add_header("Content-Type", "application/json")
+    request.add_header("Cookie", f"{COOKIE}={token}")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+
+
+def test_all_mode_accepts_a_mutation_from_any_interface_it_serves(serve):
+    """Browsers send Origin on every POST; it must pass wherever Host passes."""
+    app, port = serve("all")
+    host = f"10.0.0.5:{port}"  # a second interface the server never detected
+    status, body = _post(port, host, f"http://{host}", app.access.token, app.csrf_token)
+    assert status != 403, body
+    assert b"INVALID_ORIGIN" not in body
+    # A page served from somewhere else is still refused.
+    status, body = _post(port, host, "http://evil.example", app.access.token, app.csrf_token)
+    assert status == 403 and b"INVALID_ORIGIN" in body
+
+
+def test_lan_mode_still_narrows_the_origin_by_host(serve):
+    app, port = serve("lan")
+    status, body = _post(port, f"127.0.0.1:{port}", f"http://10.0.0.5:{port}", app.access.token, app.csrf_token)
+    assert status == 403 and b"INVALID_ORIGIN" in body


### PR DESCRIPTION
接着 #149 的 remote access。审查发现 `_check_origin` 对 `Host` 用 `accepts()`（`all` 模式接受任意字面 IP），对 `Origin` 却只比对 `allowed_hosts()`（回环、配置的 hostname、探测到的那一个 LAN 地址）。浏览器每个 POST 都带 `Origin`，所以 `--listen all` 时从第二块网卡地址（Tailscale / Docker / 另一块 Wi‑Fi）打开页面：读正常，发消息、接入、启动全部 `INVALID_ORIGIN` 403。

改动只有一处：`Origin` 解析出 scheme 与 netloc 后走同一个 `accepts()`。`loopback` / `lan` 模式下 `accepts()` 就是 allowlist 成员判断，行为不变。

测试：`tests/test_mms_web_remote_access.py` 新增两条：`all` 模式下未探测到的接口地址上的 POST 不再 403、外站 Origin 仍拒绝；`lan` 模式仍按 host 收窄。文件 14 通过。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
