### PR TITLE
fix(web): npx 装进 npm 默认缓存的 Pi 也要认

### DIFF
--- a/mms_web/drivers/launch_bridge.py
+++ b/mms_web/drivers/launch_bridge.py
@@ -31,19 +31,31 @@ def cached_pi() -> str:
     gate in front of it has to accept the same installs; looking only at PATH
     reported "cannot run sessions" on machines whose terminal runs Pi fine.
     """
+    for cache in _npx_caches():
+        for candidate in sorted(cache.glob("_npx/*/node_modules/.bin/pi")):
+            manifest = candidate.parent.parent / "@earendil-works" / "pi-coding-agent" / "package.json"
+            if os.access(candidate, os.X_OK) and manifest.is_file():
+                return str(candidate)
+    return ""
+
+
+def _npx_caches() -> list[Path]:
+    """Where an npx-installed Pi can be, most specific first.
+
+    The wrapper points npx at the installation's own cache, but a Pi installed
+    by a plain `npx` call — or by a run that never saw MMS_PI_NPX_CACHE — lands
+    in npm's default cache instead, and that machine can still run Pi.
+    """
+    caches = []
     try:
         from mms_pi_support import _pi_npx_cache_dir
+
+        caches.append(Path(_pi_npx_cache_dir()))
     except Exception:
-        return ""
-    try:
-        cache = Path(_pi_npx_cache_dir())
-    except Exception:
-        return ""
-    for candidate in sorted(cache.glob("_npx/*/node_modules/.bin/pi")):
-        manifest = candidate.parent.parent / "@earendil-works" / "pi-coding-agent" / "package.json"
-        if os.access(candidate, os.X_OK) and manifest.is_file():
-            return str(candidate)
-    return ""
+        pass
+    npm_cache = str(os.environ.get("NPM_CONFIG_CACHE") or os.environ.get("npm_config_cache") or "").strip()
+    caches.append(Path(npm_cache).expanduser() if npm_cache else Path.home() / ".npm")
+    return [cache for cache in caches if cache.is_dir()]
 
 
 def pi_runtime() -> tuple[str, str]:

--- a/tests/test_launch_unavailable_reason.py
+++ b/tests/test_launch_unavailable_reason.py
@@ -81,6 +81,13 @@ def _warm_cache(root: Path, *, executable=True, manifest=True) -> Path:
     return binary
 
 
+@pytest.fixture(autouse=True)
+def _no_real_npm_cache(tmp_path_factory, monkeypatch):
+    """Keep this machine's own ~/.npm out of the cache search."""
+    monkeypatch.setenv("NPM_CONFIG_CACHE", str(tmp_path_factory.mktemp("empty-npm")))
+    monkeypatch.delenv("npm_config_cache", raising=False)
+
+
 def test_the_warmed_npx_cache_counts_as_an_installed_pi(tmp_path, monkeypatch):
     """The wrapper a launch goes through accepts it, so the gate must too.
 
@@ -115,3 +122,29 @@ def test_a_global_pi_still_wins(tmp_path, monkeypatch):
     monkeypatch.setattr(bridge, "cached_pi", lambda: pytest.fail("PATH pi must be preferred"))
     executable, _node = bridge.pi_runtime()
     assert executable == "/usr/local/bin/pi"
+
+
+def test_a_pi_installed_into_npms_own_cache_is_found_too(tmp_path, monkeypatch):
+    """`npx pi` without the wrapper puts it in npm's default cache.
+
+    That machine can run Pi, so the gate has to see it; only the wrapper's own
+    cache was consulted before.
+    """
+    import mms_web.drivers.launch_bridge as bridge
+
+    binary = _warm_cache(tmp_path / "npm-home")
+    monkeypatch.setenv("NPM_CONFIG_CACHE", str(tmp_path / "npm-home"))
+    monkeypatch.setitem(__import__("sys").modules, "mms_pi_support",
+                        type("M", (), {"_pi_npx_cache_dir": staticmethod(lambda: str(tmp_path / "absent"))}))
+    assert bridge.cached_pi() == str(binary)
+
+
+def test_the_installation_cache_is_preferred_over_npms(tmp_path, monkeypatch):
+    import mms_web.drivers.launch_bridge as bridge
+
+    mine = _warm_cache(tmp_path / "mms-cache")
+    _warm_cache(tmp_path / "npm-home")
+    monkeypatch.setenv("NPM_CONFIG_CACHE", str(tmp_path / "npm-home"))
+    monkeypatch.setitem(__import__("sys").modules, "mms_pi_support",
+                        type("M", (), {"_pi_npx_cache_dir": staticmethod(lambda: str(tmp_path / "mms-cache"))}))
+    assert bridge.cached_pi() == str(mine)


### PR DESCRIPTION
接 #200。那一版只看 `MMS_PI_NPX_CACHE` 指向的安装内缓存，但 `npx` 装出来的 Pi 也可能在 **npm 默认缓存**里（有人手动跑过 `npx pi`，或者那次运行没带上 `MMS_PI_NPX_CACHE`）。这台开发机上就有一份：`~/.npm/_npx/99fca817.../node_modules/.bin/pi`。这种机器能正常跑 Pi，闸门却仍然判它不可用。

现在按「安装内缓存 → npm 默认缓存（`NPM_CONFIG_CACHE` 或 `~/.npm`）」的顺序查找，条件与 wrapper 一致（可执行的 `.bin/pi` 且包 manifest 存在）。全局 `pi` 依然最优先。

## 顺带澄清一个被验证为不成立的判断

有一种说法是「wrapper 的 cache 探测不覆盖当前 npx 的实际目录布局」。实测 npm 11.13 不成立：

```
$ npx -y --cache <dir> cowsay@1.6.0
<dir>/_npx/e3e1d528ee105f80/node_modules/.bin/cowsay        ← wrapper 的 glob 命中
<dir>/_npx/e3e1d528ee105f80/node_modules/cowsay/package.json
```

第一次用 `pi` 去测会得到相反结论，因为本机已全局安装同版本 pi，npx 直接复用、根本不落缓存。换一个未安装的包即可复现真实布局。所以 `scripts/pi-cli-wrapper.sh` 里那个 glob 是对的，不需要按「布局变了」去重写。

## 验证

`tests/test_launch_unavailable_reason.py` 增至 10 条，新增：npm 默认缓存里的 Pi 被找到、两处都有时优先安装内缓存。新增 autouse fixture 把 `NPM_CONFIG_CACHE` 指向空临时目录，避免用例读到开发机自己的 `~/.npm`。

本机实测：`cached_pi()` 现在返回 `~/.npm/_npx/99fca817.../node_modules/.bin/pi`。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
