### PR TITLE
chore: release v4.14.0

### DIFF
--- a/apps/mms-web/package-lock.json
+++ b/apps/mms-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mms/web",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mms/web",
-      "version": "4.13.1",
+      "version": "4.14.0",
       "dependencies": {
         "lucide-react": "0.468.0",
         "qrcode-generator": "2.0.4",

--- a/apps/mms-web/package.json
+++ b/apps/mms-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mms/web",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/mms-web/RELEASE-v4.14.0.md
+++ b/docs/mms-web/RELEASE-v4.14.0.md
@@ -1,0 +1,6 @@
+# v4.14.0 · 管理本机 Pilot 服务；DeepSeek v4.1 / GLM / Qwen 档位
+
+- **`mms web status / url / start / stop / restart`**（#189）：安装后在后台跑的 Pilot 不再是「不知道在哪」的进程。`status` 列出本机所有在监听的 Pilot（地址、版本、pid、state-root、config-root、来源目录）并标出当前实例；`url` 只打印地址；`start` 已在跑就返回地址，没跑就后台启动并打印地址（日志在 `<state-root>/logs/mms-web.log`）；`stop` 只发 SIGTERM，`--all` 停本机全部 Pilot；`restart` 先停再起。`mmf web ...` 同样可用；`mms web --open` 前台启动不变。
+- **DeepSeek v4 全家按 v4.1 能力**（#185）：v4-pro / v4-flash / vision-exp 的旧档位钉扎移除，上下文 1048576、最大输出 393216，`xhigh` 成为独立档位（不再映射到 `max`）；v4-flash / chat / reasoner / vision-exp 识图，v4-pro 仅文本。GLM 5.2/5.3 与 coding-effort 开放 none..max 七档，默认仍为 `max`；Qwen 3.7/3.6 六档，Qwen 3.8 含 `max`。证据记录在 `docs/reference/model-capability-calibration/2026-09-10-deepseek-v41-glm-qwen-tiers.json`。
+
+已设 `reasoning_effort: xhigh` 的 DeepSeek 用户会按真实 xhigh 档发送，不再被抬到 max。版本源、Web package metadata 和静态 Web bundle 同步为 `4.14.0`。

--- a/mms_version.py
+++ b/mms_version.py
@@ -1,2 +1,2 @@
 """Version of the packaged MMS source and Web client."""
-VERSION = "4.13.1"
+VERSION = "4.14.0"

--- a/mms_web_static/build.json
+++ b/mms_web_static/build.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.13.1",
-  "sourceSha256": "7c94ee98de7e5701075fbb53ad8bf582429f60a297d48e8fb85f4a9efe25702e",
+  "version": "4.14.0",
+  "sourceSha256": "4211bd2b808404339a5c2f7b657cb00987f474a5355eb99328f8363c894020fd",
   "files": {
     "assets/index-BowAa16X.css": "93bc440e20c0f5b7a736dc91f76f1b8d7b7ab783d98277fa32ac87df8385ef06",
     "assets/index-DpDVbYOo.js": "b0d6751f0b899524a4eb29243c67c5309d4fe9123810d364c04f4ec63d0d53ee",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-model-switch",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
Release v4.14.0 after #189 (`mms web status/url/start/stop/restart`) and #185 (DeepSeek v4.1 / GLM / Qwen effort tiers). Bumps version metadata, rebuilds the Pilot static bundle (4.14.0), records `docs/mms-web/RELEASE-v4.14.0.md`. Validated: py_compile, frontend build, git diff --check, web service / pi vision relay / provider profiles / install script tests (the one provider_profiles failure is pre-existing on dev).

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi