### PR TITLE
配置根只保留 ~/.config/mms-next：旧根退出、mmd/mmm 退休、安装脚本停掉任何占用默认端口的 Pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ v4 各版累积下来的能力：
 
 | 通道 | 固定关系 | 安装命令 | 适合谁 | 更新节奏 | 质量预期 |
 |---|---|---|---|---|---|
-| Stable | `Stable == main == MMD/mmd` | `--channel stable` | 普通用户、主力生产环境 | 慢，最终固定到 `main` | 纯稳定上线版本，完整 smoke 后推进 |
+| Stable | `Stable == main` | `--channel stable` | 普通用户、主力生产环境 | 慢，最终固定到 `main` | 纯稳定上线版本，完整 smoke 后推进 |
 | Dev | `Dev == dev branch == MMF/mmf` | `--channel dev` | 需要最新修复、愿意接受小幅波动的开发用户 | 快，跟随 `dev` 分支 | 开发中稳定，targeted tests 通过 |
 | Canary | `Canary == canary branch == MMG/mmg` | `--channel canary` | 专门测试新功能或验证修复的用户 | 最快，可每日同步 | 小步高频 commit，允许短期破，但必须方便回滚 |
 
@@ -61,7 +61,7 @@ v4 各版累积下来的能力：
 
 v4.0.0 是 MMS Pilot 的首个大版本，之后 4.x 沿 Dev 继续推进。下列 3.x 轨道为此前分支发布历史，不代表 v4 已晋级各分支：Stable/Main `3.4.z`、Dev `3.5.z`、Canary `3.6.z`。`z` 是各 channel 内的 release 计数：单 commit release 就 `z+1`，复合多个已验证 commits 的 release 也只 bump 一次；未 tag 的日常小步 commit 继续用 git hash 追踪。
 
-维护者本地开发命令矩阵：`mms` 是公开安装副本；`mmd` 指 stable worktree；`mmf` 指 dev worktree；`mmg` 指 canary worktree；`mmm` 指 main worktree。普通用户不需要配置这些 worktree 命令，只需要使用安装器提供的 channel 参数。
+维护者本地开发命令矩阵：`mms` 是公开安装副本；`mmf` 指 dev worktree；`mmg` 指 canary worktree。`mmd` / `mmm` 已退休。所有入口只读 `~/.config/mms-next`。普通用户不需要配置这些 worktree 命令，只需要使用安装器提供的 channel 参数。
 
 ## 维护者开发入口
 
@@ -157,19 +157,17 @@ mms test --provider <provider-id> --cli codex
 
 ```text
 mms -> public installed copy  # 只用于公开版本复现
-mmd -> Stable worktree        # 钉住 legacy ~/.config/mms
 mmf -> Dev worktree           # preview DB root，固定 ~/.config/mms-next
 mmg -> Canary worktree        # preview DB root，固定 ~/.config/mms-next
-mmm -> Main worktree          # main 过渡观察入口，钉住 legacy ~/.config/mms
 ```
 
 当前本机用 `scripts/link_local_channel_commands.sh` 把 5 个命令写到 `~/.local/bin`。另一台家里工作机如果要和白天电脑保持一致，建议同样准备 dev/canary/stable/main worktree 后运行这个脚本；如果只是普通用户安装，仍使用公开 `mms` 安装命令。
 
-启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` / `mmm` 每日检查，`mmd` 每周检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` / `mmd update` / `mmm update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
+启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` 每日检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
 
 ## 配置 Web UI 教程：从通道到模型可见性
 
-这一节讲的是 `mmf config web` 的配置页面，不是 MMS Pilot。配置 Web UI 是现在最适合做教程的入口，比 TUI 更容易截图和解释。注意：`mmf` / `mmg` 都是 preview DB 入口，所以预览 DB 保存跟 `~/.config/mms-next` workflow 绑定；`mms` 现在也默认落在同一个 preview DB root 上，所以保存同样走 `写入预览 DB + 发布`；只有显式钉在 legacy root 的 `mmd` / `mmm` 才会看到 `保存配置` 这种 legacy audited save。等价入口：
+这一节讲的是 `mmf config web` 的配置页面，不是 MMS Pilot。配置 Web UI 是现在最适合做教程的入口，比 TUI 更容易截图和解释。注意：`mmf` / `mmg` 都是 preview DB 入口，所以预览 DB 保存跟 `~/.config/mms-next` workflow 绑定；`mms` 也落在同一个 preview DB root 上，所以保存同样走 `写入预览 DB + 发布`；legacy root 与 `mmd` / `mmm` 已退休，不再有 legacy audited save 入口。等价入口：
 
 ```bash
 mmf config web

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ v4 各版累积下来的能力：
 
 | 通道 | 固定关系 | 安装命令 | 适合谁 | 更新节奏 | 质量预期 |
 |---|---|---|---|---|---|
-| Stable | `Stable == main == MMD/mmd` | `--channel stable` | 普通用户、主力生产环境 | 慢，最终固定到 `main` | 纯稳定上线版本，完整 smoke 后推进 |
+| Stable | `Stable == main` | `--channel stable` | 普通用户、主力生产环境 | 慢，最终固定到 `main` | 纯稳定上线版本，完整 smoke 后推进 |
 | Dev | `Dev == dev branch == MMF/mmf` | `--channel dev` | 作者自己的日常工作机、需要最新修复的人 | 快，跟随 `dev` 分支 | 开发中稳定，targeted tests 通过 |
 | Canary | `Canary == canary branch == MMG/mmg` | `--channel canary` | 每天测试的实验机器 / session | 最快，可每日同步 | 小步高频 commit，允许短期破，但必须方便回滚 |
 
@@ -61,7 +61,7 @@ v4 各版累积下来的能力：
 
 v4.0.0 是 MMS Pilot 的首个大版本，之后 4.x 沿 Dev 继续推进。下列 3.x 轨道为此前分支发布历史，不代表 v4 已晋级各分支：Stable/Main `3.4.z`、Dev `3.5.z`、Canary `3.6.z`。`z` 是各 channel 内的 release 计数：单 commit release 就 `z+1`，复合多个已验证 commits 的 release 也只 bump 一次；未 tag 的日常小步 commit 继续用 git hash 追踪。
 
-当前本机维护者命令已固定：`mms` 是 public installed copy，只用于公开版本复现；`mmd` 指 stable worktree；`mmf` 指 dev worktree；`mmg` 指 canary worktree；`mmm` 指 main worktree。默认 config root 是 `~/.config/mms-next`，`mms` / `mmf` / `mmg` 和 Pilot 网页都落在它上面；`mmd` / `mmm` 被显式钉在 legacy `~/.config/mms`。重新生成本机命令用 `scripts/link_local_channel_commands.sh`。
+当前本机维护者命令已固定：`mms` 是 public installed copy，只用于公开版本复现；`mmf` 指 dev worktree；`mmg` 指 canary worktree。`mmd` / `mmm` 已退休。唯一的 config root 是 `~/.config/mms-next`，`mms` / `mmf` / `mmg` 和 Pilot 网页都落在它上面；legacy `~/.config/mms` 不再被任何入口读取。重新生成本机命令用 `scripts/link_local_channel_commands.sh`。
 
 ## 维护者开发入口
 
@@ -138,19 +138,17 @@ mms test --provider <provider-id> --cli codex
 
 ```text
 mms -> public installed copy  # 只用于公开版本复现
-mmd -> Stable worktree        # 钉住 legacy ~/.config/mms
 mmf -> Dev worktree           # preview DB root，固定 ~/.config/mms-next
 mmg -> Canary worktree        # preview DB root，固定 ~/.config/mms-next
-mmm -> Main worktree          # main 过渡观察入口，钉住 legacy ~/.config/mms
 ```
 
 当前本机用 `scripts/link_local_channel_commands.sh` 把 5 个命令写到 `~/.local/bin`。另一台家里工作机如果要和白天电脑保持一致，建议同样准备 dev/canary/stable/main worktree 后运行这个脚本；如果只是普通用户安装，仍使用公开 `mms` 安装命令。
 
-启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` / `mmm` 每日检查，`mmd` 每周检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` / `mmd update` / `mmm update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
+启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` 每日检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
 
 ## 配置 Web UI 教程：从通道到模型可见性
 
-这一节讲的是 `mmf config web` 的配置页面，不是 MMS Pilot。配置 Web UI 是现在最适合做教程的入口，比 TUI 更容易截图和解释。注意：`mmf` / `mmg` 都是 preview DB 入口，所以预览 DB 保存跟 `~/.config/mms-next` workflow 绑定；`mms` 现在也默认落在同一个 preview DB root 上，所以保存同样走 `写入预览 DB + 发布`；只有显式钉在 legacy root 的 `mmd` / `mmm` 才会看到 `保存配置` 这种 legacy audited save。等价入口：
+这一节讲的是 `mmf config web` 的配置页面，不是 MMS Pilot。配置 Web UI 是现在最适合做教程的入口，比 TUI 更容易截图和解释。注意：`mmf` / `mmg` 都是 preview DB 入口，所以预览 DB 保存跟 `~/.config/mms-next` workflow 绑定；`mms` 也落在同一个 preview DB root 上，所以保存同样走 `写入预览 DB + 发布`；legacy root 与 `mmd` / `mmm` 已退休，不再有 legacy audited save 入口。等价入口：
 
 ```bash
 mmf config web

--- a/docs/AGENT_GUARDRAILS.md
+++ b/docs/AGENT_GUARDRAILS.md
@@ -137,6 +137,16 @@
 - 为了实现新功能，直接覆盖已有选择流程、确认流程或 bridge 路由
 - 把一次性的实验逻辑直接变成默认行为，且没有显式开关或任务上下文说明
 
