### PR TITLE
fix(capability): kimi-code k3 context 262144 -> 1048576 (match official calibration)

### DIFF
--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -1291,7 +1291,7 @@
       },
       "context_windows": {
         "kimi-k3": 1048576,
-        "k3": 262144,
+        "k3": 1048576,
         "kimi-for-coding": 262144,
         "kimi-for-coding-highspeed": 262144,
         "kimi-k2.5": 262144,

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -4949,7 +4949,7 @@ def test_config_web_mmf_official_overrides_use_provider_profiles(monkeypatch, tm
     assert deepseek["max_output_tokens"] == 393_216
 
     k3 = result["model_capabilities"]["k3"]
-    assert k3["context_window_tokens"] == 262_144
+    assert k3["context_window_tokens"] == 1_048_576
     assert k3["max_output_tokens"] == 131_072
     assert k3["vision"] is True
     assert k3["reasoning_effort"] == "max"

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -1196,7 +1196,7 @@ def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path
     assert model_by_id["k3[1m]"]["maxTokens"] == 1_048_576
     assert model_by_id["k3[1m]"]["reasoning"] is True
     assert model_by_id["k3"]["input"] == ["text", "image"]
-    assert model_by_id["k3"]["contextWindow"] == 262_144
+    assert model_by_id["k3"]["contextWindow"] == 1_048_576
     assert model_by_id["k3"]["maxTokens"] == 131_072
     assert model_by_id["k3"]["reasoning"] is True
     assert model_by_id["kimi-for-coding-highspeed"]["contextWindow"] == 262_144

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -319,7 +319,7 @@ def test_kimi_k3_profile_uses_reasoning_effort_without_k2_thinking_patch(monkeyp
         "k3",
         provider_id="kimi",
         base_url="https://api.kimi.com/coding/",
-    ) == 262_144
+    ) == 1_048_576
     assert profiles.profile_context_window(
         "k3[1m]",
         provider_id="kimi",


### PR DESCRIPTION
Follow-up to #185 (already merged). Found via the user's WebUI screenshot: the model page's "MMF 官方数据" row tried to **downgrade** k3's context from the user's correct 1048576 to 262144 with a "会覆盖你设置的值" warning.

## Root cause

The official-override chain resolves from provider profiles, and `kimi-code` still carried `k3: 262144` — the stale outlier:

- `2026-09-02-kimi-k3-official.json` calibration (captured from platform.kimi.ai): **1048576**
- `kimi-k3-coding` profile: 1048576
- `openrouter-moonshot-kimi-k3` profile: 1048576
- `kimi-code` profile: **262144** — fixed here

## Changes

- `kimi-code` profile: k3 context 262144 -> 1048576. Unchanged: k3 max_out 131072, kimi-for-coding(-highspeed) 256K (documented coding-plan tier), `k3-256k` alias entry.
- Tests: update the three stale `262_144` k3 expectations (one ironically lives in `test_pi_kimi_k3_exports_1m_context_and_openai_protocol`).

## Verification

- `test_config_web.py -k official_overrides`: 4 passed (now asserts k3 == 1_048_576)
- the two previously-stale k3 tests: 2 passed
- selection suite `-k "provider_profile or capability or effort or vision or kimi"`: identical failure set vs clean baseline

After merge + web restart, the k3 official row shows 1M and stops downgrading the user's setting.

Agent-Model: glm-5.3
Agent-Family: zhipu
Agent-Session: stride-6dca62da9ecf404e
