### PR TITLE
mms web status / url / start / stop / restart：管理本机的 Pilot 服务

### DIFF
--- a/docs/mms-web/GETTING-STARTED.md
+++ b/docs/mms-web/GETTING-STARTED.md
@@ -22,7 +22,19 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 
 macOS 也可以在 Finder 打开 `~/.mms/MMS Pilot.command`。如果从 Finder 启动时找不到通过 shell 管理器安装的 Node/Pi，先从能运行 `pi` 的终端启动上面的命令。系统文件选择器的交互与 macOS 本机权限有关。
 
-独立命令 `mms-web --open` 与 `mms web --open` 都可打开 Web。终端中按 Ctrl+C 停止服务；浏览器关闭只关闭页面。服务重启后，对话保留，继续发送时会恢复 Pi 会话。
+独立命令 `mms-web --open` 与 `mms web --open` 都可在前台打开 Web。终端中按 Ctrl+C 停止服务；浏览器关闭只关闭页面。服务重启后，对话保留，继续发送时会恢复 Pi 会话。
+
+安装脚本装完后会在后台起一个服务，它不是系统服务：机器重启或进程被结束后不会自己回来。用下面几个命令管理它，不用再翻进程列表：
+
+| 命令 | 作用 |
+|---|---|
+| `mms web status` | 列出本机所有在监听的 Pilot（地址、版本、pid、state-root、config-root、来源目录），● 标出属于当前 state-root 的那个 |
+| `mms web url` | 只打印当前实例的地址；没在跑就返回非零并提示 `mms web start` |
+| `mms web start [--open]` | 已在跑就直接返回地址；没跑就在后台启动，日志在 `<state-root>/logs/mms-web.log` |
+| `mms web stop [--all]` | 请当前实例退出（`--all` 是本机全部 Pilot），等待最多 20 秒，不会 `kill -9` |
+| `mms web restart` | 先停再起 |
+
+`mmf web status` 等同样可用。`--state-root` / `--port` 与前台启动时的含义一致；`--json` 给脚本用。
 
 ## 第一次配置
 

--- a/mms_web/__main__.py
+++ b/mms_web/__main__.py
@@ -1,6 +1,7 @@
 import argparse
 import signal
 import os
+import sys
 import webbrowser
 from pathlib import Path
 
@@ -9,6 +10,15 @@ from .remote_access import QUERY
 
 
 def main(argv=None):
+    from .service import VERBS, run as run_service
+
+    raw = list(sys.argv[1:] if argv is None else argv)
+    # `mms web status|url|start|stop|restart` manage the detached service;
+    # the verb may follow options mms_core prepends (for example
+    # `--config-root <root> status`), so look for it anywhere.
+    for index, token in enumerate(raw):
+        if token in VERBS:
+            raise SystemExit(run_service(token, raw[:index] + raw[index + 1:]))
     parser = argparse.ArgumentParser(description="MMS Pilot — local conversations powered by MMS and Pi")
     from mms_version import VERSION
     parser.add_argument("--version", action="version", version=f"MMS Pilot {VERSION}")

--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -472,6 +472,7 @@ def create_server(app: WebApplication, static_root: Path, port: int = 8765):
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Cache-Control", "no-store")
             self.send_header("X-MMS-Web-Identity", identity)
+            self.send_header("X-MMS-Web-Version", VERSION)
             self.send_header("X-Content-Type-Options", "nosniff")
             self.send_header("Referrer-Policy", "no-referrer")
             self.send_header("X-Frame-Options", "SAMEORIGIN" if preview else "DENY")

