### PR TITLE
fix(web): 模型页不再把未设置的 models_endpoint 当成 manual（拉取模型变灰）

### DIFF
--- a/mms_config_web.py
+++ b/mms_config_web.py
@@ -665,7 +665,10 @@ def _preview_bundle_config_from_verified_files(verified_files: dict[str, Any], *
                 "enabled": profile.get("enabled", True) is not False,
                 "role": _safe_text(profile.get("role") or "auto"),
                 "priority": int(profile.get("priority") or 0),
-                "models_endpoint": _safe_text(profile.get("models_endpoint") or "manual"),
+                # An unset endpoint means "/models" everywhere else (config
+                # normalisation, the CLI probe, the publish plan). Only an
+                # explicit "manual" turns model discovery off.
+                "models_endpoint": _safe_text(profile.get("models_endpoint") or "/models"),
                 "protocols": protocols,
                 "supported_clis": _normalize_model_list(profile.get("supported_clis")),
                 "openai_base_url": openai_base_url,

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -1095,6 +1095,41 @@ def test_config_web_preview_bundle_config_from_verified_files_replaces_redacted_
     provider = result["providers"][0]
     assert provider["secret_ref"] == "pending-webui:demo:api_key"
     assert provider["has_api_key"] is True
+    # The profile above never set models_endpoint: discovery stays available,
+    # matching the "/models" default the CLI and the publish plan use.
+    assert provider["models_endpoint"] == "/models"
+
+
+def test_config_web_preview_bundle_config_keeps_explicit_manual_models_endpoint(tmp_path):
+    config_root = tmp_path / "mms-next"
+    generated_dir = config_root / "generated"
+    generated_dir.mkdir(parents=True)
+    profile_path = generated_dir / "provider-profiles.generated.json"
+    router_path = generated_dir / "model-routes.json"
+    profile_path.write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "relay": {"name": "Relay", "protocols": ["openai_chat_completions"], "models_endpoint": "manual"},
+                    "empty": {"name": "Empty", "protocols": ["openai_chat_completions"], "models_endpoint": ""},
+                },
+                "provider": {"default": "relay"},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    router_path.write_text(json.dumps({"routes": {}}), encoding="utf-8")
+
+    result = mms_config_web._preview_bundle_config_from_verified_files(
+        {"profile": {"path": str(profile_path)}, "router": {"path": str(router_path)}},
+        config_root=str(config_root),
+    )
+
+    endpoints = {item["id"]: item["models_endpoint"] for item in result["providers"]}
+    # A relay kept in manual mode on purpose stays manual; a profile that was
+    # published without the field (registry writes "") is not turned manual.
+    assert endpoints == {"relay": "manual", "empty": "/models"}
 
 
 def test_config_web_snapshot_includes_read_only_model_source_status(tmp_path):


### PR DESCRIPTION
## 现象

另一台电脑的 Pilot 模型页，通道 `company` 的「拉取模型」按钮灰掉，悬停提示「通道使用手工模型目录」。

## 根因

`ChannelModels.tsx` 只在 `canDiscover` 为假时禁用按钮；`model_settings_worker.public_rows` 把 `models_endpoint ∈ {manual, none, off}` 判为不可拉取。而在有 approved bundle 的配置根里，通道行来自 `mms_config_web._preview_bundle_config_from_verified_files`，那里对 profile 缺失的 `models_endpoint` 默认填 **`"manual"`**。

registry 发布 profile 时写的是 `str(provider.get("models_endpoint") or "")`，所以一个从未显式设置过该字段的 provider（旧 config 导入、bootstrap 生成）在 bundle 里就是 `""`，到了模型页就变成 manual。同一个值在别处都按 `/models` 处理：`mms_core._normalize_models_endpoint` 写入时默认 `/models`，CLI 探测 `provider.get("models_endpoint", "/models")`，publish plan 的 `_provider_summary` 默认 `/models`。只有 Web 预览这一处默认 manual。

## 改动

`mms_config_web.py` 一行：未设置 → `/models`。显式 `manual` 原样保留，所以手工模型目录的敏感 relay 不受影响（本机 bundle 里所有 manual 通道都是显式写的）。

## 验证

- `tests/test_config_web.py`：原有 preview 测试补断言（未设置 → `/models`）；新增一条同时覆盖显式 `manual` 保留与 `""` 不变 manual。
- `test_config_web.py` + `test_mms_web_model_settings.py`：150 passed, 3 skipped。

## 边界

只影响「拉取模型」按钮是否可点以及经 Web 发布时写回的默认值；不改模型列表实际来源（bundle runtime 下模型仍来自 approved routes），不碰 launcher / bridge。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
