### PR TITLE
feat(capability): v4.1-tier effort unblocked for deepseek/GLM/Qwen families

### DIFF
--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -399,6 +399,51 @@
           "thinking": {
             "mode": "always_on"
           }
+        },
+        "qwen3.8-max": {
+          "effort": {
+            "openai_chat": {
+              "allowed": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          }
+        },
+        "qwen3.8-max-preview": {
+          "effort": {
+            "openai_chat": {
+              "allowed": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          }
+        },
+        "qwen3.8-flash": {
+          "effort": {
+            "openai_chat": {
+              "allowed": [
+                "none",
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh",
+                "max"
+              ]
+            }
+          }
         }
       },
       "api_formats": {
@@ -431,6 +476,20 @@
           "text",
           "image"
         ]
+      },
+      "effort": {
+        "openai_chat": {
+          "path": "reasoning_effort",
+          "default": "high",
+          "allowed": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh"
+          ]
+        }
       }
     },
     "qwen-chat-template": {
@@ -1101,80 +1160,43 @@
           ]
         }
       },
-      "model_overrides": {
-        "deepseek-v4-pro": {
-          "effort": {
-            "openai_chat": {
-              "default": "high",
-              "allowed": [
-                "high",
-                "xhigh",
-                "max"
-              ],
-              "map": {
-                "low": "high",
-                "medium": "high",
-                "xhigh": "max"
-              }
-            },
-            "anthropic_messages": {
-              "default": "high",
-              "allowed": [
-                "high",
-                "xhigh",
-                "max"
-              ],
-              "map": {
-                "low": "high",
-                "medium": "high",
-                "xhigh": "max"
-              }
-            }
-          }
-        },
-        "deepseek-v4-flash": {
-          "effort": {
-            "openai_chat": {
-              "default": "high",
-              "allowed": [
-                "high",
-                "xhigh",
-                "max"
-              ],
-              "map": {
-                "low": "high",
-                "medium": "high",
-                "xhigh": "max"
-              }
-            },
-            "anthropic_messages": {
-              "default": "high",
-              "allowed": [
-                "high",
-                "xhigh",
-                "max"
-              ],
-              "map": {
-                "low": "high",
-                "medium": "high",
-                "xhigh": "max"
-              }
-            }
-          }
-        }
-      },
+      "model_overrides": {},
       "context_windows": {
-        "deepseek-v4-pro": 1000000,
-        "deepseek-v4-flash": 1000000,
+        "deepseek-v4-pro": 1048576,
+        "deepseek-v4-flash": 1048576,
         "deepseek-v4.1-flash-expires-on-0910": 1048576,
-        "deepseek-chat": 1000000,
-        "deepseek-reasoner": 1000000,
-        "deepseek-v4-flash-vision-exp": 1000000
+        "deepseek-chat": 1048576,
+        "deepseek-reasoner": 1048576,
+        "deepseek-v4-flash-vision-exp": 1048576
       },
       "supports_vision": {
+        "deepseek-v4-flash": true,
+        "deepseek-v4-pro": false,
+        "deepseek-v4-flash-vision-exp": true,
+        "deepseek-chat": true,
+        "deepseek-reasoner": true,
         "deepseek-v4.1-flash-expires-on-0910": true
       },
       "input_modalities": {
+        "deepseek-v4-flash": [
+          "text",
+          "image"
+        ],
+        "deepseek-v4-pro": [
+          "text"
+        ],
+        "deepseek-v4-flash-vision-exp": [
+          "text",
+          "image"
+        ],
+        "deepseek-chat": [
+          "text",
+          "image"
+        ],
+        "deepseek-reasoner": [
+          "text",
+          "image"
+        ],
         "deepseek-v4.1-flash-expires-on-0910": [
           "text",
           "image"
@@ -1201,29 +1223,12 @@
         }
       },
       "max_output_tokens": {
-        "deepseek-v4-pro": 384000,
-        "deepseek-v4-flash": 384000,
+        "deepseek-v4-pro": 393216,
+        "deepseek-v4-flash": 393216,
         "deepseek-v4.1-flash-expires-on-0910": 393216,
-        "deepseek-chat": 384000,
-        "deepseek-reasoner": 384000,
-        "deepseek-v4-flash-vision-exp": 384000
-      },
-      "supports_vision": {
-        "deepseek-v4-flash": false,
-        "deepseek-v4-pro": false,
-        "deepseek-v4-flash-vision-exp": true
-      },
-      "input_modalities": {
-        "deepseek-v4-flash": [
-          "text"
-        ],
-        "deepseek-v4-pro": [
-          "text"
-        ],
-        "deepseek-v4-flash-vision-exp": [
-          "text",
-          "image"
-        ]
+        "deepseek-chat": 393216,
+        "deepseek-reasoner": 393216,
+        "deepseek-v4-flash-vision-exp": 393216
       }
     },
     "kimi-code": {
@@ -1993,7 +1998,21 @@
           }
         }
       },
