### PR TITLE
install: 公开默认钉在已验证的 v4.4.0，不再跟最新 release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,12 @@ INSTALL_CHANNEL="stable"
 REQUESTED_INSTALL_CHANNEL=""
 LATEST_TAG_CACHE=""
 LATEST_RELEASE_TAG_CACHE=""
+# The public default installs this exact version, not "whatever is newest".
+# Releases are cut from dev several times a day; pointing the one-liner at the
+# latest of them hands every new user code nobody has used yet. Raise this
+# after a version has been verified. MMS_INSTALL_STABLE_REF overrides it, and
+# --channel dev / --ref still reach anything else.
+STABLE_CHANNEL_REF="${MMS_INSTALL_STABLE_REF:-v4.4.0}"
 DEV_CHANNEL_REF="${MMS_INSTALL_DEV_REF:-dev}"
 CANARY_CHANNEL_REF="${MMS_INSTALL_CANARY_REF:-canary}"
 DEFAULT_INSTALL_FALLBACK_TAG="${MMS_INSTALL_FALLBACK_TAG:-v3.3.1}"
@@ -603,12 +609,17 @@ prepare_source_dir() {
 
 resolve_requested_ref() {
     local ref="$INSTALL_REF"
-    if [ -z "$ref" ] && { [ "$INSTALL_CHANNEL" = "stable" ] || [ "$INSTALL_CHANNEL" = "latest-release" ]; }; then
+    if [ -z "$ref" ] && [ "$INSTALL_CHANNEL" = "stable" ]; then
+        ref="$STABLE_CHANNEL_REF"
+        echo "✓ stable: $ref"
+        echo "  $(t "这是已验证的稳定版本。要装最新的开发版本：--channel dev；要装指定版本：--ref vX.Y.Z" "This is the verified stable version. For the newest development build use --channel dev, or --ref vX.Y.Z for a specific one.")"
+    fi
+    if [ -z "$ref" ] && [ "$INSTALL_CHANNEL" = "latest-release" ]; then
         ref="$(resolve_latest_release_tag || true)"
         if [ -n "$ref" ]; then
-            echo "✓ stable release: $ref"
+            echo "✓ latest release: $ref"
         else
-            echo "⚠ $(t "获取 stable/latest release 失败，回退到最新 tag" "Failed to fetch stable/latest release, falling back to latest tag")"
+            echo "⚠ $(t "获取 latest release 失败，回退到最新 tag" "Failed to fetch the latest release, falling back to the latest tag")"
             INSTALL_CHANNEL="latest-tag"
         fi
     fi


### PR DESCRIPTION
**这个 PR 的目标分支是 `main`，请你确认后再合。** 它改变每个新用户执行那条安装命令后拿到的版本。

## 现状（和直觉不一样）

```
curl -fsSL .../main/install.sh | bash
```

拿到的**不是** main 上的 4.10.0，而是**今天刚发的 4.15.1**。因为脚本默认走 `stable` 通道，而 `stable` 解析的是 GitHub 上标记为 Latest 的 release，我们所有 release 都是从 dev 发的并被标成 Latest。

也就是说：main 分支停在哪个版本根本不影响公开安装，真正决定版本的是「最近发了什么」。dev 一天发好几次，等于每个新用户都在装还没人用过的代码。

## 改动

`stable` 通道改为指向一个明确的版本：

```sh
STABLE_CHANNEL_REF="${MMS_INSTALL_STABLE_REF:-v4.4.0}"
```

以后要把稳定版往前推，改这一行即可。其它入口全部保留：

| 入口 | 结果 |
|---|---|
| 默认（无参数） | `v4.4.0`，并提示可以用 `--channel dev` 或 `--ref` 装别的 |
| `--channel dev` | `dev` |
| `--ref v4.15.1` | `v4.15.1` |
| `--latest-release` | `v4.15.1`（原来的「跟最新 release」行为保留在这个显式开关里） |
| `--latest-tag` | `v4.15.1` |
| `MMS_INSTALL_STABLE_REF=v4.10.0` | `v4.10.0`，不用改脚本 |

以上六条全部用 `--dry-run` 在非源码目录下实测过（从源码目录跑会被识别成 local-source，测不到这条路径）。

## 需要你权衡的两点

1. **这对已经装了 4.1x 的人是降级路径。** 他们如果再跑一次默认命令，会被装回 4.4.0，而 4.13 之后的配置根（`~/.config/mms-next`）是 4.4.0 不认识的。要不要在检测到已安装版本更高时给一个明确提示并要求 `--force` 之类，我可以加，但那是另一个改动。
2. **v4.4.0 是否就是你要的那个「已验证」版本。** 它比现在落后很多；如果只是想「别自动跟最新」，把这一行改成某个更近的、你验过的版本会更实际。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
