### PR TITLE
fix(test): 补上 #185 漏改的两条 pi launcher 断言（dev 当前是红的）

### DIFF
--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -799,13 +799,16 @@ def test_pi_openai_provider_compat_uses_profile_specific_flags(monkeypatch, tmp_
         "supportsDeveloperRole": False,
         "thinkingFormat": "deepseek",
     }
-    assert provider["models"][0]["maxTokens"] == 384_000
+    # The 2026-09-10 live probes moved the whole deepseek family onto the
+    # v4.1 backend: 393216 output tokens and every tier accepted as itself,
+    # so xhigh is no longer folded into max.
+    assert provider["models"][0]["maxTokens"] == 393_216
     assert provider["models"][0]["thinkingLevelMap"] == {
-        "minimal": None,
-        "low": None,
-        "medium": None,
+        "minimal": "minimal",
+        "low": "low",
+        "medium": "medium",
         "high": "high",
-        "xhigh": "max",
+        "xhigh": "xhigh",
         "max": "max",
     }
 
@@ -874,12 +877,14 @@ def test_pi_profile_derived_effort_maps_expose_only_truthful_levels():
         "qwen3.6-plus",
         {"supports_thinking": True},
     )
+    # qwen3.6 accepts six values; only max is refused, and the map has to say
+    # so rather than hiding tiers this route can actually execute.
     assert qwen_map == {
-        "minimal": None,
-        "low": None,
-        "medium": None,
+        "minimal": "minimal",
+        "low": "low",
+        "medium": "medium",
         "high": "high",
-        "xhigh": None,
+        "xhigh": "xhigh",
         "max": None,
     }
 


### PR DESCRIPTION
`origin/dev` 上 `tests/test_pi_launcher.py` 有两条失败，是 #185 合并时留下的：

| 断言 | 旧值 | #185 实测后的真值 |
|---|---|---|
| `provider["models"][0]["maxTokens"]` | `384_000` | `393_216`（deepseek 全家上 v4.1 后端） |
| deepseek `thinkingLevelMap` | `xhigh → "max"`，minimal/low/medium 为 `None` | 六档各自直通，`xhigh` 是独立档 |
| `qwen_map`（qwen3.6-plus） | 只有 `high`，其余 `None` | 六档接受五档，只有 `max` 仍是 `None` |

都是断言迁就旧钉扎，不是产品回归：改动本身在 #185 里有实测证据（invalid-value 枚举探测 + max_tokens 区间报错）。#185 的验证只跑了 `-k "provider_profile or capability or effort"`，这个文件不在其中，所以没被发现。

改后 `tests/test_pi_launcher.py`：45 passed，剩余 5 条失败与 dev 基线完全一致（npx cache 预热、gemini alias、anthropic models config，都是环境相关的存量红项），无新增。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
