### PR TITLE
fix(web): 终端能跑 Pi 但 Pilot 全灰；顺带说清到底缺什么

### DIFF
--- a/mms_web/drivers/launch_bridge.py
+++ b/mms_web/drivers/launch_bridge.py
@@ -23,8 +23,31 @@ class LaunchPlan:
     notes: list[str] = field(default_factory=list)
 
 
+def cached_pi() -> str:
+    """The Pi the launcher would use when no global one is installed.
+
+    `scripts/pi-cli-wrapper.sh` resolves a global pi, then this warmed npx
+    cache, then warms it. A session launch goes through that wrapper, so the
+    gate in front of it has to accept the same installs; looking only at PATH
+    reported "cannot run sessions" on machines whose terminal runs Pi fine.
+    """
+    try:
+        from mms_pi_support import _pi_npx_cache_dir
+    except Exception:
+        return ""
+    try:
+        cache = Path(_pi_npx_cache_dir())
+    except Exception:
+        return ""
+    for candidate in sorted(cache.glob("_npx/*/node_modules/.bin/pi")):
+        manifest = candidate.parent.parent / "@earendil-works" / "pi-coding-agent" / "package.json"
+        if os.access(candidate, os.X_OK) and manifest.is_file():
+            return str(candidate)
+    return ""
+
+
 def pi_runtime() -> tuple[str, str]:
-    executable = shutil.which("pi")
+    executable = shutil.which("pi") or cached_pi()
     if not executable:
         return "", ""
     # npm/fnm installations have a matching Node beside their global bin.
