### PR TITLE
chore: release v4.13.0

### DIFF
--- a/apps/mms-web/package-lock.json
+++ b/apps/mms-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mms/web",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mms/web",
-      "version": "4.12.1",
+      "version": "4.13.0",
       "dependencies": {
         "lucide-react": "0.468.0",
         "qrcode-generator": "2.0.4",

--- a/apps/mms-web/package.json
+++ b/apps/mms-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mms/web",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/mms-web/RELEASE-v4.13.0.md
+++ b/docs/mms-web/RELEASE-v4.13.0.md
@@ -1,0 +1,8 @@
+# v4.13.0 · 只有一个配置根
+
+- **所有入口只读 `~/.config/mms-next`**（#183）：`mms`、`mmf`、`mmg` 和 Pilot 共用同一个根。在 Pilot 里保存的通道，终端下一次启动就能看到；同样的通道在任何电脑上都能拉取模型。
+- **旧根 `~/.config/mms` 退出配置来源**：不再自动读取、导入或回退；shell 里残留的 `MMS_CONFIG_ROOT=~/.config/mms` 或 `MMS_CONFIG_ROOT_MODE=stable` 会被忽略并指回 `mms-next`。空根时终端提示 `mms web` 去 Pilot 完成配置。旧目录本身保留不动，其中的 gateway 会话目录继续作为运行时状态使用。
+- **`mmd` / `mmm` 退休**：本机命令矩阵只剩 `mms` / `mmf` / `mmg`；`scripts/link_local_channel_commands.sh` 会删除它写过的这两个包装器。
+- **安装不再多起一个 Pilot**：安装脚本会请任何占用默认端口的 Pilot 退出（包括页面里自更新过的、或另一份安装起的），装完重新打开；识别已有实例的方式与服务端一致，不再在 8766 起第二个实例造成 403。
+
+升级后请在每台电脑重跑一次安装命令，然后打开 Pilot；旧电脑上如果之前只在终端配过通道，需要在 Pilot 里重新添加一次。版本源、Web package metadata 和静态 Web bundle 同步为 `4.13.0`。

--- a/mms_version.py
+++ b/mms_version.py
@@ -1,2 +1,2 @@
 """Version of the packaged MMS source and Web client."""
-VERSION = "4.12.1"
+VERSION = "4.13.0"

--- a/mms_web_static/build.json
+++ b/mms_web_static/build.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.12.1",
-  "sourceSha256": "949e131fa7d61b003626f38d4c24a3eeeed50c10f3b3cca2d811e354f1661d0a",
+  "version": "4.13.0",
+  "sourceSha256": "833bccabd92c57ba3e26c5018c4a4f32d82c53cf378f9b6b38b7f1bd4aed8d06",
   "files": {
     "assets/index-BowAa16X.css": "93bc440e20c0f5b7a736dc91f76f1b8d7b7ab783d98277fa32ac87df8385ef06",
     "assets/index-DpDVbYOo.js": "b0d6751f0b899524a4eb29243c67c5309d4fe9123810d364c04f4ec63d0d53ee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-model-switch",
-  "version": "4.12.1",
+  "version": "4.13.0",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Release v4.13.0 after #183 (single config root: legacy `~/.config/mms` retired, `mmd`/`mmm` retired, installer stops any Pilot holding the default port). Bumps version metadata, rebuilds the Pilot static bundle (4.13.0), records `docs/mms-web/RELEASE-v4.13.0.md`.

Validated on this branch: py_compile, frontend build, `git diff --check`, 198 targeted tests (single config root, install script paths, install lock, registry CLI, model settings); the 4 registry_cli failures are pre-existing on dev. Full suite and fresh-user gate were run on the #183 branch head, which is this branch minus the version bump.

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