--- a/mms_web/service.py
+++ b/mms_web/service.py
@@ -1,0 +1,296 @@
+"""`mms web status|url|start|stop|restart`: manage the Pilot service from a shell.
+
+The server has no supervisor: the installer starts one detached process and
+nothing restarts it later. These commands answer the two questions that
+kept getting lost — "which of the Pilots on this machine is mine, and what
+is its address" — and start or stop that one. Discovery is by port probe:
+every Pilot answers HEAD / with `X-MMS-Web-Identity` (source|config_root|
+version) and `X-MMS-Web-Version`; the process details come from `lsof` and
+`ps`, never from a pid file that could go stale.
+"""
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+VERBS = ("status", "url", "start", "stop", "restart")
+DEFAULT_PORT_BASE = 8765
+PORT_SEARCH_LIMIT = 20
+START_TIMEOUT = 30
+STOP_TIMEOUT = 20
+
+
+def default_state_root() -> Path:
+    base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local/share")
+    return (Path(base) / "mms-web").expanduser().resolve()
+
+
+def source_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def _probe(port: int, timeout: float = 0.4):
+    """Headers of a Pilot listening on the port, or None."""
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+        conn.request("HEAD", "/", headers={"Host": f"127.0.0.1:{port}"})
+        response = conn.getresponse()
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    identity = response.getheader("X-MMS-Web-Identity")
+    if not identity:
+        return None
+    return {"identity": identity, "version": response.getheader("X-MMS-Web-Version") or ""}
+
+
+def _listening_pids(port: int) -> list[int]:
+    try:
+        out = subprocess.run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-Fp"],
+                             capture_output=True, text=True, timeout=5).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+    pids = []
+    for line in out.splitlines():
+        if line.startswith("p") and line[1:].isdigit():
+            pids.append(int(line[1:]))
+    return sorted(set(pids))
+
+
+def _command_line(pid: int) -> list[str]:
+    try:
+        out = subprocess.run(["ps", "-o", "command=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=5).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return []
+    try:
+        return shlex.split(out)
+    except ValueError:
+        return out.split()
+
+
+def _option(argv: list[str], name: str) -> str:
+    for index, token in enumerate(argv):
+        if token == name and index + 1 < len(argv):
+            return argv[index + 1]
+        if token.startswith(name + "="):
+            return token[len(name) + 1:]
+    return ""
+
+
+def _cwd(pid: int) -> str:
+    try:
+        out = subprocess.run(["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"],
+                             capture_output=True, text=True, timeout=5).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    for line in out.splitlines():
+        if line.startswith("n"):
+            return line[1:]
+    return ""
+
+
+def discover(port_base: int = DEFAULT_PORT_BASE, limit: int = PORT_SEARCH_LIMIT,
+             state_root: Path | None = None) -> list[dict]:
+    """Every Pilot answering on the probed ports, ours flagged by state root."""
+    mine_root = (state_root or default_state_root())
+    found = []
+    for port in range(port_base, port_base + limit):
+        probe = _probe(port)
+        if probe is None:
+            continue
+        pids = _listening_pids(port)
+        pid = pids[0] if pids else 0
+        argv = _command_line(pid) if pid else []
+        raw_state = _option(argv, "--state-root")
+        state = str(Path(raw_state).expanduser().resolve()) if raw_state else str(default_state_root())
+        entry = {
+            "port": port,
+            "pid": pid,
+            "version": probe["version"],
+            "identity": probe["identity"],
+            "stateRoot": state,
+            "configRoot": _option(argv, "--config-root"),
+            "source": _cwd(pid) if pid else "",
+            "url": f"http://127.0.0.1:{port}",
+            "mine": bool(argv) and state == str(mine_root),
+        }
+        token_file = Path(state) / "remote-access-token"
+        if entry["mine"] and (Path(state) / "remote-access.json").is_file() and token_file.is_file():
+            try:
+                token = token_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                token = ""
+            if token:
+                from .remote_access import QUERY
+                entry["url"] = f"http://127.0.0.1:{port}/?{QUERY}={token}"
+        found.append(entry)
+    return found
+
+
+def _mine(instances: list[dict]) -> dict | None:
+    for entry in instances:
+        if entry["mine"]:
+            return entry
+    return None
+
+
+def _free_port(port_base: int, limit: int) -> int:
+    import socket
+
+    for port in range(port_base, port_base + limit):
+        with socket.socket() as probe:
+            try:
+                probe.bind(("127.0.0.1", port))
+            except OSError:
+                continue
+        return port
+    raise SystemExit(f"没有空闲端口（{port_base}..{port_base + limit - 1}）。")
+
+
+def _print_status(instances: list[dict], state_root: Path, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps({"stateRoot": str(state_root), "instances": instances}, ensure_ascii=False, indent=2))
+        return
+    if not instances:
+        print("没有 Pilot 在运行。启动：mms web start")
+        return
+    for entry in instances:
+        mark = "●" if entry["mine"] else "○"
+        version = entry["version"] or "?"
+        print(f"{mark} {entry['url']}  v{version}  pid {entry['pid'] or '?'}")
+        print(f"    state-root  {entry['stateRoot']}")
+        if entry["configRoot"]:
+            print(f"    config-root {entry['configRoot']}")
+        if entry["source"]:
+            print(f"    source      {entry['source']}")
+    mine = _mine(instances)
+    if mine is None:
+        print(f"○ 这些都不是当前 state-root（{state_root}）的实例。启动自己的：mms web start")
+    else:
+        print("● 当前实例。停止：mms web stop；重启：mms web restart")
+
+
+def start(*, state_root: Path, port_base: int, limit: int, open_browser: bool,
+          extra_args: list[str] | None = None, quiet: bool = False) -> dict:
+    """Return the running instance, starting one detached when there is none."""
+    mine = _mine(discover(port_base, limit, state_root))
+    if mine is not None:
+        if not quiet:
+            print(f"MMS Pilot 已在运行：{mine['url']}")
+        if open_browser:
+            import webbrowser
+            webbrowser.open(mine["url"])
+        return mine
+    port = _free_port(port_base, limit)
+    log_dir = state_root / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "mms-web.log"
+    command = [sys.executable, "-P", "-m", "mms_web", "--state-root", str(state_root), "--port", str(port),
+               *(extra_args or [])]
+    env = dict(os.environ)
+    env.setdefault("PYTHONPATH", str(source_root()))
+    with log_path.open("ab") as log:
+        subprocess.Popen(command, cwd=str(source_root()), env=env, stdin=subprocess.DEVNULL,
+                         stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    deadline = time.monotonic() + START_TIMEOUT
+    while time.monotonic() < deadline:
+        mine = _mine(discover(port_base, limit, state_root))
+        if mine is not None and mine["port"] == port:
+            if not quiet:
+                print(f"MMS Pilot: {mine['url']}")
+                print(f"  后台运行中，日志在 {log_path}")
+            if open_browser:
+                import webbrowser
+                webbrowser.open(mine["url"])
+            return mine
+        time.sleep(0.5)
+    raise SystemExit(f"MMS Pilot 没有在 {START_TIMEOUT}s 内就绪，日志在 {log_path}")
+
+
+def stop(*, state_root: Path, port_base: int, limit: int, everyone: bool, quiet: bool = False) -> list[dict]:
+    """SIGTERM ours (or every Pilot with --all) and wait; never kill -9."""
+    targets = [e for e in discover(port_base, limit, state_root) if everyone or e["mine"]]
+    targets = [e for e in targets if e["pid"]]
+    if not targets:
+        if not quiet:
+            print("没有需要停止的 Pilot。")
+        return []
+    for entry in targets:
+        try:
+            os.kill(entry["pid"], signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            print(f"无权停止 pid {entry['pid']}（{entry['url']}）", file=sys.stderr)
+    deadline = time.monotonic() + STOP_TIMEOUT
+    remaining = list(targets)
+    while remaining and time.monotonic() < deadline:
+        time.sleep(0.5)
+        remaining = [e for e in remaining if _probe(e["port"]) is not None]
+    for entry in targets:
+        if entry in remaining:
+            print(f"⚠ pid {entry['pid']}（{entry['url']}）在 {STOP_TIMEOUT}s 内没有退出，未强制结束。", file=sys.stderr)
+        elif not quiet:
+            print(f"已停止 {entry['url']}（pid {entry['pid']}）")
+    return [e for e in targets if e not in remaining]
+
+
+def run(verb: str, argv: list[str]) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog=f"mms web {verb}")
+    parser.add_argument("--state-root", type=Path, default=default_state_root())
+    parser.add_argument("--config-root", type=Path, default=None,
+                        help="Passed through to the server on start; discovery does not need it")
+    parser.add_argument("--port", type=int, default=int(os.environ.get("MMS_WEB_PORT_BASE") or DEFAULT_PORT_BASE),
+                        help="First port to probe or bind")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--open", action="store_true", help="start/restart: open the browser afterwards")
+    parser.add_argument("--all", action="store_true", help="stop: every Pilot on this machine, not only this state root")
+    args = parser.parse_args(argv)
+    state_root = args.state_root.expanduser().resolve()
+    extra = ["--config-root", str(args.config_root.expanduser())] if args.config_root else []
+    limit = PORT_SEARCH_LIMIT
+    if verb == "status":
+        instances = discover(args.port, limit, state_root)
+        _print_status(instances, state_root, args.json)
+        return 0 if _mine(instances) else 1
+    if verb == "url":
+        mine = _mine(discover(args.port, limit, state_root))
+        if mine is None:
+            print("Pilot 没有在运行。启动：mms web start", file=sys.stderr)
+            return 1
+        print(json.dumps(mine, ensure_ascii=False) if args.json else mine["url"])
+        return 0
+    if verb == "start":
+        mine = start(state_root=state_root, port_base=args.port, limit=limit, open_browser=args.open,
+                     extra_args=extra, quiet=args.json)
+        if args.json:
+            print(json.dumps(mine, ensure_ascii=False))
+        return 0
+    if verb == "stop":
+        stopped = stop(state_root=state_root, port_base=args.port, limit=limit, everyone=args.all, quiet=args.json)
+        if args.json:
+            print(json.dumps(stopped, ensure_ascii=False))
+        return 0
+    if verb == "restart":
+        stop(state_root=state_root, port_base=args.port, limit=limit, everyone=False, quiet=args.json)
+        mine = start(state_root=state_root, port_base=args.port, limit=limit, open_browser=args.open,
+                     extra_args=extra, quiet=args.json)
+        if args.json:
+            print(json.dumps(mine, ensure_ascii=False))
+        return 0
+    parser.error(f"unknown verb {verb}")
+    return 2

--- a/tests/test_mms_web_service.py
+++ b/tests/test_mms_web_service.py
@@ -1,0 +1,121 @@
+"""`mms web status|url|start|stop|restart` manage the detached Pilot (issue #188)."""
+import json
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port_base() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _run(args, *, home: Path, timeout=90):
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("MMS_CONFIG_ROOT", "MMS_CONFIG_DIR", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+                        "MMS_REAL_HOME", "REAL_HOME", "ORIGINAL_HOME", "MMS_WEB_PORT_BASE")}
+    env.update({"HOME": str(home), "MMS_REAL_HOME": str(home), "PYTHONPATH": str(ROOT)})
+    return subprocess.run([sys.executable, "-P", "-m", "mms_web", *args], cwd=ROOT, env=env,
+                          capture_output=True, text=True, timeout=timeout)
+
+
+@pytest.fixture
+def home(tmp_path):
+    (tmp_path / "config").mkdir()
+    return tmp_path
+
+
+def _stop_everything(home: Path, port: int):
+    _run(["stop", "--all", "--port", str(port), "--json"], home=home)
+
+
+def test_status_and_url_report_nothing_on_an_unused_port_range(home):
+    port = _free_port_base()
+    status = _run(["status", "--port", str(port), "--json"], home=home)
+    assert status.returncode == 1, status.stderr
+    assert json.loads(status.stdout)["instances"] == []
+    url = _run(["url", "--port", str(port)], home=home)
+    assert url.returncode == 1
+    assert "mms web start" in url.stderr
+
+
+def test_start_status_url_stop_cycle(home):
+    port = _free_port_base()
+    state = home / "state"
+    config = home / "config"
+    try:
+        started = _run(["start", "--port", str(port), "--state-root", str(state), "--config-root", str(config), "--json"], home=home)
+        assert started.returncode == 0, started.stdout + started.stderr
+        instance = json.loads(started.stdout)
+        assert instance["mine"] is True and instance["port"] == port
+        assert instance["url"] == f"http://127.0.0.1:{port}"
+        assert (state / "logs" / "mms-web.log").is_file()
+
+        # A second start does not spawn another server: same pid, same port.
+        again = _run(["start", "--port", str(port), "--state-root", str(state), "--json"], home=home)
+        assert json.loads(again.stdout)["pid"] == instance["pid"]
+
+        status = _run(["status", "--port", str(port), "--state-root", str(state), "--json"], home=home)
+        assert status.returncode == 0
+        rows = json.loads(status.stdout)["instances"]
+        assert [r["port"] for r in rows] == [port]
+        assert rows[0]["mine"] is True
+        assert rows[0]["stateRoot"] == str(state.resolve())
+        assert rows[0]["configRoot"] == str(config)
+        from mms_version import VERSION
+        assert rows[0]["version"] == VERSION
+
+        # Another state root sees the same server but not as its own.
+        other = _run(["status", "--port", str(port), "--state-root", str(home / "elsewhere"), "--json"], home=home)
+        assert other.returncode == 1
+        assert json.loads(other.stdout)["instances"][0]["mine"] is False
+
+        url = _run(["url", "--port", str(port), "--state-root", str(state)], home=home)
+        assert url.stdout.strip() == f"http://127.0.0.1:{port}"
+
+        stopped = _run(["stop", "--port", str(port), "--state-root", str(state), "--json"], home=home)
+        assert stopped.returncode == 0, stopped.stderr
+        assert [r["pid"] for r in json.loads(stopped.stdout)] == [instance["pid"]]
+        after = _run(["status", "--port", str(port), "--state-root", str(state), "--json"], home=home)
+        assert after.returncode == 1 and json.loads(after.stdout)["instances"] == []
+    finally:
+        _stop_everything(home, port)
+
+
+def test_stop_only_touches_its_own_state_root_unless_all(home):
+    port = _free_port_base()
+    a, b = home / "a", home / "b"
+    config = home / "config"
+    try:
+        for state in (a, b):
+            started = _run(["start", "--port", str(port), "--state-root", str(state), "--config-root", str(config), "--json"], home=home)
+            assert started.returncode == 0, started.stdout + started.stderr
+        # Stopping b leaves a alone.
+        assert _run(["stop", "--port", str(port), "--state-root", str(b), "--json"], home=home).returncode == 0
+        rows = json.loads(_run(["status", "--port", str(port), "--state-root", str(a), "--json"], home=home).stdout)["instances"]
+        assert len(rows) == 1 and rows[0]["stateRoot"] == str(a.resolve())
+        # --all from an unrelated root stops what is left.
+        assert _run(["stop", "--all", "--port", str(port), "--state-root", str(home / "none"), "--json"], home=home).returncode == 0
+        rows = json.loads(_run(["status", "--port", str(port), "--json"], home=home).stdout)["instances"]
+        assert rows == []
+    finally:
+        _stop_everything(home, port)
+
+
+def test_the_verb_may_follow_options_that_mms_core_prepends(home):
+    """`mms web status` arrives here as `--config-root <root> status` when
+    MMS_CONFIG_ROOT is set, and `mms web --open` must keep serving as before."""
+    port = _free_port_base()
+    result = _run(["--config-root", str(home / "config"), "status", "--port", str(port), "--json"], home=home)
+    assert result.returncode == 1, result.stderr
+    assert json.loads(result.stdout)["instances"] == []
+    # An unknown positional is still an argparse error from the server parser.
+    bogus = _run(["frobnicate"], home=home)
+    assert bogus.returncode == 2 and "unrecognized arguments" in bogus.stderr


### PR DESCRIPTION
Closes #188。

## 为什么

安装脚本装完只在后台起一个 Pilot，之后没有任何东西看着它：被结束或重启后不会回来，也没有命令能回答「本机哪个 Pilot 是我的、地址是什么」。今天本机同时跑着 5 个测试起的实例，没有一个是当前 dev 的。

## 命令

| 命令 | 行为 |
|---|---|
| `mms web status [--json]` | 探测 8765 起 20 个端口，凡是回 `X-MMS-Web-Identity` 头的都列出：地址、版本、pid、state-root、config-root、来源目录；● 标出属于当前 state-root 的实例。有自己的实例返回 0，否则 1 |
| `mms web url` | 只打印当前实例地址（远程访问打开时带 token）；没在跑返回 1 并提示 `mms web start` |
| `mms web start [--open]` | 已在跑就直接返回地址；没跑就用第一个空闲端口在后台起（`start_new_session`，日志写 `<state-root>/logs/mms-web.log`），等就绪后打印 |
| `mms web stop [--all]` | 对当前实例（`--all` 是本机全部 Pilot）发 SIGTERM，等最多 20 秒，从不 `kill -9` |
| `mms web restart` | 先 stop 再 start |

实现在 `mms_web/service.py`；`mms_web/__main__.py` 在 argv 里找到动词就分派，找不到走原来的前台启动，所以 `mms web --open` / `mms-web --open` 不变；`mms_core` 会在 `MMS_CONFIG_ROOT` 设置时前置 `--config-root`，动词放在它后面也能识别。服务端 `_send` 多发一个 `X-MMS-Web-Version` 头供 status 显示版本。

「我的」实例按 state-root 判定而不是身份哈希，因为算默认 config-root 会触发一次配置收拢，`status` 不该有副作用。

## 验证

- `tests/test_mms_web_service.py` 4 条：空端口段的 status/url 返回码；start → 重复 start 不再起新进程 → status（含版本、config-root、另一 state-root 视角为非自有）→ url → stop → 消失；stop 只碰自己的 state-root、`--all` 停全部；动词跟在 `--config-root` 后面可识别、未知位置参数仍是原 parser 的报错。全部用临时 HOME、临时 config-root 和随机端口，不碰本机真实 Pilot。
- 邻近文件 `test_mms_web_remote_access.py` / `test_install_script_paths.py` / `test_mms_web_lan_switch.py`：119 passed。
- 本机实测 `./mms web url`（经 mms_core 分派）：无实例时正确返回 1 并提示。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