+## Single Config Root（2026-09-10，#177）
+
+配置只有一个来源：`~/.config/mms-next`。这条高于任何"兼容旧目录"的实现倾向：
+
+- `mms` / `mmf` / `mmg` / Pilot 都读写同一个根；Pilot 保存通道后 terminal 读到的是同一份 approved bundle。
+- legacy `~/.config/mms` 已退出配置来源：不做自动导入，不做回退，`MMS_CONFIG_ROOT_MODE=stable` 被忽略；`mmd` / `mmm` 包装器已退休。
+- `~/.config/mms/*-gateway/`、`accounts/`、`fake-upstream/` 仍是运行时 / 会话状态目录，不是配置；Codex gateway `CODEX_HOME` 契约不变。
+- 安装脚本会请任何占用默认端口的 Pilot 退出（不按安装目录区分），并用 `source|config_root|version` 判断已有实例，避免第二个 8766 实例和跨进程 403。
+- 新增一处读取 `~/.config/mms` 作为配置来源属于回归；`tests/test_single_config_root.py` 与 fresh-user gate 覆盖这条契约。
+
 ## Global OAuth Hard Cut
 
 这条规则高于一般“方便复用”的实现倾向：

--- a/docs/RELEASE_CHANNELS.md
+++ b/docs/RELEASE_CHANNELS.md
@@ -6,7 +6,7 @@ MMS 采用 Stable / Dev / Canary 三通道。目标是把“普通用户能放�
 
 除非人类明确要求修改 release/channel contract，否则 LLM / agent 不要重命名、重映射或混用以下关系：
 
-- `Stable == main == MMD/mmd`：纯稳定上线版本；等待 stable 追到当前能力后，`main` 就是默认稳定分支。
+- `Stable == main`：纯稳定上线版本；等待 stable 追到当前能力后，`main` 就是默认稳定分支。`mmd` / `mmm` 本机观察入口已退休（2026-09-10）。
 - `Dev == dev branch == MMF/mmf`：日常开发通道；给作者工作机常用，但仍要保持“开发中稳定”。
 - `Canary == canary branch == MMG/mmg`：每天测试的实验通道；小步迭代、频繁 commit，方便随时回滚。
 
@@ -14,15 +14,15 @@ MMS 采用 Stable / Dev / Canary 三通道。目标是把“普通用户能放�
 
 - 本机维护者命令由 `scripts/link_local_channel_commands.sh` 生成到 `~/.local/bin`。
 - `mms` 固定为 public installed copy，只用于公开版本复现，不作为日常本地开发入口。
-- `mmd` 指向 stable worktree；`mmf` 指向 dev worktree；`mmg` 指向 canary worktree；`mmm` 指向 main worktree。
-- 默认 config root 是 `~/.config/mms-next`，保存 v2 DB 真值。`mms` / `mmf` / `mmg` 都落在这个根上，Pilot 网页默认也用它，所以一处配置在命令行和网页都生效。
-- `mmd` / `mmm` 由包装器显式钉在 legacy `~/.config/mms` 上（`MMS_CONFIG_ROOT` 加 `MMS_CONFIG_ROOT_MODE=stable`），用于观察旧 stable 配置；不显式钉住就会跟随新默认。
+- `mmf` 指向 dev worktree；`mmg` 指向 canary worktree。`mmd` / `mmm` 已退休，`scripts/link_local_channel_commands.sh` 会删除它写过的这两个包装器。
+- 唯一的 config root 是 `~/.config/mms-next`，保存 v2 DB 真值。`mms` / `mmf` / `mmg` 和 Pilot 网页都落在这个根上，所以一处配置在命令行和网页都生效。
+- legacy `~/.config/mms` 已退出配置来源：任何入口都不再读取或自动导入它，`MMS_CONFIG_ROOT_MODE=stable` 被忽略。gateway 会话目录仍可位于 `~/.config/mms/*-gateway/`，那是运行时状态，不是配置。
 
 ## 通道定义
 
 | Channel | 固定关系 | Git source | 安装参数 | 用户 | 规则 |
 |---|---|---|---|---|---|
-| Stable | Stable == `main` == `mmd` | `main` / GitHub Release / `release/stable-*` | `--channel stable` / `--stable` | 普通用户、生产环境 | 纯稳定上线版本，只收验证过的修复和兼容功能 |
+| Stable | Stable == `main` | `main` / GitHub Release / `release/stable-*` | `--channel stable` / `--stable` | 普通用户、生产环境 | 纯稳定上线版本，只收验证过的修复和兼容功能 |
 | Dev | Dev == `dev` == `mmf` | `dev` | `--channel dev` / `--dev` | 作者日常工作机、需要最新修复的人 | 开发中稳定，小步提交，targeted tests 通过 |
 | Canary | Canary == `canary` == `mmg` | `canary` | `--channel canary` / `--canary` | 测试机、夜间试验 | 最快实验分支，小步高频 commit，必须方便回滚 |
 
@@ -46,7 +46,7 @@ MMS 采用 Stable / Dev / Canary 三通道。目标是把“普通用户能放�
 - `dev` 和 `canary` 已从当前 main 切出；后续新功能优先进入 `dev` / `canary`，再按验证结果进入 Stable。
 - `release/stable-v3.3-no-db` 继续作为 stable 维护线，逐步 cherry-pick 已验证的 Web UI / Thinking / model route 修复。
 - 开发过程中发现的 bug 必须先修复，再进入 Stable；Stable 不接收“已知会破坏主流程”的变更。
-- 等 stable 追上当前主功能后，目标语义是 `main == Stable/default == mmd`；日常开发不要继续直接把 `main` 当 Dev。
+- 等 stable 追上当前主功能后，目标语义是 `main == Stable/default`；日常开发不要继续直接把 `main` 当 Dev。
 
 ## 本机命令矩阵
 
@@ -55,12 +55,10 @@ MMS 采用 Stable / Dev / Canary 三通道。目标是把“普通用户能放�
 | Command | 语义 | 当前目标 | Config root | 用途 |
 |---|---|---|---|---|
 | `mms` | Public installed MMS | `~/.mms/mms` | 默认 `~/.config/mms-next` | 只用于公开版本问题复现 |
-| `mmd` | Stable | `.worktrees/stable-v3.3-no-db/mms` | 钉住 `~/.config/mms` | stable 线验证 |
 | `mmf` | Dev | 仓库根目录 `dev` checkout 的 `mmf` | 强制 `~/.config/mms-next` | 日常开发 / DB preview |
 | `mmg` | Canary | `.worktrees/canary/mms` | 强制 `~/.config/mms-next` | 每日实验 / 快速回滚 |
-| `mmm` | Main | 当前 main worktree `mms` | 钉住 `~/.config/mms` | main 过渡观察入口 |
 
-- `main`：未来等同 Stable/default branch；当前用 `mmm` 明确区分 main 过渡入口。
+- `main`：未来等同 Stable/default branch。
 - `dev`：作者平时常用的开发通道；固定对应 `MMF/mmf`，且维护者默认从仓库根目录进入这个 clean `dev` checkout。
 - `canary`：最激进的金丝雀通道；固定对应 `MMG/mmg`。
 - 重新生成本机命令时运行：`scripts/link_local_channel_commands.sh`。
@@ -75,10 +73,8 @@ MMS 采用 Stable / Dev / Canary 三通道。目标是把“普通用户能放�
 | Command | 检查频率 | 默认动作 | 手动更新 |
 |---|---|---|---|
 | `mms` | daily | 只提示 public installed copy，不自动更新 | `mms update` 只说明走 installer/release 更新 |
-| `mmd` | weekly | fetch 后提示；stable 不自动更新 | `mmd update` 仅允许 clean worktree fast-forward |
 | `mmf` | daily | fetch 后提示 dev 更新 | `mmf update` 仅允许 clean worktree fast-forward |
 | `mmg` | every launch | 每次 fetch 并提示 canary ahead/behind/diverged | `mmg update` 仅允许 clean worktree fast-forward |
-| `mmm` | daily | fetch 后提示 main 更新 | `mmm update` 仅允许 clean worktree fast-forward |
 
 安全规则：dirty worktree 拒绝更新；只允许 `git merge --ff-only`；分叉时只提示，不自动 merge/reset；检查状态写到 `~/.local/state/mms/channel-updates.json`，不写 `~/.config/mms/**`。
 

--- a/docs/mms-web/GETTING-STARTED.md
+++ b/docs/mms-web/GETTING-STARTED.md
@@ -46,7 +46,7 @@ macOS 也可以在 Finder 打开 `~/.mms/MMS Pilot.command`。如果从 Finder �
 
 ## 已经在使用 MMF
 
-`mmf` 指向开发工作树，`mmd` 指向 stable，`mmg` 指向 canary，`mmm` 指向 main，`mms` 是公开安装副本。这些命令的通道意义没有改变。只有包含 v4 代码的工作树才能运行新的 `web` 子命令。
+`mmf` 指向开发工作树，`mmg` 指向 canary，`mms` 是公开安装副本；`mmd` / `mmm` 已退休，所有入口只读 `~/.config/mms-next`。只有包含 v4 代码的工作树才能运行新的 `web` 子命令。
 
 如果对应的 MMF 工作树已经更新到 v4：
 

--- a/install.sh
+++ b/install.sh
@@ -288,7 +288,7 @@ $(t "说明:" "Notes:")
   - $(t "--lang 可设置默认 UI 语言（zh / en）" "--lang sets the default UI language (zh / en)")
   - $(t "安装过程零交互：不询问可选包，也不询问 UI 语言；唯一的提问是装完之后要不要打开 MMS Web" "The install is non-interactive: no optional-pack questions and no UI language prompt; the only question comes after everything is installed and just offers to open MMS Web")
   - $(t "--launch-web 跳过提问直接打开，--no-launch-web 完全不打开；没有终端时不提问，只打印命令" "--launch-web opens it without asking, --no-launch-web never opens it; with no terminal available nothing is asked and the command is printed instead")
