### PR TITLE
fix(web): --listen all 下关闭开关不再清空 token 门禁

### DIFF
--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -217,8 +217,11 @@ class WebApplication:
             raise WebError("INVALID_PARAMETER", "enabled 必须是 true 或 false。", 400)
         wanted = "lan" if payload["enabled"] else "loopback"
         # "all" is a deliberate command-line choice; the switch never widens
-        # past the machine's own addresses on its own.
-        if self.access.mode == "all" and wanted == "lan":
+        # past the machine's own addresses on its own, and it must not narrow
+        # it either: the wildcard socket stays bound for the life of the
+        # process, so dropping to loopback would only clear the token gate
+        # while the network can still reach every endpoint.
+        if self.access.mode == "all":
             return self.remote_access_state()
         self.access.set_mode(wanted)
         if self.listeners:

--- a/tests/test_mms_web_lan_switch.py
+++ b/tests/test_mms_web_lan_switch.py
@@ -216,6 +216,13 @@ def test_the_command_line_still_wins_over_the_switch(tmp_path):
         # socket and opens no extras.
         assert state["listening"] == []
         assert application.access.bind_address() == "0.0.0.0"
+        # Turning the switch off must not narrow "all" either: the wildcard
+        # socket cannot be recalled, so the token gate has to stay in place.
+        state = application.post(["remote-access"], {"enabled": False})
+        assert state["mode"] == "all"
+        assert application.access.mode == "all"
+        assert application.access.required is True
+        assert application.access.token
     finally:
         application.close()
 


### PR DESCRIPTION
#181 合并后复审发现：`--listen all` 启动时，主 socket 绑定 `0.0.0.0` 且整个进程周期不会回收；`POST /remote-access {enabled:false}` 只拦了 `all → lan`，没拦 `all → loopback`，于是 `set_mode("loopback")` 把 token 清空、`access.required` 变 False，网络上任何人都能不带 token 访问全部接口。界面只是把 checkbox 置灰，API 没有防住。

改动一处：`mode == "all"` 时对 `enabled` 一律返回当前状态（原来只对 `enabled:true` 这样做）。`tests/test_mms_web_lan_switch.py` 的「命令行优先」测试补上 `enabled:false` 的断言：mode 仍为 all、token 仍必需。

`test_mms_web_lan_switch.py` + `test_mms_web_remote_access.py`：51 passed。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