@@ -58,7 +81,7 @@ def probe_mms_pi_seam() -> dict:
     """
     executable, node = pi_runtime()
     if not executable:
-        reason = "找不到 pi 命令。重新运行安装脚本，或在能运行 pi 的终端里启动 Pilot。"
+        reason = "找不到 Pi：PATH 上没有，安装目录的缓存里也没有。重新运行安装脚本即可补上。"
     elif not node:
         # pi_runtime accepts a Node only when node:zlib has zstd, which
         # arrived in 22.15. An older Node is the usual cause on a machine

--- a/mms_web/drivers/launch_bridge.py
+++ b/mms_web/drivers/launch_bridge.py
@@ -51,10 +51,25 @@ def pi_runtime() -> tuple[str, str]:
 
 
 def probe_mms_pi_seam() -> dict:
+    """Whether this machine can run a Pi session, and what is missing if not.
+
+    The reason reaches the page, so it has to name the thing to install rather
+    than restate that something is wrong.
+    """
     executable, node = pi_runtime()
-    return {"available": bool(executable and node and _WORKER.is_file()),
-            "driver": "pi-rpc", "launcher": "mms_launchers.launch_cli",
-            "reason": "" if executable and node else "需要安装 Pi 和兼容的 Node.js 运行环境。"}
+    if not executable:
+        reason = "找不到 pi 命令。重新运行安装脚本，或在能运行 pi 的终端里启动 Pilot。"
+    elif not node:
+        # pi_runtime accepts a Node only when node:zlib has zstd, which
+        # arrived in 22.15. An older Node is the usual cause on a machine
+        # where pi itself installed fine.
+        reason = "没有找到符合要求的 Node.js：需要 22.15 以上的版本。升级 Node 后重启 Pilot。"
+    elif not _WORKER.is_file():
+        reason = "这份安装缺少会话执行组件，请重新运行安装脚本。"
+    else:
+        reason = ""
+    return {"available": not reason, "driver": "pi-rpc",
+            "launcher": "mms_launchers.launch_cli", "reason": reason}
 
 
 def build_pi_launch_plan(model_info, runtime, cwd, *, config_root=None, extra_args=None):

--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -84,13 +84,18 @@ class WebApplication:
         if self.sessions:
             capabilities.update(self.sessions.capabilities())
         if not capabilities["launch"]:
+            # The probe knows what is missing — an absent pi, a Node too old to
+            # run it. Repeating "not ready" instead leaves the reader with
+            # nothing to act on, which is what a whole machine of greyed-out
+            # models looked like.
+            blocker = str(capabilities.get("launchReason") or "").strip() or "Web 会话接入尚未就绪。"
             snapshot = {
                 **snapshot,
                 "models": [{**model, "available": False,
-                            "reason": model.get("reason") or "Web 会话接入尚未就绪。"}
+                            "reason": model.get("reason") or blocker}
                            for model in snapshot.get("models", [])],
                 "presets": [{**preset, "available": False,
-                             "reason": preset.get("reason") or "Web 会话接入尚未就绪。"}
+                             "reason": preset.get("reason") or blocker}
                             for preset in snapshot.get("presets", [])],
             }
         if capabilities["launch"]:

--- a/mms_web/sessions.py
+++ b/mms_web/sessions.py
@@ -310,13 +310,20 @@ class SessionService(SessionActions):
     # -- capabilities --------------------------------------------------
 
     def capabilities(self) -> dict:
-        return {
-            "launch": bool(
-                self._real_launch
-                and self._seam.get("available")
-                and callable(getattr(self._catalog, "resolve_launch", None))
-            )
-        }
+        launch = bool(
+            self._real_launch
+            and self._seam.get("available")
+            and callable(getattr(self._catalog, "resolve_launch", None))
+        )
+        return {"launch": launch, "launchReason": "" if launch else self._launch_blocker()}
+
+    def _launch_blocker(self) -> str:
+        """What to do about it, in the order the reader can act on."""
+        if not self._real_launch:
+            return "没有选定 MMS 配置根，无法启动会话。"
+        if not self._seam.get("available"):
+            return str(self._seam.get("reason") or "")
+        return "模型目录暂时不可用，无法解析启动参数。"
 
     def seam_report(self) -> dict:
         """Diagnostics for the lead; not part of the HTTP contract."""

--- a/tests/test_launch_unavailable_reason.py
+++ b/tests/test_launch_unavailable_reason.py
@@ -14,7 +14,8 @@ def test_a_missing_pi_names_pi(monkeypatch):
     monkeypatch.setattr("mms_web.drivers.launch_bridge.pi_runtime", lambda: ("", ""))
     seam = probe_mms_pi_seam()
     assert seam["available"] is False
-    assert "pi" in seam["reason"] and "安装脚本" in seam["reason"]
+    # Says both places it looked, so "but my terminal runs pi" has an answer.
+    assert "Pi" in seam["reason"] and "缓存" in seam["reason"] and "安装脚本" in seam["reason"]
 
 
 def test_an_old_node_names_the_version_it_needs(monkeypatch):
@@ -64,3 +65,53 @@ def test_the_snapshot_repeats_the_blocker_instead_of_a_generic_line():
     assert 'blocker = str(capabilities.get("launchReason")' in source
     assert '"reason": model.get("reason") or blocker' in source
     assert '"reason": preset.get("reason") or blocker' in source
+
+
+def _warm_cache(root: Path, *, executable=True, manifest=True) -> Path:
+    """The shape `scripts/pi-cli-wrapper.sh` looks for in the npx cache."""
+    binary = root / "_npx" / "a1b2c3" / "node_modules" / ".bin" / "pi"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/usr/bin/env node\n")
+    if executable:
+        binary.chmod(0o755)
+    if manifest:
+        package = binary.parent.parent / "@earendil-works" / "pi-coding-agent"
+        package.mkdir(parents=True)
+        (package / "package.json").write_text("{}")
+    return binary
+
+
+def test_the_warmed_npx_cache_counts_as_an_installed_pi(tmp_path, monkeypatch):
+    """The wrapper a launch goes through accepts it, so the gate must too.
+
+    A colleague's machine ran Pi fine from the terminal while every model in
+    Pilot showed 不可用, because only PATH was consulted here.
+    """
+    import mms_web.drivers.launch_bridge as bridge
+
+    binary = _warm_cache(tmp_path / "pi-npx")
+    monkeypatch.setattr(bridge.shutil, "which", lambda name: None if name == "pi" else "/usr/bin/node")
+    monkeypatch.setitem(__import__("sys").modules, "mms_pi_support",
+                        type("M", (), {"_pi_npx_cache_dir": staticmethod(lambda: str(tmp_path / "pi-npx"))}))
+    assert bridge.cached_pi() == str(binary)
+
+
+def test_an_incomplete_cache_is_not_mistaken_for_an_install(tmp_path, monkeypatch):
+    import mms_web.drivers.launch_bridge as bridge
+
+    _warm_cache(tmp_path / "no-manifest", manifest=False)
+    _warm_cache(tmp_path / "not-executable", executable=False)
+    for name in ("no-manifest", "not-executable", "empty"):
+        monkeypatch.setitem(__import__("sys").modules, "mms_pi_support",
+                            type("M", (), {"_pi_npx_cache_dir": staticmethod(lambda n=name: str(tmp_path / n))}))
+        assert bridge.cached_pi() == "", name
+
+
+def test_a_global_pi_still_wins(tmp_path, monkeypatch):
+    import mms_web.drivers.launch_bridge as bridge
+
+    _warm_cache(tmp_path / "pi-npx")
+    monkeypatch.setattr(bridge.shutil, "which", lambda name: "/usr/local/bin/" + name)
+    monkeypatch.setattr(bridge, "cached_pi", lambda: pytest.fail("PATH pi must be preferred"))
+    executable, _node = bridge.pi_runtime()
+    assert executable == "/usr/local/bin/pi"

--- a/tests/test_launch_unavailable_reason.py
+++ b/tests/test_launch_unavailable_reason.py
@@ -1,0 +1,66 @@
+"""A machine that cannot run sessions says what is missing (colleague report).
+
+Every model showing 不可用 with "Web 会话接入尚未就绪" gave the reader nothing
+to act on, while the probe already knew it was a missing pi or a Node too old.
+"""
+from pathlib import Path
+
+import pytest
+
+from mms_web.drivers.launch_bridge import probe_mms_pi_seam
+
+
+def test_a_missing_pi_names_pi(monkeypatch):
+    monkeypatch.setattr("mms_web.drivers.launch_bridge.pi_runtime", lambda: ("", ""))
+    seam = probe_mms_pi_seam()
+    assert seam["available"] is False
+    assert "pi" in seam["reason"] and "安装脚本" in seam["reason"]
+
+
+def test_an_old_node_names_the_version_it_needs(monkeypatch):
+    """pi installed, Node too old: the usual shape of the colleague's machine."""
+    monkeypatch.setattr("mms_web.drivers.launch_bridge.pi_runtime", lambda: ("/usr/local/bin/pi", ""))
+    seam = probe_mms_pi_seam()
+    assert seam["available"] is False
+    assert "22.15" in seam["reason"]
+
+
+def test_a_healthy_machine_gives_no_reason(monkeypatch):
+    monkeypatch.setattr("mms_web.drivers.launch_bridge.pi_runtime",
+                        lambda: ("/usr/local/bin/pi", "/usr/local/bin/node"))
+    monkeypatch.setattr("mms_web.drivers.launch_bridge._WORKER", Path(__file__))
+    seam = probe_mms_pi_seam()
+    assert seam["available"] is True and seam["reason"] == ""
+
+
+def _capabilities(*, real_launch=True, seam=None, catalog=True):
+    """A real SessionService with only the fields capabilities() reads.
+
+    Constructing one for real would probe this machine, which is the thing
+    being stubbed.
+    """
+    from mms_web.sessions import SessionService
+
+    service = SessionService.__new__(SessionService)
+    service._real_launch = real_launch
+    service._seam = seam if seam is not None else {"available": True, "reason": ""}
+    service._catalog = type("C", (), {"resolve_launch": lambda self: None})() if catalog else object()
+    return service.capabilities()
+
+
+def test_capabilities_carry_the_blocker_for_each_cause():
+    assert _capabilities() == {"launch": True, "launchReason": ""}
+    assert _capabilities(real_launch=False)["launchReason"] == "没有选定 MMS 配置根，无法启动会话。"
+    seam = {"available": False, "reason": "没有找到符合要求的 Node.js：需要 22.15 以上的版本。升级 Node 后重启 Pilot。"}
+    assert _capabilities(seam=seam)["launchReason"] == seam["reason"]
+    assert "模型目录" in _capabilities(catalog=False)["launchReason"]
+
+
+def test_the_snapshot_repeats_the_blocker_instead_of_a_generic_line():
+    """What the page actually renders under every model and channel."""
+    import mms_web.server as server
+
+    source = Path(server.__file__).read_text(encoding="utf-8")
+    assert 'blocker = str(capabilities.get("launchReason")' in source
+    assert '"reason": model.get("reason") or blocker' in source
+    assert '"reason": preset.get("reason") or blocker' in source