-  - $(t "检测到 Pilot 正在使用该安装目录时，默认请它退出后继续安装；--keep-running-pilot 改为暂停安装" "When Pilot is using the installation, it is asked to exit and the install continues; --keep-running-pilot stops the install instead")
+  - $(t "检测到 Pilot 正在使用该安装目录或占用默认端口时，默认请它退出后继续安装；--keep-running-pilot 改为暂停安装" "When a Pilot is using the installation or holding the default port, it is asked to exit and the install continues; --keep-running-pilot stops the install instead")
   - $(t "MMS Web 在后台运行，安装进程随即退出；PATH 默认写入 shell 配置，--no-shell-rc 可关闭" "MMS Web runs in the background and the installer exits right after; PATH is written to your shell config by default and --no-shell-rc turns that off")
   - $(t "pi 是必装项，pilot web 端依赖它；缺失的 claude/codex/opencode 会自动补装，已安装的不会被改动" "pi is mandatory because the pilot web app depends on it; missing claude/codex/opencode are installed automatically while existing ones are left untouched")
   - $(t "内建能力（weber 网页路由、grill-me、TOON、NSR）随 MMS 一起安装，只在 MMS 启动的会话里生效" "Built-in tools (weber web routing, grill-me, TOON, NSR) ship with MMS and only apply inside sessions MMS starts")
@@ -1820,35 +1820,6 @@ print_version_overview() {
     echo "  $(t "安装通道" "Install channel"): $(install_channel_label)"
 }
 
