### PR TITLE
fix(update): 不要把新版装进上一次更新留下的暂存副本

### DIFF
--- a/mms_web/update_install.py
+++ b/mms_web/update_install.py
@@ -59,6 +59,18 @@ def _is_checkout(root: Path) -> bool:
     return any((parent / ".git").exists() for parent in (root, *root.parents))
 
 
+def _is_staged_copy(root: Path) -> bool:
+    """True for a release unpacked under `<state>/updates/versions/<tag>/source`.
+
+    A Pilot that was updated before this existed serves from such a copy, and
+    it is not an installation: writing a newer release into it would leave the
+    pointer removed and the next start falling back to whatever the launcher
+    points at, which is older. Refusing keeps the pointer, which is correct.
+    """
+    return any(parent.name == "versions" and parent.parent.name == "updates"
+               for parent in root.parents)
+
+
 def _writable(root: Path) -> bool:
     try:
         with tempfile.NamedTemporaryFile(dir=root, prefix=".mms-write-probe-"):
@@ -77,6 +89,9 @@ def describe(source: Path | str) -> dict:
     if _is_checkout(root):
         return {"updatesCli": False, "root": str(root),
                 "reason": "这是源码检出，更新不会改工作树；命令行请用 git 更新。"}
+    if _is_staged_copy(root):
+        return {"updatesCli": False, "root": str(root),
+                "reason": "当前服务跑的是上一次更新的暂存副本，不是安装目录；请重新安装一次，之后更新就会同时换掉命令行。"}
     if not _writable(root):
         return {"updatesCli": False, "root": str(root),
                 "reason": "安装目录不可写，更新只换网页服务。"}

--- a/tests/test_update_install.py
+++ b/tests/test_update_install.py
@@ -164,7 +164,7 @@ def test_the_upgrade_notice_is_the_release_section_and_nothing_else():
 
 def _spec(tmp_path, *, old_source: Path, staged: Path) -> dict:
     state = tmp_path / "state"
-    (state / "updates").mkdir(parents=True)
+    (state / "updates").mkdir(parents=True, exist_ok=True)
     operation_root = state / "updates" / "operations" / "op-1"
     operation_root.mkdir(parents=True)
     return {"state": str(state), "source": str(staged), "oldSource": str(old_source),
@@ -211,3 +211,29 @@ def test_a_failed_installation_is_reported_and_not_claimed(tmp_path, monkeypatch
     assert install_alongside(spec) is False
     report = json.loads((Path(spec["armed"]).parent / "installation.json").read_text())
     assert report["installed"] is False and "ValueError" in report["reason"]
+
+
+def test_a_staged_copy_from_an_earlier_update_is_not_an_installation(tmp_path):
+    """A Pilot updated before #195 serves from `<state>/updates/versions/...`.
+
+    Installing into that directory would remove the pointer and leave the next
+    start falling back to the older source the launcher points at, so the web
+    app would silently move backwards.
+    """
+    staged = _release(tmp_path / "state" / "updates" / "versions" / "v4.15.0-abcd" / "source",
+                      version="4.15.0")
+    verdict = describe(staged)
+    assert verdict["updatesCli"] is False
+    assert "暂存副本" in verdict["reason"]
+
+
+def test_a_staged_copy_keeps_the_pointer_instead_of_being_overwritten(tmp_path):
+    from mms_web.update_handoff import install_alongside
+
+    staged_old = _release(tmp_path / "state" / "updates" / "versions" / "v1.0.0-aaaa" / "source",
+                          version="1.0.0")
+    staged_new = _release(tmp_path / "staged", version="2.0.0")
+    spec = _spec(tmp_path, old_source=staged_old, staged=staged_new)
+
+    assert install_alongside(spec) is False
+    assert 'VERSION = "1.0.0"' in (staged_old / "mms_version.py").read_text()


### PR DESCRIPTION
#195 合并后在真机上发现的缺陷，发现方式是用户在 4.14.0 的 Pilot 里点了更新。

## 怎么踩到的

4.14.0 及更早的更新逻辑只做「解包到 `<state>/updates/versions/<tag>/source` + 写 `active.json` 指针 + 重启网页」。所以任何一台在本次改动之前更新过的机器，**它的 Pilot 现在跑的就是那份暂存副本**，`Path(__file__).parent.parent` 指向的也是它。

`describe()` 只挡了两件事：是不是 git 检出、可不可写。暂存副本两条都通过，于是被判成「可以替换的安装目录」。接下来：

1. 新版被写进**旧的**暂存目录；
2. `active.json` 被删掉（因为自认为已经装进安装目录了）；
3. 当前这个候选进程仍是新版，一切看起来正常；
4. **下次重启时没有指针可跟**，回落到启动器指向的源码，也就是更老的那份 —— 网页静默降级。

真机现状即是这个前提：8765 的 Pilot 是 4.15.0，源码是 `~/.local/share/mms-web/updates/versions/v4.15.0-kcxtrj1n/source`，命令行的检出还在 4.14.0。下一次点更新就会命中。

## 改动

`describe()` 增加一条判定：源码位于 `updates/versions/` 暂存树内时拒绝安装，保留指针（也就是 #195 之前的行为，安全且已知）。理由文案同时给出出路：重新安装一次，之后更新就会同时换掉命令行。

判定方式是路径形状（祖先目录里存在 `versions` 且其父目录为 `updates`），不依赖 state root 是否已知，因为 guardian 那一侧只拿得到源码路径。

## 验证

`tests/test_update_install.py` 新增 2 条：暂存副本被 `describe()` 拒绝并给出原因；guardian 层对暂存副本返回 False 且原目录一字未动。该文件 14 条 + `test_mms_web_update_coordinator.py` 共 24 条全过。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
