### PR TITLE
feat(mms-web): 会话页 composer 滚动感知折叠

### DIFF
--- a/apps/mms-web/src/App.tsx
+++ b/apps/mms-web/src/App.tsx
@@ -2096,6 +2096,7 @@ export function App() {
                     workspaceId={detail.session.workspaceId}
                     sessionId={detail.session.id}
                     sessionAlive={!!detail.runtime?.alive}
+                    scroll={scroll}
                     onCommand={async (command, args) => {
                       if (command === "export") {
                         exportConversation(detail);

--- a/apps/mms-web/src/Composer.tsx
+++ b/apps/mms-web/src/Composer.tsx
@@ -1,7 +1,7 @@
 import { appendGuidePrompt } from "./guide-content";
 import { readDraft, saveDraft, discardDraft } from "./drafts";
 import { useEffect, useRef, useState } from "react";
-import type { FormEvent, ReactNode } from "react";
+import type { FormEvent, ReactNode, RefObject } from "react";
 import {
   CircleAlert,
   ArrowUp,
@@ -72,6 +72,7 @@ export function Composer({
   guideHandled,
   draftKey: providedDraftKey,
   placeholder = "继续补充你的想法…",
+  scroll,
 }: {
   initialText?: string;
   requiredSkillNames?: string[];
@@ -91,6 +92,8 @@ export function Composer({
   workspaceId?: string;
   sessionId?: string;
   sessionAlive?: boolean;
+  /** Transcript scroller; enables the scroll-aware fold when provided. */
+  scroll?: RefObject<HTMLDivElement | null>;
   onCommand?: (command: string, args: string) => Promise<boolean>;
 }) {
   const draftKey =
@@ -231,6 +234,31 @@ export function Composer({
   const [choice, setChoice] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const input = useRef<HTMLTextAreaElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  // Scroll-aware fold: a deliberate upward scroll in the transcript means
+  // "I am reading", so the composer folds to one line. Scrolling back down,
+  // reaching the latest message, focusing or clicking the box restores it.
+  const [collapsed, setCollapsed] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const collapsedRef = useRef(false);
+  collapsedRef.current = collapsed;
+  const canCollapseRef = useRef((): boolean => false);
+  function setCollapsedState(next: boolean) {
+    if (next) {
+      // Native top-layer popovers would stay floating over the transcript
+      // with their anchor folded away; dismiss them instead.
+      formRef.current
+        ?.querySelectorAll<HTMLElement>("[popover]")
+        .forEach((p) => {
+          try {
+            if (p.matches(":popover-open")) p.hidePopover();
+          } catch {
+            /* engines without the popover API */
+          }
+        });
+    }
+    setCollapsed(next);
+  }
   // The box grew with neither the text nor the window: three rows with an
   // inner scrollbar while the page below it sat empty. It now follows the
   // content up to a share of the viewport, and stops following as soon as the
@@ -238,7 +266,7 @@ export function Composer({
   const dragged = useRef(false);
   function fitToContent() {
     const el = input.current;
-    if (!el || dragged.current) return;
+    if (!el || dragged.current || collapsedRef.current) return;
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, Math.round(window.innerHeight * 0.4))}px`;
   }
@@ -290,6 +318,63 @@ export function Composer({
     else if (!files) dialog.current?.close();
   }, [files]);
   const menu = !dismissed && /^\/[\w:-]*$/.test(text);
+  // Anything that needs the reader's attention or holds an open surface
+  // vetoes the fold; evaluated lazily so the scroll listener never sees
+  // stale state.
+  canCollapseRef.current = () =>
+    !focused &&
+    !menu &&
+    !skillsOpen &&
+    !files &&
+    !help &&
+    !submitting &&
+    !uploading &&
+    !localFilesBusy &&
+    !error &&
+    !uploadErrors.length &&
+    !requirementIssues.length &&
+    !(disabled && reason);
+  useEffect(() => {
+    const el = scroll?.current;
+    if (!el) return;
+    let last = el.scrollTop;
+    let up = 0;
+    let down = 0;
+    const onScroll = () => {
+      const top = el.scrollTop;
+      const delta = top - last;
+      last = top;
+      if (el.scrollHeight - top - el.clientHeight < 48) {
+        up = down = 0;
+        setCollapsedState(false);
+        return;
+      }
+      // Hysteresis: fold only after a real upward intent, unfold eagerly.
+      if (delta < 0) {
+        up += -delta;
+        down = 0;
+      } else if (delta > 0) {
+        down += delta;
+        up = 0;
+      }
+      if (up > 48 && canCollapseRef.current()) {
+        setCollapsedState(true);
+        up = 0;
+      } else if (down > 24) {
+        setCollapsedState(false);
+        down = 0;
+      }
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [scroll]);
+  // A guard flipping on (error, picker, upload…) cancels the fold at once.
+  useEffect(() => {
+    if (collapsed && !canCollapseRef.current()) setCollapsedState(false);
+  });
+  useEffect(() => {
+    if (!collapsed) fitToContent();
+  }, [collapsed]);
   const items = [
     ...commands.filter((c) => sessionId || ["help", "files"].includes(c.name)),
     ...nativeCommands.filter(
@@ -515,11 +600,21 @@ export function Composer({
         />
       )}
       <form
+        ref={formRef}
         className={
           "composer " +
+          (collapsed ? "collapsed " : "") +
           (disabled ? "unavailable " : "") +
           (dragging ? "dragging" : "")
         }
+        onMouseDownCapture={(e) => {
+          if (!collapsed) return;
+          // Buttons (send/stop) keep working in the folded state.
+          if ((e.target as HTMLElement).closest("button")) return;
+          e.preventDefault();
+          setCollapsedState(false);
+          requestAnimationFrame(() => input.current?.focus());
+        }}
         onSubmit={submit}
         onDragEnter={(e) => {
           if (e.dataTransfer.types.some(type => type === "Files" || type === "text/uri-list")) {
@@ -634,6 +729,47 @@ export function Composer({
               ))}
           </div>
         )}
+        {collapsed &&
+          (running ||
+            !!text.trim() ||
+            attachments.some((a) => referencedInText(a)) ||
+            !!references.length ||
+            !!fileSelections.length ||
+            !!selectedSkills.length) && (
+            <div className="composer-summary">
+              {running && (
+                <span className="chip live">
+                  <LoaderCircle size={11} className="spin" />
+                  执行中…
+                </span>
+              )}
+              {!!text.trim() && (
+                <span className="chip">草稿 {text.trim().length} 字</span>
+              )}
+              {attachments.filter((a) => referencedInText(a)).length +
+                references.length >
+                0 && (
+                <span className="chip">
+                  <Paperclip size={11} />
+                  {attachments.filter((a) => referencedInText(a)).length +
+                    references.length}{" "}
+                  个附件
+                </span>
+              )}
+              {!!fileSelections.length && (
+                <span className="chip">
+                  <AtSign size={11} />
+                  {fileSelections.length} 个选段
+                </span>
+              )}
+              {!!selectedSkills.length && (
+                <span className="chip">
+                  <BookOpen size={11} />
+                  {selectedSkills.length} 个 Skills
+                </span>
+              )}
+            </div>
+          )}
         <div className="composer-editor">
           {menu && (
             <div className="command-menu" role="listbox" aria-label="可用命令">
@@ -676,10 +812,15 @@ export function Composer({
               if (box.right - e.clientX < 18 && box.bottom - e.clientY < 18)
                 dragged.current = true;
             }}
+            onFocus={() => {
+              setFocused(true);
+              setCollapsedState(false);
+            }}
+            onBlur={() => setFocused(false)}
             placeholder={
               running ? "补充一条消息，将在当前执行完成后处理…" : placeholder
             }
-            rows={3}
+            rows={2}
             maxLength={50000}
             onPaste={(e) => {
               const paths = localFilePaths(
@@ -715,6 +856,10 @@ export function Composer({
               } else if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
                 void submit();
+              } else if (e.key === "Escape") {
+                // The fold only engages while unfocused; Escape explicitly
+                // hands focus back to the transcript.
+                e.currentTarget.blur();
               }
             }}
           />

--- a/apps/mms-web/src/Composer.tsx
+++ b/apps/mms-web/src/Composer.tsx
@@ -344,11 +344,7 @@ export function Composer({
       const top = el.scrollTop;
       const delta = top - last;
       last = top;
-      if (el.scrollHeight - top - el.clientHeight < 48) {
-        up = down = 0;
-        setCollapsedState(false);
-        return;
-      }
+      const gap = el.scrollHeight - top - el.clientHeight;
       // Hysteresis: fold only after a real upward intent, unfold eagerly.
       if (delta < 0) {
         up += -delta;
@@ -357,7 +353,17 @@ export function Composer({
         down += delta;
         up = 0;
       }
-      if (up > 48 && canCollapseRef.current()) {
+      // The fold itself shrinks the composer and grows the scroller's
+      // clientHeight, moving the gap by ~100px. Gating every transition on
+      // the scroll direction — unfold only on a real downward delta, fold
+      // only when the gap clearly exceeds the layout shift — keeps that
+      // self-inflicted movement from bouncing the state back and forth.
+      if (delta > 0 && gap < 48) {
+        up = down = 0;
+        setCollapsedState(false);
+        return;
+      }
+      if (up > 48 && gap > 240 && canCollapseRef.current()) {
         setCollapsedState(true);
         up = 0;
       } else if (down > 24) {

--- a/apps/mms-web/src/styles.css
+++ b/apps/mms-web/src/styles.css
@@ -2106,8 +2106,8 @@ dialog:has(.dialog-body.sheet) .dialog-body.sheet > header {
    latest message unfolds it. */
 .composer {
   transition:
-    padding 0.18s var(--ease-out),
-    border-radius 0.18s var(--ease-out);
+    padding 0.26s var(--ease-out),
+    border-radius 0.26s var(--ease-out);
 }
 .composer.collapsed {
   padding: 5px 12px;
@@ -2163,7 +2163,7 @@ dialog:has(.dialog-body.sheet) .dialog-body.sheet > header {
   color: var(--accent);
 }
 .session-composer {
-  transition: padding 0.18s var(--ease-out);
+  transition: padding 0.26s var(--ease-out);
 }
 .session-composer:has(.composer.collapsed) {
   padding-top: 2px;

--- a/apps/mms-web/src/styles.css
+++ b/apps/mms-web/src/styles.css
@@ -2101,6 +2101,77 @@ dialog:has(.dialog-body.sheet) .dialog-body.sheet > header {
 .composer.dragging {
   border-color: var(--accent);
 }
+/* Scroll-aware fold: while the transcript is being read (upward scroll), the
+   composer folds to a one-line pill. Focus, click, or returning to the
+   latest message unfolds it. */
+.composer {
+  transition:
+    padding 0.18s var(--ease-out),
+    border-radius 0.18s var(--ease-out);
+}
+.composer.collapsed {
+  padding: 5px 12px;
+  border-radius: 22px;
+  cursor: text;
+}
+.composer.collapsed .composer-editor textarea {
+  min-height: 0 !important;
+  height: 30px !important;
+  max-height: 30px !important;
+  padding-right: 88px;
+  overflow: hidden;
+  resize: none;
+}
+.composer.collapsed .attachment-list,
+.composer.collapsed .selected-skills,
+.composer.collapsed .composer-tools,
+.composer.collapsed .composer-context,
+.composer.collapsed .composer-reason,
+.composer.collapsed .composer-file-hint,
+.composer.collapsed .composer-selections,
+.composer.collapsed .composer-footnote,
+.composer.collapsed .composer-help {
+  display: none;
+}
+/* Send/stop stay reachable in the folded state, pinned to the pill's right. */
+.composer.collapsed .composer-bottom {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-top: 0;
+}
+.composer-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 0 88px 3px 2px;
+}
+.composer-summary .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: var(--soft);
+  color: var(--muted);
+  border-radius: 99px;
+  padding: 1px 9px;
+  font-size: max(11px, 0.7857rem);
+  white-space: nowrap;
+}
+.composer-summary .chip.live {
+  color: var(--accent);
+}
+.session-composer {
+  transition: padding 0.18s var(--ease-out);
+}
+.session-composer:has(.composer.collapsed) {
+  padding-top: 2px;
+  padding-bottom: 6px;
+}
+.session-composer:has(.composer.collapsed) .session-workbar {
+  display: none;
+}
 .drop-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## 背景

会话页底部 composer 常驻过高(输入区 min-height + 工具行 + workbar 叠三层),压缩消息阅读区,小显示器更严重。用户确认的方案:**滚动感知折叠**——向上滚动阅读时折叠为一行,聚焦/点击/回到底部时展开。原型手感已由用户验收。

## 改动

- `Composer.tsx`: 折叠状态机 + 新增 `scroll` prop(传入 transcript 滚动容器即启用)
  - 折叠: 向上滚动累计 >48px 且距底 >240px
  - 展开: 聚焦/点击折叠体/真实向下滚动(delta>0 且距底 <48px 或累计下滚 >24px)
  - 折叠态保留: 单行输入、发送/停止键、摘要 chips(草稿字数/附件数/选段数/Skills 数/执行中)
  - veto 折叠: 聚焦中、SkillPicker/文件弹窗/命令菜单/帮助打开、有错误、上传/提交中
  - 折叠时 dismiss 原生 top-layer popover(避免锚点消失后悬浮孤儿)
  - Esc 失焦;textarea 默认 rows 3→2
- `App.tsx`: 会话页 Composer 传入 `scroll={scroll}`
- `styles.css`: `.composer.collapsed` pill 样式、`.composer-summary` chips、`.session-composer:has(.composer.collapsed)` 联动隐藏 workbar;折叠动画 0.26s

**首页(新会话页)不启用**: composer 嵌在内容流里随内容滚动,非底部固定,折叠无适用场景;不传 `scroll` prop 即完全不变。无屏幕高度门槛,所有尺寸 viewport 一致启用。

## 防闪烁设计(第二个 commit)

折叠自身会改变滚动区 clientHeight,使"距底距离"瞬移 ~100px;若展开条件只看距底阈值,惯性滚动中会自激振荡(逐帧闪),并连带「回到最新消息」按钮闪现。现展开必须带真实向下滚动增量、折叠要求距底大于折叠位移,回路从逻辑上断开。

## 验证

- `tsc --noEmit && vite build` 通过
- Playwright 无头行为测试 **15/15**(preview 示例会话,1280×640 小视口):
  初始展开 / 上滚折叠 / workbar 隐藏 / 发送键保留 / 折叠后惯性滚动不回弹 / 「回到最新消息」折叠后保持可见 / 下滚展开 / 点击展开 / 展开聚焦 / 聚焦时不折叠 / Esc 失焦 / 失焦后可折叠 / 草稿 chip / 回底部自动展开
- 回归报告(本地,`.ai` 被 gitignore): `.ai/regression-reports/2026-09-10-composer-scroll-collapse.md`
- 用户已实机确认: 无闪烁、手感通过

## 明确未覆盖

- 真实流式输出场景(preview 模式无真实流);逻辑上与 `followOutput` 贴底机制一致——贴底跟随时不产生向上滚动增量,不触发折叠
- 移动端触摸滚动(监听同一 scroll 事件,预期一致)

## 任务记录

- Stride 任务 `1d8f13f1ee754c32`;issue 索引 `/Users/xin/issue-tracking/multi-model-switch/2026-09-10-pilot-composer-scroll-collapse.md`
- 本 PR 不含版本号/发布动作