-legacy_config_has_route_candidates() {
-    "$(_python_bin)" - "$LEGACY_CONFIG_ROOT" <<'PY' >/dev/null 2>&1
-import sys
-import tomllib
-from pathlib import Path
-
-root = Path(sys.argv[1]).expanduser()
-config_path = root / "config.toml"
-if not config_path.exists():
-    raise SystemExit(1)
-try:
-    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
-except Exception:
-    raise SystemExit(1)
-
-providers = config.get("providers")
-if not isinstance(providers, list):
-    raise SystemExit(1)
-
-for provider in providers:
-    if not isinstance(provider, dict) or provider.get("enabled") is False:
-        continue
-    for key in ("fallback_models", "extra_models"):
-        models = provider.get(key)
-        if isinstance(models, list) and any(str(item).strip() for item in models):
-            raise SystemExit(0)
-raise SystemExit(1)
-PY
-}
 
 run_install_check() {
     local node_label=""
@@ -2027,11 +1998,12 @@ PY
 # <pid> <command>" line per process that merely uses this installation.
 # Exit 0 when the installation is free, 3 when it is in use.
 inspect_live_pilot() {
-    "$(_python_bin)" - "$MMS_HOME" <<'PY'
+    "$(_python_bin)" - "$MMS_HOME" "${MMS_WEB_DEFAULT_PORT:-${MMS_WEB_PORT_BASE:-8765}}" <<'PY'
 import fcntl, os, shlex, subprocess, sys
 from pathlib import Path
 
 root = Path(sys.argv[1]).resolve()
+port = int(sys.argv[2] or 0)
 lease_held = False
 try:
     fcntl.flock(9, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -2078,6 +2050,21 @@ def is_server(command):
     return False
 
 
+def listening_on_port():
+    """PIDs bound to the Pilot port. A Pilot from another install, or one that
+    updated itself from the page, serves here with a different source path;
+    leaving it alive would make the fresh install start a second Pilot."""
+    if port <= 0:
+        return set()
+    try:
+        out = subprocess.run(['lsof', '-nP', '-iTCP:%d' % port, '-sTCP:LISTEN', '-Fp'],
+                             capture_output=True, text=True, timeout=5).stdout
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    return {line[1:] for line in out.splitlines() if line.startswith('p')}
+
+
+port_holders = listening_on_port()
 servers = []
 others = []
 for row in rows:
@@ -2088,6 +2075,9 @@ for row in rows:
     if pid == str(os.getpid()):
         continue
     if not any(word in command for word in ('-m mms_web', '/mms-web', '/mms web')):
+        continue
+    if pid in port_holders:
+        servers.append((pid, command))
         continue
     if not uses_installation(pid, command):
         continue
@@ -2135,7 +2125,7 @@ confirm_open_web() {
 
 # Report the port of an MMS Web instance that is already serving, if any.
 running_mms_web_port() {
-    "$(_python_bin)" - "$MMS_WEB_DEFAULT_PORT" "$MMS_WEB_PORT_SEARCH_LIMIT" "$MMS_HOME" "${XDG_DATA_HOME:-$REAL_HOME/.local/share}/mms-web/config" <<'PY'
+    "$(_python_bin)" - "$MMS_WEB_DEFAULT_PORT" "$MMS_WEB_PORT_SEARCH_LIMIT" "$MMS_HOME" "$CONFIG_ROOT" <<'PY'
 import hashlib
 import re
 from pathlib import Path
@@ -2828,17 +2818,10 @@ if [ -x "$BIN_DIR/mms" ]; then
 
     if [ "$PREVIEW_CHANNEL_INSTALL" -eq 1 ]; then
         echo ""
-        if legacy_config_has_route_candidates; then
-            echo "  $(t "下一步（首次 preview/mmf 只做这两行）:" "Next step (first preview/mmf run: only do these two lines):")"
-            echo "    $NEXT_MMF_CMD preview prepare"
-            echo "    $NEXT_MMF_CMD"
-            echo "  $(t "说明：prepare 只读取 ~/.config/mms，并写入 ~/.config/mms-next；不会改 stable 配置。" "Note: prepare only reads ~/.config/mms and writes ~/.config/mms-next; stable config is not modified.")"
-        else
-            echo "  $(t "下一步（全新机器先配通道）:" "Next step (fresh machine: configure providers first):")"
-            echo "    $NEXT_MMF_CMD config web"
-            echo "    $NEXT_MMF_CMD"
-            echo "  $(t "说明：没有检测到可迁移的旧模型路由，先在 WebUI 添加 provider/API Key 并保存。" "Note: no migratable legacy model routes were detected; add providers/API keys in the WebUI first.")"
-        fi
+        echo "  $(t "下一步（先配通道）:" "Next step (configure providers first):")"
+        echo "    $NEXT_MMF_CMD config web"
+        echo "    $NEXT_MMF_CMD"
+        echo "  $(t "说明：所有入口只读 ~/.config/mms-next；旧的 ~/.config/mms 不再被读取，请在 WebUI 添加 provider/API Key 并保存。" "Note: every entrance reads only ~/.config/mms-next; the old ~/.config/mms is no longer read, so add providers/API keys in the WebUI and save.")"
         echo ""
         echo "  $(t "以后需要排查时再运行:" "Only run this later when debugging:") $NEXT_MMF_CMD config doctor"
     fi

--- a/mms_bridge.py
+++ b/mms_bridge.py
@@ -2145,7 +2145,7 @@ def _incident_log_path(server=None):
         try:
             config_root = resolve_mms_config_dir()
         except Exception:
-            config_root = os.path.join(os.path.expanduser("~"), ".config", "mms")
+            config_root = os.path.join(os.path.expanduser("~"), ".config", "mms-next")
     return os.path.join(str(config_root), "logs", "incidents.jsonl")
 
 

--- a/mms_core.py
+++ b/mms_core.py
@@ -15693,51 +15693,13 @@ def _load_config_or_preview_bundle():
     return load_config()
 
 
-def _legacy_root_import_candidate():
-    """Return the stable root when it still holds an importable legacy config."""
-    status = mms_config_root_status(command=current_command())
-    stable_root = str(status.get("stable_root") or "")
-    if not stable_root or os.path.normpath(stable_root) == os.path.normpath(PRIMARY_CONFIG_DIR):
-        return ""
-    if not os.path.exists(os.path.join(stable_root, "config.toml")):
-        return ""
-    return stable_root
-
-
-def _import_legacy_root_into_v2(stable_root):
-    """Import an existing stable root into this v2 root, keeping the source read-only."""
-    from mms_registry_cli import preview_prepare
-
-    console.print(
-        f"[cyan]{_L('正在从', 'Importing from')} {stable_root} {_L('导入现有配置，源目录只读不会被修改…', 'into this root; the source stays read-only…')}[/cyan]"
-    )
-    try:
-        summary = preview_prepare(
-            config_dir=PRIMARY_CONFIG_DIR,
-            source_config_dir=stable_root,
-            include_secrets=True,
-            command_name=f"{current_command()} preview prepare",
-        )
-    except Exception as exc:
-        console.print(f"[red]{_L('导入失败', 'Import failed')}: {type(exc).__name__}: {exc}[/red]")
-        return None
-    cfg = _load_config_or_preview_bundle()
-    if cfg is None:
-        detail = str(summary.get("status") or summary.get("result") or "unknown")
-        console.print(
-            f"[yellow]{_L('导入完成但没有可用路由', 'Import finished without usable routes')}: {detail}[/yellow]"
-        )
-        return None
-    console.print(f"[green]✓ {_L('已导入现有配置', 'Existing config imported')}[/green]\n")
-    return cfg
-
-
 def _bootstrap_preview_root_config(ui_language=None):
     """Configure an empty v2 root, writing DB truth instead of config.toml.
 
-    Imports an existing stable root when one is present, otherwise collects one
-    channel. Returns the freshly loaded runtime config, or None when the caller
-    should fall back to the read-only preview guidance.
+    Collects one channel interactively. The legacy ~/.config/mms root is never
+    read: Pilot (`mms web`) and this prompt are the only ways to fill the root.
+    Returns the freshly loaded runtime config, or None when the caller should
+    fall back to the read-only preview guidance.
     """
     if not sys.stdin.isatty():
         return None
@@ -15746,23 +15708,9 @@ def _bootstrap_preview_root_config(ui_language=None):
     set_language(language)
     title = display_title()
 
-    legacy_root = _legacy_root_import_candidate()
-    if legacy_root:
-        console.print(Panel(
-            f"[bold cyan]{_L('发现旧配置目录', 'Found an existing config root')}: {legacy_root}[/bold cyan]\n\n"
-            f"{_L('当前配置根使用配置库真值，可以一次性导入旧配置的通道、模型和 Key。', 'This root keeps DB truth; the channels, models and keys from the old root can be imported once.')}\n"
-            f"{_L('导入只读取旧目录，不会修改它。', 'The import only reads the old root and never modifies it.')}",
-            title=f"{title} Setup",
-        ))
-        if Confirm.ask(_L("现在导入", "Import now"), default=True):
-            cfg = _import_legacy_root_into_v2(legacy_root)
-            if cfg is not None:
-                return cfg
-            console.print(f"[dim]{_L('改为手动配置一个通道。', 'Falling back to configuring one channel manually.')}[/dim]\n")
-
     console.print(Panel(
         f"[bold cyan]{_L(f'欢迎使用 {title} — AI Coding CLI 统一启动器', f'Welcome to {title} — unified AI coding CLI launcher')}[/bold cyan]\n\n"
-        f"{_L('首次使用，需要配置 API 地址和认证信息', 'First-time setup needs an API endpoint and credentials')}\n"
+        f"{_L('首次使用，需要配置 API 地址和认证信息；也可以运行', 'First-time setup needs an API endpoint and credentials; alternatively run')} `{current_command()} web` {_L('在 Pilot 页面里完成', 'and finish it in Pilot')}\n"
         f"{_L('这个配置根使用配置库真值，填写的内容会写入配置库和 secret backend', 'This config root keeps DB truth; your answers go into the registry database and the secret backend')}",
         title=f"{title} Setup",
     ))
@@ -17135,7 +17083,7 @@ def _exit_preview_legacy_config_disabled(args_rest=None):
     console.print("[red]Preview root uses v2 DB truth; legacy config.toml writes are disabled.[/red]")
     console.print(f"[dim]config_root={root}[/dim]")
     console.print(f"[cyan]下一步:[/cyan] {current_command()} config doctor --json")
-    console.print("[dim]准备预览 root: mmf preview prepare --from ~/.config/mms --json[/dim]")
+    console.print(f"[dim]在 Pilot 里添加通道: {current_command()} web[/dim]")
     console.print(
         f"[dim]已审核 plan 后写入预览 DB: {current_command()} config apply-plan "
         "--plan-json <plan.json> --apply --confirm-preview-apply --json[/dim]"

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -517,7 +517,7 @@ def _model_context_overrides_path():
     try:
         config_root = _resolve_mms_config_dir()
     except Exception:
-        config_root = _real_user_path(".config", "mms")
+        config_root = _real_user_path(".config", "mms-next")
     return os.path.join(config_root, "model-context-overrides.json")
 
 
@@ -1174,7 +1174,7 @@ def _selected_mms_config_root(env):
     try:
         return _resolve_mms_config_dir(merged_env)
     except Exception:
-        return _real_user_path(".config", "mms")
+        return _real_user_path(".config", "mms-next")
 
 
 def _config_root_is_explicit(env):

--- a/mms_registry.py
+++ b/mms_registry.py
@@ -16,7 +16,7 @@ from mms_registry_schema import (
     REVISION_STATUSES,
     migrate as migrate_schema,
 )
-from mms_state_io import mms_config_root_mode, resolve_mms_config_dir
+from mms_state_io import mms_config_root_mode, resolve_mms_config_dir, DEFAULT_CONFIG_ROOT_NAME
 
 
 LATEST_APPROVED_SCHEMA = "mms.model_registry.latest_approved.v1"
@@ -1770,11 +1770,10 @@ def assert_legacy_artifact_publish_allowed(
 ) -> Path:
     """Return config root or reject legacy-artifact publish for preview roots."""
     config_root = Path(config_dir) if config_dir is not None else Path(resolve_mms_config_dir())
-    try:
-        root_mode = mms_config_root_mode(config_root)
-    except Exception:
-        root_mode = "stable"
-    if root_mode == "preview":
+    # Every root is preview mode now, so the guard keys on what makes a root
+    # DB-truth: the manifest the v2 initializer writes. A plain directory of
+    # legacy artifacts can still be published from those artifacts.
+    if (config_root / "root-manifest.json").is_file() or config_root.name == DEFAULT_CONFIG_ROOT_NAME:
         raise RegistryValidationError(
             "publish-approved from legacy root artifacts is disabled for preview config roots; "
             "use publish-preview so the latest-approved bundle is generated from DB candidates"

--- a/mms_registry_cli.py
+++ b/mms_registry_cli.py
@@ -518,7 +518,7 @@ def _model_source_readiness(
     route_count = int(candidates.get("provider_route_count") or 0)
     missing_keys = int(bundle.get("router_missing_api_key_count") or 0)
     missing_urls = int(bundle.get("router_missing_base_url_count") or 0)
-    if root_status.get("mode") != "preview":
+    if root_status.get("legacy_root"):
         status = "stable_root_read_only"
         headline = "Stable root: v2 DB-truth writes stay human-only; use mmf for preview."
         next_action = {"label": "Open preview root status", "command": "./mmf config source --json"}
@@ -757,13 +757,13 @@ def registry_v2_save_plan(
     guard_blocked = bool(guard) and guard.get("ok") is False
     backup_dir = root / "backups" / "db"
     blocked_reasons: list[str] = []
-    if mode != "preview":
+    if root_status.get("legacy_root"):
         blocked_reasons.append("stable_root_human_only")
     if not has_changes:
         blocked_reasons.append("no_draft_changes")
     if guard_blocked:
         blocked_reasons.append(str(guard.get("reason") or "route_publish_guard_blocked"))
-    can_write_preview = bool(has_changes and mode == "preview" and not guard_blocked)
+    can_write_preview = bool(has_changes and mode == "preview" and not root_status.get("legacy_root") and not guard_blocked)
     plan_json_name = "webui-plan.json"
     cli_apply_command = f"./mmf config apply-plan --plan-json <{plan_json_name}> --apply --confirm-preview-apply --json"
     return {
@@ -790,7 +790,7 @@ def registry_v2_save_plan(
         },
         "would_write": {
             "db_candidate_revision": can_write_preview,
-            "secret_backend": bool(credentials and mode == "preview" and not guard_blocked),
+            "secret_backend": bool(credentials and mode == "preview" and not root_status.get("legacy_root") and not guard_blocked),
             "generated_latest_approved_bundle": can_write_preview,
             "legacy_compat_files": {
                 "config_toml": bool(summary.get("will_write_config")),
@@ -822,7 +822,7 @@ def registry_v2_save_plan(
             "cli_apply_command": cli_apply_command,
             "cli_dry_run_command": f"./mmf config apply-plan --plan-json <{plan_json_name}> --json",
             "requires_preview_root": True,
-            "blocked_in_current_root": mode != "preview",
+            "blocked_in_current_root": bool(root_status.get("legacy_root")),
             "credential_note": "Downloaded WebUI plan JSON is redacted; credential updates should be applied through WebUI or a local secret-bearing plan file that is not shared.",
         },
         "next_implementation_step": "WebUI and mms config apply-plan are wired; next: TUI/native save and stable promotion after human-gated validation",
@@ -849,8 +849,8 @@ def preview_doctor(
     checks = [
         {
             "id": "preview_root",
-            "ok": root_status.get("mode") == "preview",
-            "detail": root_status.get("mode") or "unknown",
+            "ok": not root_status.get("legacy_root"),
+            "detail": "stable" if root_status.get("legacy_root") else (root_status.get("mode") or "unknown"),
         },
         {
             "id": "registry_db",
@@ -875,7 +875,7 @@ def preview_doctor(
     ]
 
     next_actions: list[dict[str, str]] = []
-    if root_status.get("mode") != "preview":
+    if root_status.get("legacy_root"):
         overall = "wrong_root"
         next_actions.append({"label": "Use mmf preview root", "command": "./mmf config root --json"})
     elif registry_db.get("status") != "ok":
@@ -1155,7 +1155,7 @@ def config_v2_promotion_plan(
         "registry_db": stable_root / "registry" / "model-registry.sqlite",
     }
     blocked_reasons = ["stable_root_human_only", "promotion_apply_not_implemented"]
-    if preview_root_status.get("mode") != "preview":
+    if preview_root_status.get("legacy_root"):
         blocked_reasons.append("preview_root_required")
     if not preview_ready:
         blocked_reasons.append("preview_not_runtime_ready")
@@ -1665,7 +1665,7 @@ def init_config_root(
     root = root.expanduser()
     command = command_name.split()[0] if command_name else "mms"
     root_status = mms_config_root_status(command=command, config_dir=root)
-    if root_status.get("mode") != "preview" and not allow_stable:
+    if root_status.get("legacy_root") and not allow_stable:
         raise mms_registry.RegistryValidationError(
             "refusing to initialize stable config root without --allow-stable"
         )
@@ -2845,7 +2845,7 @@ def write_registry_v2_webui_secret_backend(
     root = Path(config_dir) if config_dir is not None else Path(resolve_mms_config_dir())
     root = root.expanduser()
     root_status = mms_config_root_status(command=command_name.split()[0] if command_name else "mms", config_dir=root)
-    if root_status.get("mode") != "preview" and not allow_stable:
+    if root_status.get("legacy_root") and not allow_stable:
         raise mms_registry.RegistryValidationError("refusing to write registry v2 WebUI secrets into stable config root without --allow-stable")
     update_entries = _registry_v2_webui_secret_entries(credential_updates)
     if not update_entries:
@@ -3077,7 +3077,7 @@ def import_legacy_config(
     root = root.expanduser()
     source_root = Path(source_config_dir).expanduser() if source_config_dir is not None else root
     root_status = mms_config_root_status(command=command_name.split()[0] if command_name else "mms", config_dir=root)
-    if root_status.get("mode") != "preview" and not allow_stable:
+    if root_status.get("legacy_root") and not allow_stable:
         raise mms_registry.RegistryValidationError("refusing to import into stable config root without --allow-stable")
     report = legacy_import_report(config_dir=source_root)
     payload = _legacy_import_payload(report)
@@ -3153,7 +3153,7 @@ def apply_registry_v2_save_candidate(
     root = Path(config_dir) if config_dir is not None else Path(resolve_mms_config_dir())
     root = root.expanduser()
     root_status = mms_config_root_status(command=command_name.split()[0] if command_name else "mms", config_dir=root)
-    if root_status.get("mode") != "preview" and not allow_stable:
+    if root_status.get("legacy_root") and not allow_stable:
         raise mms_registry.RegistryValidationError("refusing to write registry v2 save candidate into stable config root without --allow-stable")
     config_payload = config_payload if isinstance(config_payload, Mapping) else {}
     candidate_payload = _registry_v2_candidate_payload(
@@ -3360,13 +3360,13 @@ def apply_registry_v2_plan(
         "stable_apply_policy": {
             "apply_enabled": False,
             "allow_stable_requested": bool(allow_stable),
-            "human_gate_required": root_status.get("mode") != "preview",
+            "human_gate_required": root_status.get("legacy_root"),
             "promotion_plan_command": "./mmf promote --json",
             "note": "Stable apply-plan writes are not implemented; review the promotion plan and stop at the human gate.",
         },
         "blocked_reasons": [],
     }
-    if root_status.get("mode") != "preview":
+    if root_status.get("legacy_root"):
         summary["blocked_reasons"].append("stable_root_human_only")
         if apply:
             summary["blocked_reasons"].append("stable_apply_not_implemented")

--- a/mms_state_io.py
+++ b/mms_state_io.py
@@ -25,10 +25,11 @@ _GATEWAY_SESSION_SUBPATHS = (
     "accounts" + os.sep,
 )
 
-# A session HOME inside a gateway directory resolves back to the root that
-# gateway belongs to, so both roots have to be recognized here.
+# A session HOME inside a gateway directory resolves back to the config root.
+# Gateway homes still live under both directory names, but there is only one
+# config root now, so both markers map to it.
 GATEWAY_SESSION_MARKER_ROOTS = tuple(
-    (os.path.join(".config", root_name, subpath), root_name)
+    (os.path.join(".config", root_name, subpath), DEFAULT_CONFIG_ROOT_NAME)
     for root_name in (DEFAULT_CONFIG_ROOT_NAME, LEGACY_CONFIG_ROOT_NAME)
     for subpath in _GATEWAY_SESSION_SUBPATHS
 )
@@ -102,11 +103,17 @@ def resolve_mms_config_dir(env=None):
     env = env or os.environ
     explicit_root = str(env.get("MMS_CONFIG_ROOT") or "").strip()
     if explicit_root:
-        return _path_from_env_value(explicit_root)
+        candidate = _path_from_env_value(explicit_root)
+        if _is_real_legacy_root(candidate, env):
+            return os.path.join(resolve_real_user_home(env), ".config", DEFAULT_CONFIG_ROOT_NAME)
+        return candidate
 
     explicit = str(env.get("MMS_CONFIG_DIR") or "").strip()
     if explicit:
-        return _path_from_env_value(explicit)
+        candidate = _path_from_env_value(explicit)
+        if _is_real_legacy_root(candidate, env):
+            return os.path.join(resolve_real_user_home(env), ".config", DEFAULT_CONFIG_ROOT_NAME)
+        return candidate
 
     xdg_config_home = str(env.get("XDG_CONFIG_HOME") or "").strip()
     if xdg_config_home:
@@ -121,6 +128,13 @@ def resolve_mms_config_dir(env=None):
         return os.path.join(normalized_xdg, DEFAULT_CONFIG_ROOT_NAME)
 
     return os.path.join(resolve_real_user_home(env), ".config", DEFAULT_CONFIG_ROOT_NAME)
+
+
+def _is_real_legacy_root(path, env=None):
+    env = env or os.environ
+    candidate = os.path.normpath(str(path or ""))
+    expected = os.path.normpath(os.path.join(resolve_real_user_home(env), ".config", LEGACY_CONFIG_ROOT_NAME))
+    return candidate == expected
 
 
 def mms_config_root_source(env=None):
@@ -140,19 +154,23 @@ def mms_config_root_is_explicit(env=None):
 
 
 def mms_config_root_mode(config_dir=None, env=None):
-    env = env or os.environ
-    # Explicit pin, used by the maintainer channels that stay on the legacy
-    # stable root after the default moved to mms-next.
-    override = str(env.get("MMS_CONFIG_ROOT_MODE") or "").strip().lower()
-    if override in {"stable", "preview"}:
-        return override
-    marker = str(env.get("MMS_PREVIEW_MODE") or env.get("MMS_COMMAND_NAME") or "").strip().lower()
-    root = os.path.normpath(str(config_dir or resolve_mms_config_dir(env)))
-    if marker == "mmf" or os.path.basename(root) == "mms-next":
-        return "preview"
-    if mms_config_root_is_explicit(env):
-        return "preview"
-    return "stable"
+    """Every entrance keeps DB truth in one root, so the mode is always preview.
+
+    The legacy stable root (~/.config/mms) is retired as a config source; the
+    ``MMS_CONFIG_ROOT_MODE=stable`` pin the old ``mmd``/``mmm`` wrappers used is
+    ignored instead of switching a process back to config.toml truth.
+    """
+    return "preview"
+
+
+def is_retired_legacy_root(config_dir):
+    """True for the retired ~/.config/mms directory (or any root named like it).
+
+    It is no longer a config source, and it must not be turned into a v2 root
+    by accident either: gateway session state still lives under it.
+    """
+    root = os.path.normpath(str(config_dir or ""))
+    return os.path.basename(root) == LEGACY_CONFIG_ROOT_NAME
 
 
 def mms_config_root_status(command=None, config_dir=None, env=None):
@@ -162,6 +180,7 @@ def mms_config_root_status(command=None, config_dir=None, env=None):
     return {
         "command": str(command or env.get("MMS_COMMAND_NAME") or "mms"),
         "mode": mms_config_root_mode(root, env),
+        "legacy_root": is_retired_legacy_root(root),
         "root_source": mms_config_root_source(env),
         "config_root": root,
         "config_path": os.path.join(root, "config.toml"),

--- a/scripts/link_local_channel_commands.sh
+++ b/scripts/link_local_channel_commands.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Link the maintainer's local command matrix without touching ~/.config/mms.
-# mms = public installed copy, mmd = stable worktree, mmf = root dev checkout,
-# mmg = canary worktree, mmm = main/stable observation worktree.
+# Link the maintainer's local command matrix. Every command uses the single
+# config root ~/.config/mms-next; the legacy ~/.config/mms root is retired.
+# mms = public installed copy, mmf = root dev checkout, mmg = canary worktree.
+# mmd / mmm (pinned to the legacy root) are retired and removed when found.
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
@@ -12,17 +13,9 @@ case "$REPO_ROOT" in
   */.worktrees/*) BASE_ROOT="${REPO_ROOT%%/.worktrees/*}" ;;
 esac
 DEV_ROOT_DEFAULT="$BASE_ROOT"
-MAIN_ROOT_DEFAULT="$BASE_ROOT/.worktrees/main"
-if [ ! -f "$MAIN_ROOT_DEFAULT/mms" ]; then
-  MAIN_ROOT_DEFAULT="$BASE_ROOT"
-fi
 CANARY_ROOT_DEFAULT="$BASE_ROOT/.worktrees/canary"
-STABLE_ROOT_DEFAULT="$BASE_ROOT/.worktrees/stable-v3.3-no-db"
 if [ "$(basename "$REPO_ROOT")" = "canary" ] && [ "$(basename "$(dirname "$REPO_ROOT")")" = ".worktrees" ]; then
   CANARY_ROOT_DEFAULT="$REPO_ROOT"
-fi
-if [ "$(basename "$REPO_ROOT")" = "stable-v3.3-no-db" ] && [ "$(basename "$(dirname "$REPO_ROOT")")" = ".worktrees" ]; then
-  STABLE_ROOT_DEFAULT="$REPO_ROOT"
 fi
 
 resolve_real_home() {
@@ -37,13 +30,10 @@ resolve_real_home() {
 REAL_HOME_VALUE="$(resolve_real_home)"
 BIN_DIR="${MMS_LOCAL_BIN:-$REAL_HOME_VALUE/.local/bin}"
 PUBLIC_ENTRY="${MMS_PUBLIC_ENTRY:-$REAL_HOME_VALUE/.mms/mms}"
-MAIN_ROOT="${MMS_MAIN_ROOT:-$MAIN_ROOT_DEFAULT}"
 DEV_ROOT="${MMS_DEV_ROOT:-$DEV_ROOT_DEFAULT}"
 CANARY_ROOT="${MMS_CANARY_ROOT:-$CANARY_ROOT_DEFAULT}"
-STABLE_ROOT="${MMS_STABLE_ROOT:-$STABLE_ROOT_DEFAULT}"
 MANAGED_PYTHON="${MMS_MANAGED_PYTHON:-$REAL_HOME_VALUE/.mms/.venv/bin/python}"
 PREVIEW_CONFIG_ROOT="$REAL_HOME_VALUE/.config/mms-next"
-LEGACY_CONFIG_ROOT="$REAL_HOME_VALUE/.config/mms"
 UPDATE_SCRIPT="${MMS_LOCAL_CHANNEL_UPDATE_SCRIPT:-$REPO_ROOT/scripts/local_channel_update.py}"
 
 mkdir -p "$BIN_DIR"
@@ -78,22 +68,12 @@ UPDATE_BRANCH="$branch"
 UPDATE_CADENCE="$cadence"
 export MMS_COMMAND_NAME="$name"
 EOF_WRAPPER
-  if [ "$config_mode" = "preview" ]; then
-    cat >> "$target" <<EOF_WRAPPER
+  # Every channel shares the one config root; there is no legacy pin anymore.
+  cat >> "$target" <<EOF_WRAPPER
 export MMS_CONFIG_ROOT="$PREVIEW_CONFIG_ROOT"
 export MMS_PREVIEW_MODE="mmf"
 unset MMS_CONFIG_ROOT_MODE || true
 EOF_WRAPPER
-  else
-    # The default root is now mms-next, so a legacy-root channel has to pin
-    # both the path and the truth mode; unsetting would follow the new default.
-    cat >> "$target" <<EOF_WRAPPER
-export MMS_CONFIG_ROOT="$LEGACY_CONFIG_ROOT"
-export MMS_CONFIG_ROOT_MODE="stable"
-unset MMS_CONFIG_DIR || true
-unset MMS_PREVIEW_MODE || true
-EOF_WRAPPER
-  fi
   cat >> "$target" <<'EOF_WRAPPER'
 run_update_hook() {
   [ -f "$UPDATER" ] || return 0
@@ -149,17 +129,26 @@ EOF_WRAPPER
   chmod 755 "$target"
 }
 
+remove_retired_wrapper() {
+  # Only wrappers this script wrote are removed: they carry the legacy pin.
+  local target="$BIN_DIR/$1"
+  [ -f "$target" ] || return 0
+  if grep -q 'MMS_CONFIG_ROOT_MODE="stable"' "$target" 2>/dev/null; then
+    rm -f "$target"
+    echo "removed retired wrapper: $target"
+  fi
+}
+
 write_public_mms_wrapper
-write_python_wrapper "mmd" "$STABLE_ROOT" "mms" "stable" "release/stable-v3.3-no-db" "weekly"
 write_python_wrapper "mmf" "$DEV_ROOT" "mmf" "preview" "dev" "daily"
 write_python_wrapper "mmg" "$CANARY_ROOT" "mms" "preview" "canary" "always"
-write_python_wrapper "mmm" "$MAIN_ROOT" "mms" "stable" "main" "daily"
+remove_retired_wrapper "mmd"
+remove_retired_wrapper "mmm"
 
 cat <<EOF_SUMMARY
 linked local MMS command matrix in $BIN_DIR:
   mms -> public installed copy: $PUBLIC_ENTRY  (default root $PREVIEW_CONFIG_ROOT)
-  mmd -> stable worktree:      $STABLE_ROOT/mms  (pinned MMS_CONFIG_ROOT=$LEGACY_CONFIG_ROOT)
   mmf -> root dev checkout:    $DEV_ROOT/mmf  (MMS_CONFIG_ROOT=$PREVIEW_CONFIG_ROOT)
   mmg -> canary worktree:      $CANARY_ROOT/mms  (MMS_CONFIG_ROOT=$PREVIEW_CONFIG_ROOT)
-  mmm -> main worktree:        $MAIN_ROOT/mms  (pinned MMS_CONFIG_ROOT=$LEGACY_CONFIG_ROOT)
+  mmd / mmm are retired: every entrance reads only $PREVIEW_CONFIG_ROOT
 EOF_SUMMARY

--- a/scripts/regression_fresh_user_gate.py
+++ b/scripts/regression_fresh_user_gate.py
@@ -264,19 +264,22 @@ def _smoke_shared_config_root_default() -> None:
         if payload.get("mode") != "preview":
             raise SystemExit(f"fresh mms mode mismatch: {payload!r}")
 
+        # A stale shell export or the retired mmd/mmm wrapper env pointing at
+        # the legacy root must not drag a process back there: the pin is
+        # redirected to the shared root and the mode stays preview.
         pinned_env = _env_for_home(home)
         pinned_env["MMS_CONFIG_ROOT"] = str(legacy_root)
         pinned_env["MMS_CONFIG_ROOT_MODE"] = "stable"
         completed = _run(
-            "pinned legacy channel config root",
+            "retired legacy stable pin",
             [sys.executable, str(ROOT_DIR / "mms"), "config", "root", "--json"],
             env=pinned_env,
         )
         payload = json.loads(completed.stdout)
-        if payload.get("config_root") != str(legacy_root):
-            raise SystemExit(f"pinned root mismatch: {payload.get('config_root')} != {legacy_root}")
-        if payload.get("mode") != "stable":
-            raise SystemExit(f"pinned mode mismatch: {payload!r}")
+        if payload.get("config_root") != str(shared_root):
+            raise SystemExit(f"legacy pin not redirected: {payload.get('config_root')} != {shared_root}")
+        if payload.get("mode") != "preview":
+            raise SystemExit(f"legacy stable pin still honoured: {payload!r}")
 
         probe = (
             "import json,sys;"

--- a/tests/test_claude_isolation.py
+++ b/tests/test_claude_isolation.py
@@ -309,8 +309,9 @@ def test_stable_usage_write_keeps_legacy_routes_export(monkeypatch, tmp_path):
     monkeypatch.setenv("MMS_REAL_HOME", str(real_home))
     monkeypatch.setenv("REAL_HOME", str(real_home))
     monkeypatch.setenv("ORIGINAL_HOME", str(real_home))
-    # The default root is mms-next, which reads the published bundle, so the
-    # legacy export only runs when a channel is pinned to the stable root.
+    # The legacy stable root is retired: even a process pinned to it with the
+    # old wrapper env stays in preview mode and never rewrites the legacy
+    # model-routes.json export.
     monkeypatch.setenv("MMS_CONFIG_ROOT", str(stable_root))
     monkeypatch.setenv("MMS_CONFIG_ROOT_MODE", "stable")
     monkeypatch.delenv("MMS_COMMAND_NAME", raising=False)
@@ -331,7 +332,7 @@ def test_stable_usage_write_keeps_legacy_routes_export(monkeypatch, tmp_path):
         monkeypatch.setattr(reloaded.threading, "Thread", ImmediateThread)
         reloaded._trigger_routes_export_after_usage_write()
 
-        assert calls == [{"force": True, "quiet": True}]
+        assert calls == []
 
         # The default root publishes a verified bundle instead, so it must not
         # keep rewriting the legacy export.
@@ -785,12 +786,14 @@ def test_home_context_reports_selected_config_root(monkeypatch, tmp_path):
     assert context["config_root"] != str(stable_root)
 
 
-def test_home_context_defaults_to_stable_root_without_explicit_root(monkeypatch, tmp_path):
+def test_home_context_under_a_legacy_gateway_home_uses_the_single_root(monkeypatch, tmp_path):
+    """Gateway session homes still sit under ~/.config/mms, but the config a
+    session reads is the one shared root; the legacy root is retired (#177)."""
     import mms_launchers
 
     real_home = tmp_path / "real-home"
-    stable_root = real_home / ".config" / "mms"
-    gateway_home = stable_root / "codex-gateway" / "s" / "4174"
+    stable_root = real_home / ".config" / "mms-next"
+    gateway_home = real_home / ".config" / "mms" / "codex-gateway" / "s" / "4174"
     gateway_home.mkdir(parents=True)
     monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
     monkeypatch.delenv("MMS_CONFIG_DIR", raising=False)
@@ -840,10 +843,12 @@ def test_model_context_overrides_follow_selected_config_root(monkeypatch, tmp_pa
     assert mms_launchers._lookup_context_window("root-selected-model") == 222_000
     assert mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
 
+    # An explicit pin at the retired legacy root is redirected to the shared
+    # root (#177): a stale shell export must not resurrect the old config.
     monkeypatch.setenv("MMS_CONFIG_ROOT", str(stable_root))
 
-    assert mms_launchers._lookup_context_window("root-selected-model") == 111_000
-    assert mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE["path"] == str(stable_root / "model-context-overrides.json")
+    assert mms_launchers._lookup_context_window("root-selected-model") == 222_000
+    assert mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
 
 
 def test_mmf_wrapper_selects_mms_next_without_stable_fallback(tmp_path):

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -2694,7 +2694,10 @@ def test_config_web_registry_v2_save_plan_blocks_stable_root(tmp_path):
     )
     v2_plan = plan["registry_v2_save_plan"]
 
-    assert v2_plan["root"]["mode"] == "stable"
+    # Every root is preview mode now; the retired legacy directory is still
+    # refused as a write target (#177).
+    assert v2_plan["root"]["mode"] == "preview"
+    assert v2_plan["root"]["legacy_root"] is True
     assert v2_plan["would_write"]["db_candidate_revision"] is False
     assert v2_plan["would_write"]["secret_backend"] is False
     assert v2_plan["would_write"]["generated_latest_approved_bundle"] is False
@@ -3023,14 +3026,16 @@ def test_config_web_save_uses_audited_writers(monkeypatch, tmp_path):
     )
     encoded = json.dumps(result, ensure_ascii=False)
 
-    assert result["ok"] is True
-    assert config_path.exists()
-    assert credentials_path.exists()
-    assert "sk-super-secret-value" in credentials_path.read_text(encoding="utf-8")
-    assert policy_path.exists()
-    assert (tmp_path / "config-audit.jsonl").exists()
-    assert "setup-web-ui:interactive-save" in (tmp_path / "config-audit.jsonl").read_text(encoding="utf-8")
-    assert result["save_report"]["config"]["bak_path"].endswith(".bak")
+    # The legacy audited config.toml save went with the stable root (#177):
+    # every root is preview mode, so /api/save is refused and nothing is written.
+    assert result["ok"] is False
+    assert result["status"] == "blocked"
+    assert "preview root" in result["errors"][0]
+    assert "sk-super-secret-value" not in credentials_path.read_text(encoding="utf-8")
+    assert "sk-super-secret-value" not in encoded
+    assert not (tmp_path / "config-audit.jsonl").exists()
+    assert not list(tmp_path.glob("*.bak"))
+    return
     bak_paths = list((tmp_path / "backups").rglob("*.bak"))
     assert any(path.name == "config.toml.bak" for path in bak_paths)
     assert any(path.name == "credentials.sh.bak" for path in bak_paths)
@@ -3168,8 +3173,12 @@ def test_config_web_migration_export_import_uses_openssl_when_cryptography_missi
         preferences_path=str(preferences_path),
         command_name="mms",
     )
+    # Every root is preview mode (#177): the import lands in the registry
+    # path, not in a legacy credentials.sh next to config.toml.
     assert applied["ok"] is True
-    assert "sk-openssl-migration-secret" in credentials_path.read_text(encoding="utf-8")
+    assert applied["status"] == "imported"
+    assert applied["summary"]["credential_updates"] == 1
+    assert not credentials_path.exists()
     assert "sk-openssl-migration-secret" not in json.dumps(applied, ensure_ascii=False)
 
 
@@ -3402,8 +3411,10 @@ def test_config_web_migration_start_status_ready_when_provider_is_complete(tmp_p
         command_name="mmz1",
     )
 
-    assert status["ready_to_work"] is True
-    assert status["blockers"] == []
+    # Every root is preview mode (#177): a provider in config.toml alone is not
+    # ready until the latest-approved bundle is published and verified.
+    assert status["ready_to_work"] is False
+    assert [item["id"] for item in status["blockers"]] == ["bundle_not_verified"]
     assert status["copy_command"] == "mmz1"
 
 

--- a/tests/test_install_script_paths.py
+++ b/tests/test_install_script_paths.py
@@ -914,9 +914,11 @@ def test_install_completion_points_at_the_web_app_and_v2_preview_gate():
     assert "在 MMS Web 里添加 provider 和 API Key" in text
     assert "bash install.sh --check" in text
 
-    # preview path is unchanged
-    assert "下一步（首次 preview/mmf 只做这两行）" in text
-    assert "$NEXT_MMF_CMD preview prepare" in text
+    # preview path: the legacy root is never read, so the only next step is
+    # configuring providers in the WebUI
+    assert "下一步（先配通道）" in text
+    assert "$NEXT_MMF_CMD preview prepare" not in text
+    assert "legacy_config_has_route_candidates" not in text
     assert "$NEXT_MMF_CMD config web" in text
     assert "$NEXT_MMF_CMD config doctor" in text
 
@@ -1169,7 +1171,9 @@ class Handler(BaseHTTPRequestHandler):
     def do_HEAD(self):
         self.send_response(200)
         home = Path(sys.argv[0]).parent.parent.parent
-        identity = hashlib.sha256(f"{home / '.mms'}|{home / '.local/share/mms-web/config'}|".encode()).hexdigest()
+        # The server hashes source|config_root|version; the installer must use
+        # the shared config root, not Pilot's old private directory.
+        identity = hashlib.sha256(f"{home / '.mms'}|{home / '.config/mms-next'}|".encode()).hexdigest()
         self.send_header("X-MMS-Web-Identity", identity)
         self.end_headers()
 

--- a/tests/test_legacy_surface_cleanup.py
+++ b/tests/test_legacy_surface_cleanup.py
@@ -1094,7 +1094,9 @@ def test_mmf_missing_preview_config_does_not_run_legacy_setup(monkeypatch, tmp_p
     assert not (preview_root / "config.toml").exists()
     out = capsys.readouterr().out
     assert "Preview root uses v2 DB truth" in out
-    assert "mmf preview prepare" in out
+    # The legacy root is retired: the guidance is Pilot, not a legacy import.
+    assert "mmf web" in out
+    assert "preview prepare --from ~/.config/mms" not in out
 
 
 def test_mmf_config_mutation_is_blocked_from_legacy_config_path(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_mms_web_install_lock.py
+++ b/tests/test_mms_web_install_lock.py
@@ -11,12 +11,13 @@ from test_install_script_paths import _extract_shell_function_body
 ROOT=Path(__file__).resolve().parents[1]
 
 
-def guard(home, command='guard_live_pilot_install', keep_running=0):
+def guard(home, command='guard_live_pilot_install', keep_running=0, port=0):
+    """port=0 disables the port scan so tests never touch a real Pilot on 8765."""
     text=(ROOT/'install.sh').read_text()
     body=_extract_shell_function_body(text,'guard_live_pilot_install')
     inspect=_extract_shell_function_body(text,'inspect_live_pilot')
     script=('_python_bin() { command -v python3; }\nt() { printf "%s" "$1"; }\n'
-            f'KEEP_RUNNING_PILOT={keep_running}\nSTOPPED_PILOT=0\n'
+            f'KEEP_RUNNING_PILOT={keep_running}\nSTOPPED_PILOT=0\nMMS_WEB_DEFAULT_PORT={port}\n'
             'guard_live_pilot_install() {'+body+'\n}\n'
             'inspect_live_pilot() {'+inspect+'\n}\n'+command)
     return subprocess.run(['bash','-ec',script],env={**os.environ,'MMS_HOME':str(home)},capture_output=True,text=True)
@@ -104,3 +105,48 @@ def test_keep_running_pilot_flag_does_not_swallow_the_next_argument():
     assert 'shift' not in body,body
     loop=text[text.index('while [[ $# -gt 0 ]]; do'):]
     assert '\n    esac\n    shift\n' in loop
+
+
+def _free_port():
+    import socket
+    with socket.socket() as probe:
+        probe.bind(('127.0.0.1',0))
+        return probe.getsockname()[1]
+
+
+def test_installer_stops_a_pilot_from_another_install_holding_the_port(tmp_path):
+    """A Pilot that updated itself, or came from another install dir, serves the
+    default port with a foreign source path. It is still asked to exit so the
+    fresh install does not end up as a second Pilot on the next port."""
+    home=tmp_path/'installation';(home/'mms_web').mkdir(parents=True)
+    (home/'mms_web/__main__.py').write_text('fixture')
+    port=_free_port()
+    code=f"import socket,time; s=socket.socket(); s.bind(('127.0.0.1',{port})); s.listen(); time.sleep(60)"
+    process=subprocess.Popen([sys.executable,'-c',code,'-m','mms_web',str(tmp_path/'elsewhere'/'updates'/'v9.9.9')],
+                             stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+    time.sleep(1)
+    try:
+        result=guard(home,command='guard_live_pilot_install\necho "STOPPED=$STOPPED_PILOT"',port=port)
+        assert result.returncode==0,result.stdout+result.stderr
+        assert 'STOPPED=1' in result.stdout
+        assert process.wait(timeout=10)is not None
+    finally:
+        if process.poll()is None:
+            process.kill();process.wait(timeout=10)
+
+
+def test_port_scan_is_off_when_no_port_is_given(tmp_path):
+    """The guard must not signal anything just because some Pilot listens elsewhere."""
+    home=tmp_path/'installation';(home/'mms_web').mkdir(parents=True)
+    (home/'mms_web/__main__.py').write_text('fixture')
+    port=_free_port()
+    code=f"import socket,time; s=socket.socket(); s.bind(('127.0.0.1',{port})); s.listen(); time.sleep(60)"
+    process=subprocess.Popen([sys.executable,'-c',code,'-m','mms_web',str(tmp_path/'elsewhere')],
+                             stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+    time.sleep(1)
+    try:
+        result=guard(home,port=0)
+        assert result.returncode==0,result.stdout+result.stderr
+        assert process.poll()is None
+    finally:
+        process.kill();process.wait(timeout=10)

--- a/tests/test_single_config_root.py
+++ b/tests/test_single_config_root.py
@@ -1,0 +1,121 @@
+"""Only ~/.config/mms-next is a config source (issue #177).
+
+The legacy ~/.config/mms root is retired: no entrance reads it, no bootstrap
+imports it, the stable pin the old mmd/mmm wrappers exported is ignored, and
+the maintainer link script no longer writes those wrappers.
+"""
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+
+import mms_state_io
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_stable_pin_no_longer_switches_the_mode(tmp_path):
+    legacy = tmp_path / ".config" / "mms"
+    env = {"MMS_CONFIG_ROOT": str(legacy), "MMS_CONFIG_ROOT_MODE": "stable"}
+    assert mms_state_io.mms_config_root_mode(str(legacy), env) == "preview"
+    assert mms_state_io.mms_config_root_status(config_dir=str(legacy), env=env)["mode"] == "preview"
+
+
+def test_explicit_pin_at_the_real_legacy_root_is_redirected(tmp_path):
+    """`export MMS_CONFIG_ROOT=~/.config/mms` left in a shell rc, or the retired
+    mmd/mmm wrapper env, must not read the legacy root; any other explicit
+    directory is still honoured."""
+    real_home = tmp_path / "home"
+    env = {"MMS_REAL_HOME": str(real_home), "MMS_CONFIG_ROOT": str(real_home / ".config" / "mms")}
+    assert mms_state_io.resolve_mms_config_dir(env) == str(real_home / ".config" / "mms-next")
+    env["MMS_CONFIG_DIR"] = env.pop("MMS_CONFIG_ROOT")
+    assert mms_state_io.resolve_mms_config_dir(env) == str(real_home / ".config" / "mms-next")
+    other = {"MMS_REAL_HOME": str(real_home), "MMS_CONFIG_ROOT": str(tmp_path / "elsewhere")}
+    assert mms_state_io.resolve_mms_config_dir(other) == str(tmp_path / "elsewhere")
+
+
+def test_default_root_is_mms_next_and_mode_is_preview(tmp_path):
+    env = {"MMS_REAL_HOME": str(tmp_path)}
+    assert mms_state_io.resolve_mms_config_dir(env) == str(tmp_path / ".config" / "mms-next")
+    assert mms_state_io.mms_config_root_mode(env=env) == "preview"
+
+
+def test_gateway_session_under_the_legacy_directory_resolves_to_the_single_root(tmp_path):
+    """Gateway homes still live under ~/.config/mms/*-gateway; a child process
+    whose XDG_CONFIG_HOME points inside one must read the shared root, not the
+    retired legacy config."""
+    session_config = tmp_path / ".config" / "mms" / "claude-gateway" / "s" / "123" / ".config"
+    env = {"MMS_REAL_HOME": str(tmp_path), "XDG_CONFIG_HOME": str(session_config)}
+    assert mms_state_io.resolve_mms_config_dir(env) == str(tmp_path / ".config" / "mms-next")
+
+
+def test_core_never_imports_the_legacy_root():
+    text = (ROOT / "mms_core.py").read_text(encoding="utf-8")
+    assert "_import_legacy_root_into_v2" not in text
+    assert "_legacy_root_import_candidate" not in text
+    assert "preview prepare --from ~/.config/mms" not in text
+
+
+def test_config_root_fallbacks_do_not_point_at_the_legacy_root():
+    launchers = (ROOT / "mms_launchers.py").read_text(encoding="utf-8")
+    for name in ("_model_context_overrides_path", "_selected_mms_config_root"):
+        start = launchers.index(f"def {name}(")
+        body = launchers[start: launchers.index("\ndef ", start + 1)]
+        assert '_real_user_path(".config", "mms")' not in body, name
+    bridge = (ROOT / "mms_bridge.py").read_text(encoding="utf-8")
+    start = bridge.index("def _incident_log_path(")
+    body = bridge[start: bridge.index("\ndef ", start + 1)]
+    assert '".config", "mms")' not in body
+
+
+def test_installer_no_longer_reads_the_legacy_root_for_hints():
+    text = (ROOT / "install.sh").read_text(encoding="utf-8")
+    assert "legacy_config_has_route_candidates" not in text
+    # Port holders from any install are stoppable servers.
+    assert "listening_on_port" in text
+    assert "if pid in port_holders:" in text
+    # The reuse probe hashes the shared config root, as the server does.
+    assert '"$MMS_HOME" "$CONFIG_ROOT" <<' in text
+
+
+def test_link_script_writes_no_legacy_wrappers_and_removes_stale_ones(tmp_path):
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    public = home / ".mms" / "mms"
+    public.parent.mkdir(parents=True)
+    public.write_text("#!/bin/sh\n")
+    dev = tmp_path / "dev"
+    canary = tmp_path / "canary"
+    for root, entry in ((dev, "mmf"), (canary, "mms")):
+        root.mkdir()
+        (root / entry).write_text("#!/bin/sh\n")
+    # A wrapper this script wrote earlier carries the legacy pin: it goes.
+    (bin_dir / "mmd").write_text('#!/bin/sh\nexport MMS_CONFIG_ROOT_MODE="stable"\n')
+    # Something the user put there under the same name is not ours to delete.
+    (bin_dir / "mmm").write_text("#!/bin/sh\necho mine\n")
+    env = {**os.environ, "MMS_REAL_HOME": str(home), "HOME": str(home),
+           "MMS_LOCAL_BIN": str(bin_dir), "MMS_PUBLIC_ENTRY": str(public),
+           "MMS_DEV_ROOT": str(dev), "MMS_CANARY_ROOT": str(canary),
+           "MMS_MANAGED_PYTHON": "/usr/bin/env python3"}
+    result = subprocess.run(["bash", str(ROOT / "scripts" / "link_local_channel_commands.sh")],
+                            env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert not (bin_dir / "mmd").exists()
+    assert (bin_dir / "mmm").read_text() == "#!/bin/sh\necho mine\n"
+    for name in ("mms", "mmf", "mmg"):
+        wrapper = (bin_dir / name).read_text()
+        assert "MMS_CONFIG_ROOT_MODE=\"stable\"" not in wrapper
+        assert ".config/mms\"" not in wrapper, name
+    assert 'MMS_CONFIG_ROOT="' + str(home / ".config" / "mms-next") + '"' in (bin_dir / "mmf").read_text()
+    assert "mmd / mmm are retired" in result.stdout
+
+
+def test_retired_legacy_directory_is_still_refused_as_a_v2_root(tmp_path):
+    """Mode is always preview now, so the registry guard keys on the directory
+    name instead: ~/.config/mms holds gateway session state, never a v2 root."""
+    assert mms_state_io.is_retired_legacy_root(tmp_path / ".config" / "mms") is True
+    assert mms_state_io.is_retired_legacy_root(tmp_path / ".config" / "mms-next") is False
+    status = mms_state_io.mms_config_root_status(config_dir=str(tmp_path / ".config" / "mms"), env={})
+    assert status["legacy_root"] is True and status["mode"] == "preview"


### PR DESCRIPTION
Closes #177。用户决定（2026-09-10）：任何电脑都能拉取模型；Pilot 改通道后 terminal 同步；`mms` 只保留 `~/.config/mms-next` 配置，legacy `~/.config/mms` 不再读取、不自动迁移；`mmd` / `mmm` 退休；安装脚本停掉任何占用默认端口的 Pilot。

## 根因回顾

两台电脑的故障是同一个：`~/.config/mms`、`~/.config/mms-next`、`~/.local/share/mms-web/config` 三个根并存，Web 与 terminal 各读各的；且 Pilot 自更新后源码路径变了，安装脚本按 `source|config_root|version` 认不出它，就在 8766 再起一个 Pilot，页面拿着旧进程的 CSRF token 打新进程 → 403；模型页在另一个根里找不到 key → 全部「不可用」。

## 改动

**配置根（受保护面）**
- `mms_state_io.py`：`mms_config_root_mode` 恒为 `preview`，`MMS_CONFIG_ROOT_MODE=stable` 被忽略；gateway 会话目录（含 `~/.config/mms/*-gateway/`）内的子进程一律解析到 `~/.config/mms-next`；显式 `MMS_CONFIG_ROOT` / `MMS_CONFIG_DIR` 指向真实 `~/.config/mms` 时重定向到 `~/.config/mms-next`（旧 zshrc 里的 export 或退休包装器的 env 不再把进程拖回旧根；其它显式目录照旧）。新增 `is_retired_legacy_root` 与 status 字段 `legacy_root`。
- `mms_registry_cli.py` / `mms_registry.py`：原来靠 `mode != preview` 挡住的写入（init-root、legacy import、WebUI secrets、save candidate、save-plan、doctor）改用 `legacy_root`（目录名为 `mms`）判定，退休目录仍拒绝被初始化为 v2 根；`publish-approved` 的门改为「有 `root-manifest.json` 或目录名为 `mms-next`」。
- **说明**：`mms_state_io.py` 里显式旧根重定向那一段（`_is_real_legacy_root`）是 19:11 由另一会话写入本 worktree 的，与用户决定一致，本 PR 采纳并补了测试。
- `mms_core.py`：删除 bootstrap 里的 legacy 导入（`_legacy_root_import_candidate` / `_import_legacy_root_into_v2`）；空根提示改为 `mms web` 去 Pilot 配置；`_exit_preview_legacy_config_disabled` 不再提示 `preview prepare --from ~/.config/mms`。
- `mms_launchers.py`、`mms_bridge.py`：解析失败时的回退路径从 `~/.config/mms` 改为 `~/.config/mms-next`（各 1 处，`_model_context_overrides_path` / `_selected_mms_config_root` / `_incident_log_path`）。
- **未动**：`~/.config/mms/{claude,codex,opencode}-gateway/`、`accounts/`、`fake-upstream/`、`account-guard-state.json`、`ops-env-safe.toml` 是运行时 / 会话状态与主机能力文件，不是通道配置；Codex gateway `CODEX_HOME` 契约不变。`mms_registry_cli` 的 stable promotion 命令是显式维护命令，保留。

**安装脚本**
- `inspect_live_pilot`：用 `lsof` 找到占用默认端口的进程，只要命令形态是 mms_web 就按 server 处理并请它退出，不再按安装目录区分；`--keep-running-pilot` 语义不变；测试里 `MMS_WEB_DEFAULT_PORT=0` 关闭端口扫描，避免碰真实 Pilot。
- `running_mms_web_port`：身份哈希改用 `$CONFIG_ROOT`，与 `server.py` 的 `source|config_root|version` 一致。
- 删除 `legacy_config_has_route_candidates` 与「preview prepare」提示，安装后统一引导 `config web`。

**本机命令 / 文档**
- `scripts/link_local_channel_commands.sh`：不再生成 `mmd` / `mmm`，发现自己写过的（带 `MMS_CONFIG_ROOT_MODE="stable"`）就删除，用户自建的同名文件不动。
- `docs/RELEASE_CHANNELS.md`、README、GETTING-STARTED：通道契约更新；`docs/AGENT_GUARDRAILS.md` 新增「Single Config Root」。

## 验证

- 新增 `tests/test_single_config_root.py`（7 条：stable pin 忽略、默认根、legacy gateway 目录下解析、core 无 legacy 导入、回退路径、installer 契约、link 脚本行为）。
- `tests/test_mms_web_install_lock.py` 新增 2 条：另一安装目录的 Pilot 占用端口时被停掉并继续；未给端口时不扫描。
- `tests/test_claude_isolation.py`：stable pin 下不再写 legacy `model-routes.json`；legacy gateway home 下 config_root 为 mms-next。
- `tests/test_install_script_paths.py`：假 Pilot 身份改为 `source|~/.config/mms-next|version`。
- fresh-user gate：`pinned legacy channel` 场景改为断言 stable pin 被忽略。
- `tests/test_config_web.py` 4 条、`tests/test_registry_cli.py` 若干原本断言 stable 根语义（legacy 审计保存、config.toml-only 即 ready、mode==stable），改写为单根语义；registry 的 6 条「拒绝 stable 根」测试在 dev 上本来就红，本 PR 转绿。
- 全量 pytest 与 fresh-user gate 结果见下方评论。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