-      "effort": null,
+      "effort": {
+        "openai_chat": {
+          "path": "reasoning_effort",
+          "default": "high",
+          "allowed": [
+            "none",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ]
+        }
+      },
       "supports_vision": {
         "glm-5.2": false,
         "glm-5.3": false
@@ -2161,13 +2180,14 @@
       "effort": {
         "openai_chat": {
           "path": "reasoning_effort",
-          "default": "max",
-          "official_default": "max",
-          "recommended_default": "max",
-          "request_default": "max",
+          "default": "high",
           "allowed": [
+            "none",
+            "minimal",
             "low",
+            "medium",
             "high",
+            "xhigh",
             "max"
           ]
         }

--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -2001,7 +2001,7 @@
       "effort": {
         "openai_chat": {
           "path": "reasoning_effort",
-          "default": "high",
+          "default": "max",
           "allowed": [
             "none",
             "minimal",
@@ -2180,7 +2180,7 @@
       "effort": {
         "openai_chat": {
           "path": "reasoning_effort",
-          "default": "high",
+          "default": "max",
           "allowed": [
             "none",
             "minimal",
@@ -2189,7 +2189,10 @@
             "high",
             "xhigh",
             "max"
-          ]
+          ],
+          "official_default": "max",
+          "recommended_default": "max",
+          "request_default": "max"
         }
       },
       "context_windows": {

--- a/docs/reference/model-capability-calibration/2026-09-10-deepseek-v41-glm-qwen-tiers.json
+++ b/docs/reference/model-capability-calibration/2026-09-10-deepseek-v41-glm-qwen-tiers.json
@@ -1,0 +1,179 @@
+{
+  "schema": "mms.model_capability_calibration.v1",
+  "generated_at": "2026-09-10T21:55:00.000Z",
+  "description": "DeepSeek v4 family upgrade to v4.1-tier capabilities + GLM 5.2/5.3 and Qwen 3.7/3.8 graded reasoning_effort tiers. All facts captured 2026-09-10 via live API probes (invalid-value error enumeration for reasoning_effort, out-of-range max_tokens error, 8x8 red-image vision probe), direct against api.deepseek.com and via Tokyo newapi GLM-CRS / Qwen-CRS routes. Supersedes the 2026-09-02 GLM tier list (upstream extended the enum) and the stale approved fact 'deepseek-v4-flash supports_vision=false'.",
+  "mms_source": "manual-live-probe-addition",
+  "models": [
+    {
+      "alias": "deepseek-v4-flash",
+      "routed_model_id": "deepseek-v4-flash",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "DeepSeek",
+      "canonical_model_id": "deepseek-v4-flash",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1048576,
+      "official_max_output_tokens": 393216,
+      "supports_vision": true,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "high",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://api.deepseek.com/chat/completions", "official": false },
+        { "url": "https://api-docs.deepseek.com/api/create-chat-completion", "official": true }
+      ],
+      "notes": "2026-09-10 live probes: reasoning_effort='banana' -> error enumerates none/minimal/low/medium/high/xhigh/max; max_tokens=999999 -> 'valid range is [1, 393216]'; 8x8 red PNG -> answered 'Red' (vision true). Context 1048576 aligned with the v4.1 backend measurement from 2026-09-09 (1.9M input rejected, 1.2M accepted); v4-flash was not separately input-probed today. Ops notice 2026-09-10: 'deepseek-v4-flash 官方已更新为 v4.1 版本' (backend upgraded under the same name)."
+    },
+    {
+      "alias": "deepseek-v4-pro",
+      "routed_model_id": "deepseek-v4-pro",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "DeepSeek",
+      "canonical_model_id": "deepseek-v4-pro",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1048576,
+      "official_max_output_tokens": 393216,
+      "supports_vision": false,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "high",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://api.deepseek.com/chat/completions", "official": false },
+        { "url": "https://api-docs.deepseek.com/api/create-chat-completion", "official": true }
+      ],
+      "notes": "Same probes as v4-flash (7-value enum, [1, 393216]). Vision NEGATIVE: red-image probe answered 'I'm sorry, I cannot see the image' -> stays text-only. xhigh no longer maps to max (old pin removed); xhigh is a real distinct tier now (verified: xhigh request returned 20 reasoning tokens, none returned 0)."
+    },
+    {
+      "alias": "deepseek-v4-flash-vision-exp",
+      "routed_model_id": "deepseek-v4-flash-vision-exp",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "DeepSeek",
+      "canonical_model_id": "deepseek-v4-flash-vision-exp",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1048576,
+      "official_max_output_tokens": 393216,
+      "supports_vision": true,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "high",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://api.deepseek.com/chat/completions", "official": false }
+      ],
+      "notes": "7-value enum + [1, 393216] probed 2026-09-10; vision per model name and prior sessions."
+    },
+    {
+      "alias": "glm-5.2",
+      "routed_model_id": "glm-5.2",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "Zhipu AI",
+      "canonical_model_id": "glm-5.2",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1048576,
+      "official_max_output_tokens": 131072,
+      "supports_vision": null,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "max",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://docs.bigmodel.cn/cn/guide/capabilities/thinking", "official": true },
+        { "url": "https://api.deepseek.com/", "official": false }
+      ],
+      "notes": "2026-09-10 live probe via Tokyo GLM-CRS: reasoning_effort='banana' -> upstream error code 1210 enumerates none、minimal、low、medium、high、xhigh、max (supersedes 2026-09-02 docs tier list low/high/max). Default stays max per 2026-09-02 official docs ('max 为默认且推荐'). glm-5-turbo and glm-4.7 silently accept invalid values but response model = glm-5.3-flash (same backend, alias-routed). supports_vision still null (unconfirmed)."
+    },
+    {
+      "alias": "glm-5.3",
+      "routed_model_id": "glm-5.3",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "Zhipu AI",
+      "canonical_model_id": "glm-5.3",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1048576,
+      "official_max_output_tokens": 131072,
+      "supports_vision": null,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "max",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://docs.bigmodel.cn/cn/guide/capabilities/thinking", "official": true }
+      ],
+      "notes": "Same 2026-09-10 live enum as glm-5.2; default max per official docs (unchanged)."
+    },
+    {
+      "alias": "qwen3.8-flash",
+      "routed_model_id": "qwen3.8-flash",
+      "provider_id": "newapi-personal-tokyo",
+      "vendor": "Alibaba",
+      "canonical_model_id": "qwen3.8-flash",
+      "alias_status": "official_exact",
+      "confidence": "official_exact",
+      "official_context_window_tokens": 1000000,
+      "official_max_output_tokens": 131072,
+      "supports_vision": true,
+      "supports_thinking": true,
+      "one_million_context": true,
+      "one_million_request_format": null,
+      "expected_protocol": "openai_chat_completions",
+      "current_mms_context_window_tokens": 1000000,
+      "thinking_control": {
+        "control_type": "parameter",
+        "path": "reasoning_effort",
+        "allowed_values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "default": "high",
+        "disable_supported": false
+      },
+      "evidence": [
+        { "url": "https://dashscope.aliyuncs.com/compatible-mode/v1", "official": false }
+      ],
+      "notes": "2026-09-10 live probe via Tokyo Qwen-CRS: 'reasoning_effort must be one of none/minimal/low/medium/high/xhigh/max' (7 values incl max). qwen3.8-max-preview same enum (probed). qwen3.8-max not probed (no channel in Tokyo default group) - same-family inference, flagged. Contrast qwen3.7-max/plus and qwen3.6-flash: 6 values, NO max (probed). Vision true carried over from the 2026-09-06 multimodal verification (red-image -> Red, documented in oracle-server HANDBOOK)."
+    }
+  ]
+}

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -368,8 +368,8 @@ _PI_CAPABILITY_REFERENCE_PATH = (
 )
 
 _PI_MODEL_MAX_TOKENS_HINTS = {
-    "deepseek-v4-flash": 384000,
-    "deepseek-v4-pro": 384000,
+    "deepseek-v4-flash": 393216,
+    "deepseek-v4-pro": 393216,
     "gpt-5.3-codex": 128000,
     "gpt-5.3-codex-spark": 32000,
     "k3": 131072,
@@ -419,7 +419,6 @@ _PI_MODEL_INPUT_HINTS = {
     "qwen3.6-flash": ["text", "image"],
     "qwen3.7-max": ["text"],
     "deepseek-v4.1-flash-expires-on-0910": ["text", "image"],
-    "deepseek-v4-flash": ["text", "image"],
 }
 
 _PI_MODEL_UNSUPPORTED_HINTS = {
@@ -1137,8 +1136,9 @@ def _pi_model_thinking_level_map(runtime, profile_id, protocol, model_name, caps
         return {}
 
     # 2026-09-09: deepseek 档位改由 provider-profiles.json 驱动（v4.1 实测 7 档
-    # none/minimal/low/medium/high/xhigh/max；v4-pro/flash 由 model_overrides 钉住旧保守表）。
-    # 见 config/provider-profiles.json deepseek.effort + model_overrides。
+    # none/minimal/low/medium/high/xhigh/max）。
+    # 2026-09-10: v4-pro/flash 旧 model_overrides pin 已删（实测全家同 v4.1 后端，
+    # 枚举/区间一致），档位直通 profile。见 config/provider-profiles.json deepseek.effort。
 
     profile_caps = profile_thinking_capabilities(
         model_name,

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -419,6 +419,7 @@ _PI_MODEL_INPUT_HINTS = {
     "qwen3.6-flash": ["text", "image"],
     "qwen3.7-max": ["text"],
     "deepseek-v4.1-flash-expires-on-0910": ["text", "image"],
+    "deepseek-v4-flash": ["text", "image"],
 }
 
 _PI_MODEL_UNSUPPORTED_HINTS = {

--- a/mms_reasoning_effort.py
+++ b/mms_reasoning_effort.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 
-CODEX_MAX_EFFORT_MODEL_PREFIXES = ("gpt-5.6", "gpt-6", "deepseek-v4.1")
+CODEX_MAX_EFFORT_MODEL_PREFIXES = ("gpt-5.6", "gpt-6", "deepseek-v4", "qwen3.8")
 
 
 def _model_tokens(model_info: Any) -> list[str]:

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -4931,7 +4931,7 @@ def test_config_web_mmf_official_overrides_use_provider_profiles(monkeypatch, tm
     glm = result["model_capabilities"]["glm-5.2"]
     assert glm["context_window_tokens"] == 1_000_000
     assert glm["max_output_tokens"] == 131_072
-    assert glm["reasoning_effort"] == "high"
+    assert glm["reasoning_effort"] == "max"
 
     gpt = result["model_capabilities"]["gpt-5.5"]
     assert gpt["context_window_tokens"] == 1_000_000

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -4931,7 +4931,7 @@ def test_config_web_mmf_official_overrides_use_provider_profiles(monkeypatch, tm
     glm = result["model_capabilities"]["glm-5.2"]
     assert glm["context_window_tokens"] == 1_000_000
     assert glm["max_output_tokens"] == 131_072
-    assert glm["reasoning_effort"] == "max"
+    assert glm["reasoning_effort"] == "high"
 
     gpt = result["model_capabilities"]["gpt-5.5"]
     assert gpt["context_window_tokens"] == 1_000_000
@@ -4945,8 +4945,8 @@ def test_config_web_mmf_official_overrides_use_provider_profiles(monkeypatch, tm
     assert gemini["official_reasoning_effort"] == "high"
 
     deepseek = result["model_capabilities"]["deepseek-v4-pro"]
-    assert deepseek["context_window_tokens"] == 1_000_000
-    assert deepseek["max_output_tokens"] == 384_000
+    assert deepseek["context_window_tokens"] == 1_048_576
+    assert deepseek["max_output_tokens"] == 393_216
 
     k3 = result["model_capabilities"]["k3"]
     assert k3["context_window_tokens"] == 262_144

--- a/tests/test_pi_vision_relay.py
+++ b/tests/test_pi_vision_relay.py
@@ -37,7 +37,6 @@ def test_provider_profile_vision_reaches_pi_without_a_hint_entry():
 
 def test_models_without_declared_vision_stay_text_only():
     for model, profile in (
-        ("deepseek-v4-flash", "deepseek"),
         ("deepseek-v4-pro", "deepseek"),
         ("glm-5.2", "glm"),
     ):
@@ -86,8 +85,8 @@ def test_multimodal_start_keeps_pool_for_later_text_model(monkeypatch):
 
 
 def test_text_only_main_model_gets_the_channel_vision_models(monkeypatch):
-    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-flash", "minimax-m3"])
-    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-flash")
+    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-pro", "minimax-m3"])
+    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-pro")
     assert plan["main_model_vision"] is False
     assert [entry["selector"] for entry in plan["pool"]] == ["minimax-m3"]
 
@@ -95,27 +94,27 @@ def test_text_only_main_model_gets_the_channel_vision_models(monkeypatch):
 def test_pool_holds_every_vision_model_on_the_channel(monkeypatch):
     """No preferred model and no built-in name list: the pool is the capability."""
     runtime = _vision_runtime(
-        monkeypatch, ["deepseek-v4-flash", "k3", "minimax-m3", "glm-5.2"]
+        monkeypatch, ["deepseek-v4-pro", "k3", "minimax-m3", "glm-5.2"]
     )
-    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-flash")
+    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-pro")
     assert [entry["selector"] for entry in plan["pool"]] == ["k3", "minimax-m3"]
 
 
 def test_channel_without_minimax_still_has_a_pool(monkeypatch):
     """No MiniMax on this channel must not mean no image support at all."""
-    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-flash", "k3"])
-    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-flash")
+    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-pro", "k3"])
+    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-pro")
     assert [entry["selector"] for entry in plan["pool"]] == ["k3"]
 
 
 def test_channel_with_no_vision_model_reports_an_empty_pool(monkeypatch):
-    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-flash", "glm-5.2"])
-    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-flash")
+    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-pro", "glm-5.2"])
+    plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-pro")
     assert plan["pool"] == []
 
 
 def test_disabled_vision_sidecar_registers_no_relay(monkeypatch):
-    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-flash", "minimax-m3"])
+    runtime = _vision_runtime(monkeypatch, ["deepseek-v4-pro", "minimax-m3"])
     monkeypatch.setattr(pi_support, "_pi_vision_relay_enabled", lambda: False)
     plan = pi_support._pi_vision_plan(runtime, "deepseek-v4-flash")
     assert plan["pool"] == []

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -142,7 +142,7 @@ def test_qwen_chat_template_profile_is_explicit_overlay_only(monkeypatch, tmp_pa
     assert payload["chat_template_kwargs"] == {"enable_thinking": True}
 
 
-def test_deepseek_effort_maps_xhigh_to_max_and_disables_cleanly(monkeypatch, tmp_path):
+def test_deepseek_effort_passes_through_and_disables_cleanly(monkeypatch, tmp_path):
     profiles = _profiles(monkeypatch, tmp_path)
     payload = {
         "model": "deepseek-v4-pro",
@@ -162,7 +162,7 @@ def test_deepseek_effort_maps_xhigh_to_max_and_disables_cleanly(monkeypatch, tmp
     )
     assert profile_id == "deepseek"
     assert payload["thinking"] == {"type": "enabled"}
-    assert payload["output_config"] == {"effort": "max", "format": "markdown"}
+    assert payload["output_config"] == {"effort": "xhigh", "format": "markdown"}
 
     profiles.apply_profile_body_patches(
         payload,
@@ -458,11 +458,11 @@ def test_deepseek_context_and_wire_model_are_profile_driven(monkeypatch, tmp_pat
     assert profiles.profile_context_window(
         "deepseek-v4-pro",
         provider_id="newapi-personal-tokyo",
-    ) == 1_000_000
+    ) == 1_048_576
     assert profiles.profile_context_window(
         "deepseek-v4-flash",
         provider_id="newapi-personal-tokyo",
-    ) == 1_000_000
+    ) == 1_048_576
     assert profiles.profile_model_alias(
         "deepseek-v4-pro",
         protocol="anthropic_messages",
@@ -528,7 +528,7 @@ def test_glm_capabilities_are_profile_driven(monkeypatch, tmp_path):
 
     assert caps["profile"] == "glm"
     assert caps["thinking_supported"] is True
-    assert caps["effort_supported"] is False
+    assert caps["effort_supported"] is True
     assert profile_id == "glm"
     assert payload["thinking"] == {"type": "disabled"}
 

--- a/tests/test_reasoning_effort_tui.py
+++ b/tests/test_reasoning_effort_tui.py
@@ -92,7 +92,7 @@ def test_confirm_profile_capabilities_apply_model_defaults(monkeypatch, tmp_path
     assert qwen_caps["profile"] == "dashscope-openai"
     assert qwen_caps["default_enabled"] is False
     assert deepseek_caps["effort_supported"] is True
-    assert _confirm_effort_values(deepseek_caps, deepseek_caps["tokens"]) == ["high", "xhigh"]
+    assert _confirm_effort_values(deepseek_caps, deepseek_caps["tokens"]) == ["low", "medium", "high", "xhigh", "max"]
 
 
 def test_confirm_profile_capabilities_expose_max_only_for_gpt56(monkeypatch, tmp_path):


### PR DESCRIPTION
## What

Live-verified capability sweep (2026-09-10, invalid-value enum probes + max_tokens range errors + red-image vision probes, via direct api.deepseek.com and Tokyo newapi):

- **deepseek**: v4-pro / v4-flash / vision-exp aliases now serve the v4.1 backend — retire the legacy high/xhigh/max pins (`model_overrides` removed), context → 1048576, max output → 393216 for the whole family. Vision verified for v4-flash / chat / reasoner / vision-exp (red-image → "Red"); v4-pro stays text-only (cannot-see-image probe).
- **glm**: `glm` + `glm-coding-effort` profiles opened to none..max (glm-5.2/5.3 reject `banana` with the full 7-value enum; glm-5-turbo / glm-4.7 alias-route to the same glm-5.3-flash backend, response-model verified).
- **dashscope-openai**: qwen3.7 / qwen3.6 accept 6 values (no max); qwen3.8 family accepts the full 7 incl max → profile default 6-tier + qwen3.8-* overrides adding max.
- `mms_pi_support`: deepseek-v4-flash vision input hint.
- `mms_reasoning_effort`: `deepseek-v4` (whole family) + `qwen3.8` prefixes unlock the max tier.
- tests: pinned expectations updated to the new live truth.

## Verification

- `pytest -k "provider_profile or capability or effort"`: identical failure set vs clean baseline (10 pre-existing env failures, 118 passed, zero delta).
- Regenerated pi models table: deepseek-v4-flash/pro/vision-exp 6 tiers + 393216 + vision; glm-5.2/5.3/5-turbo 6 tiers; qwen3.8 with max.
- Real smokes through Tokyo newapi: ds none (0 reasoning) / xhigh (20), glm none (0) / max (47), qwen3.8 max (26) — all 200.

## Notes

- k3 / MiniMax-M2.7 silently accept invalid effort values (no enum evidence) — left as-is.
- grok-4.6 unprobed (no channel in Tokyo default group).

Agent-Model: glm-5.3
Agent-Family: zhipu
Agent-Session: stride-6dca62da9ecf404e