--- a/tests/test_mms_web_sessions_service.py
+++ b/tests/test_mms_web_sessions_service.py
@@ -154,7 +154,10 @@ def test_capabilities_require_real_launch_and_seam(tmp_path, seeded_seam):
 
 def test_launch_disabled_without_real_launch(tmp_path, seeded_seam):
     service, _ = make_service(tmp_path, real_launch=False)
-    assert service.capabilities() == {"launch": False}
+    # The blocker travels with the flag now: a page full of unavailable models
+    # has to be able to say what is missing.
+    assert service.capabilities() == {"launch": False,
+                                      "launchReason": "没有选定 MMS 配置根，无法启动会话。"}
     with pytest.raises(WebError) as err:
         launch_ok(service)
     assert err.value.status == 409


### PR DESCRIPTION
现场：同事的电脑，v4.15.0，Pilot 里 24 个模型 46 条通道**全部灰掉**，每条通道写着「Web 会话接入尚未就绪。」。但**同一台机器上，终端跑 `mms` 选 Pi 能正常对话**。

## 根因：两边找 Pi 的方式不一样

一次真正的启动走 `scripts/pi-cli-wrapper.sh`，它有三级：

1. `MMS_PI_EXECUTABLE`（PATH 上的全局 pi）
2. 安装目录下预热好的 npx 缓存 `<install>/.ai/cache/pi-npx/_npx/*/node_modules/.bin/pi`
3. 都没有就现场 `npx` 拉一份

`install.sh` 的 `warm_pi_runtime_cache` 预热的正是第 2 级。所以一台没有全局 pi、只有缓存的机器，终端完全正常。

而挡在启动前面的那道闸 `pi_runtime()` 只做了 `shutil.which("pi")`。第 2 级它看不见，于是判定整台机器「不能跑会话」，`capabilities.launch` 为假，**所有模型和通道被标灰**。

这不是「没装 Pi」，是闸门比它守护的东西更严。

## 改动

**1. 闸门与实际启动路径对齐**：`pi_runtime()` 在 PATH 找不到时，按 wrapper 的同一套条件去认那份缓存（可执行的 `.bin/pi`，且 `@earendil-works/pi-coding-agent/package.json` 存在）。全局 pi 仍然优先。

**2. 说清楚到底缺什么**（原本这个 PR 的内容）：`probe_mms_pi_seam()` 本来就算出了原因，但 `server.py` 把它扔掉，只显示写死的「Web 会话接入尚未就绪。」。现在区分三种成因并各自给出动作：

- 找不到 Pi：说明 PATH 和缓存两处都查过了，重跑安装脚本即可补上
- Node 不合要求：`pi_runtime()` 实际要求 `node:zlib` 有 `createZstdDecompress`，也就是 **Node 22.15 以上**，原文案只笼统说「兼容的 Node.js」
- 执行组件缺失：重装

`SessionService.capabilities()` 带上 `launchReason`，`server.py` 用它填每个模型和通道，写死的兜底只在什么都没有时才用。

## 验证

`tests/test_launch_unavailable_reason.py` 8 条：预热缓存被认成已安装、缓存不完整（缺 manifest / 不可执行）不被误认、全局 pi 优先、缺 Pi / Node 过旧 / 健康机器各自的 reason、`capabilities` 对三种成因给出正确阻塞、快照确实改用该 reason。

`test_mms_web_sessions_service.py` 里 `capabilities() == {"launch": False}` 的断言已更新。相关文件 83 passed；`test_pi_launcher.py` 剩余 5 条失败与 dev 基线一致（npx 预热、gemini alias、anthropic models config，均为环境相关存量红项）。

本机实测 `pi_runtime()` 仍从 PATH 命中，`cached_pi()` 在无缓存时返回空，行为未变。

## 同事那台合并后怎么确认

升到含本 PR 的版本后重启 Pilot，模型应恢复可用。若仍不可用，页面现在会直接说明缺的是 Pi 还是 Node，不用再猜。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
