### PR TITLE
fix(pi): 全局装了 pi 但 bin 不在 PATH 时，安装被卡死

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1142,7 +1142,11 @@ warm_pi_runtime_cache() {
         fi
     fi
 
-    echo "✗ $(t "pi 运行时预热失败；Pilot 无法安全启动，本次安装已停止" "pi runtime warmup failed; Pilot cannot start safely, installation stopped")"
+    # The wrapper resolves an installed pi on PATH or under npm's global
+    # prefix before it ever needs the cache, so reaching here means no pi is
+    # runnable at all — not merely that npx declined to fill the cache.
+    echo "✗ $(t "pi 运行时未就绪：PATH 上没有可运行的 pi，npm 全局目录下也没有，缓存预热同样没产出" "The pi runtime is not ready: no runnable pi on PATH, none under npm's global prefix, and the cache warmup produced nothing")"
+    echo "  $(t "先确认 pi 可用再重装：npm install -g" "Make pi runnable, then reinstall: npm install -g") $PI_CLI_PACKAGE_SPEC"
     return 1
 }
 

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import shutil
+import subprocess
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -214,11 +215,36 @@ def _pi_npx_cache_dir():
     return str(Path(__file__).resolve().parent / ".ai" / "cache" / "pi-npx")
 
 
+_PI_NPM_PREFIX_CACHE = None
+
+
+def _npm_global_prefix():
+    """npm's global prefix, asked once. Empty when npm is unavailable."""
+    global _PI_NPM_PREFIX_CACHE
+    if _PI_NPM_PREFIX_CACHE is None:
+        try:
+            result = subprocess.run(["npm", "prefix", "-g"], capture_output=True, text=True, timeout=10)
+            _PI_NPM_PREFIX_CACHE = result.stdout.strip() if result.returncode == 0 else ""
+        except (OSError, subprocess.SubprocessError):
+            _PI_NPM_PREFIX_CACHE = ""
+    return _PI_NPM_PREFIX_CACHE
+
+
 def _pi_global_executable():
-    """Use an active global Pi install when available; the wrapper owns fallback."""
+    """An installed global Pi, whether or not its bin directory is on PATH.
+
+    A session started from Finder or by the installer does not inherit the
+    shell PATH that nvm/fnm/npm-global rely on, so `which` alone reported no
+    Pi on machines that run it fine from a terminal.
+    """
     candidate = shutil.which("pi")
     if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
         return candidate
+    prefix = _npm_global_prefix()
+    if prefix:
+        candidate = os.path.join(prefix, "bin", "pi")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
     return ""
 
 

--- a/mms_web/drivers/launch_bridge.py
+++ b/mms_web/drivers/launch_bridge.py
@@ -63,8 +63,20 @@ def _npx_caches() -> list[Path]:
     return [cache for cache in caches if cache.is_dir()]
 
 
+def installed_pi() -> str:
+    """The same Pi the launcher resolves, including one off this PATH."""
+    try:
+        from mms_pi_support import _pi_global_executable
+    except Exception:
+        return shutil.which("pi") or ""
+    try:
+        return _pi_global_executable() or ""
+    except Exception:
+        return shutil.which("pi") or ""
+
+
 def pi_runtime() -> tuple[str, str]:
-    executable = shutil.which("pi") or cached_pi()
+    executable = installed_pi() or cached_pi()
     if not executable:
         return "", ""
     # npm/fnm installations have a matching Node beside their global bin.

--- a/scripts/pi-cli-wrapper.sh
+++ b/scripts/pi-cli-wrapper.sh
@@ -8,6 +8,45 @@ if [ -n "${MMS_PI_EXECUTABLE:-}" ]; then
 fi
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+SELF_PATH="$SCRIPT_DIR/$(basename "$0")"
+
+absolute_path() {
+  [ -n "${1:-}" ] || return 1
+  dir=$(CDPATH= cd -- "$(dirname "$1")" 2>/dev/null && pwd) || return 1
+  printf '%s/%s\n' "$dir" "$(basename "$1")"
+}
+
+# An installed Pi, whether or not its bin directory is on this PATH. MMS
+# normally passes MMS_PI_EXECUTABLE, but the installer calls this script
+# directly, and npm's global bin is often outside a non-interactive PATH.
+# Without this the cache below is the only option, and npx refuses to fill it
+# while a global copy exists — which left "warmup did not produce an
+# executable" on machines whose terminal ran pi perfectly well.
+installed_pi_path() {
+  candidate=$(command -v pi 2>/dev/null) || candidate=""
+  if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+    resolved=$(absolute_path "$candidate" || printf '%s' "$candidate")
+    # Never exec ourselves: `pi` on PATH can be this very wrapper.
+    if [ "$resolved" != "$SELF_PATH" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+  prefix=$(npm prefix -g 2>/dev/null) || prefix=""
+  if [ -n "$prefix" ] && [ -x "$prefix/bin/pi" ]; then
+    resolved=$(absolute_path "$prefix/bin/pi" || printf '%s' "$prefix/bin/pi")
+    if [ "$resolved" != "$SELF_PATH" ]; then
+      printf '%s\n' "$prefix/bin/pi"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if INSTALLED_PI=$(installed_pi_path); then
+  exec "$INSTALLED_PI" "$@"
+fi
+
 ROOT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 CACHE_DIR=${MMS_PI_NPX_CACHE:-"$ROOT_DIR/.ai/cache/pi-npx"}
 LOCK_DIR="$CACHE_DIR/.mms-pi-npx-install.lock"
@@ -72,10 +111,17 @@ fi
 acquire_lock
 if ! CACHED_PI=$(cached_pi_path); then
   npx -y --cache "$CACHE_DIR" @earendil-works/pi-coding-agent --version >/dev/null
-  CACHED_PI=$(cached_pi_path) || {
-    echo "MMS Pi cache warmup did not produce an executable" >&2
+  if ! CACHED_PI=$(cached_pi_path); then
+    # npx exits 0 without filling the cache when the package is already
+    # installed globally, so look once more for that copy before giving up.
+    if INSTALLED_PI=$(installed_pi_path); then
+      release_lock
+      trap - EXIT INT TERM HUP
+      exec "$INSTALLED_PI" "$@"
+    fi
+    echo "MMS Pi cache warmup did not produce an executable, and no installed pi was found on PATH or under npm's global prefix" >&2
     exit 1
-  }
+  fi
 fi
 release_lock
 trap - EXIT INT TERM HUP

--- a/tests/test_launch_unavailable_reason.py
+++ b/tests/test_launch_unavailable_reason.py
@@ -114,14 +114,32 @@ def test_an_incomplete_cache_is_not_mistaken_for_an_install(tmp_path, monkeypatc
         assert bridge.cached_pi() == "", name
 
 
-def test_a_global_pi_still_wins(tmp_path, monkeypatch):
+def test_an_installed_pi_still_wins_over_the_cache(tmp_path, monkeypatch):
+    """Resolution order mirrors the wrapper: installed first, cache second."""
     import mms_web.drivers.launch_bridge as bridge
 
     _warm_cache(tmp_path / "pi-npx")
+    monkeypatch.setattr(bridge, "installed_pi", lambda: "/usr/local/bin/pi")
+    monkeypatch.setattr(bridge, "cached_pi", lambda: pytest.fail("an installed pi must be preferred"))
     monkeypatch.setattr(bridge.shutil, "which", lambda name: "/usr/local/bin/" + name)
-    monkeypatch.setattr(bridge, "cached_pi", lambda: pytest.fail("PATH pi must be preferred"))
     executable, _node = bridge.pi_runtime()
     assert executable == "/usr/local/bin/pi"
+
+
+def test_installed_pi_follows_the_launchers_own_resolver(monkeypatch):
+    """One truth: the gate must see whatever `mms` would run, PATH or not."""
+    import sys
+
+    import mms_web.drivers.launch_bridge as bridge
+
+    monkeypatch.setitem(sys.modules, "mms_pi_support",
+                        type("M", (), {"_pi_global_executable": staticmethod(lambda: "/opt/npm/bin/pi")}))
+    assert bridge.installed_pi() == "/opt/npm/bin/pi"
+    # A launcher that cannot answer must not take the gate down with it.
+    monkeypatch.setitem(sys.modules, "mms_pi_support",
+                        type("M", (), {"_pi_global_executable": staticmethod(lambda: (_ for _ in ()).throw(RuntimeError()))}))
+    monkeypatch.setattr(bridge.shutil, "which", lambda name: "/usr/bin/" + name)
+    assert bridge.installed_pi() == "/usr/bin/pi"
 
 
 def test_a_pi_dist_cli_in_npms_own_cache_is_found_too(tmp_path, monkeypatch):

--- a/tests/test_pi_wrapper_finds_installed_pi.py
+++ b/tests/test_pi_wrapper_finds_installed_pi.py
@@ -1,0 +1,114 @@
+"""The wrapper must use an installed Pi, not only the npx cache.
+
+A machine with pi installed globally but its bin directory outside the
+launching process's PATH used to fail with "cache warmup did not produce an
+executable": npx exits 0 without filling the cache while a global copy
+exists, so the cache was the only option and it was always empty.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts" / "pi-cli-wrapper.sh"
+
+
+def _fake_pi(path: Path, *, marker: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'#!/bin/sh\necho "{marker}"\n')
+    path.chmod(0o755)
+    return path
+
+
+def _cached(cache: Path, *, marker: str) -> Path:
+    binary = cache / "_npx" / "abc123" / "node_modules" / ".bin" / "pi"
+    manifest = binary.parent.parent / "@earendil-works" / "pi-coding-agent" / "package.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("{}")
+    return _fake_pi(binary, marker=marker)
+
+
+def _run(tmp_path, *, path_dirs, cache, npm=None, timeout=60):
+    env = {
+        "HOME": str(tmp_path / "home"),
+        "PATH": os.pathsep.join([*(str(d) for d in path_dirs), "/usr/bin", "/bin"]),
+        "MMS_PI_NPX_CACHE": str(cache),
+    }
+    (tmp_path / "home").mkdir(exist_ok=True)
+    if npm:
+        env["PATH"] = os.pathsep.join([str(npm), env["PATH"]])
+    return subprocess.run(["sh", str(WRAPPER), "--version"], env=env,
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def test_a_pi_on_path_is_used_even_with_an_empty_cache(tmp_path):
+    bin_dir = tmp_path / "global-bin"
+    _fake_pi(bin_dir / "pi", marker="global-pi")
+    cache = tmp_path / "cache"
+    cache.mkdir()
+
+    result = _run(tmp_path, path_dirs=[bin_dir], cache=cache)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "global-pi"
+
+
+def test_npms_global_prefix_is_consulted_when_path_has_no_pi(tmp_path):
+    """npm install -g succeeded, but its bin is not on this PATH."""
+    prefix = tmp_path / "npm-prefix"
+    _fake_pi(prefix / "bin" / "pi", marker="prefix-pi")
+    npm_dir = tmp_path / "npm-stub"
+    npm_dir.mkdir()
+    npm = npm_dir / "npm"
+    npm.write_text(f'#!/bin/sh\nif [ "$1" = "prefix" ]; then echo "{prefix}"; exit 0; fi\nexit 1\n')
+    npm.chmod(0o755)
+    cache = tmp_path / "cache"
+    cache.mkdir()
+
+    result = _run(tmp_path, path_dirs=[], cache=cache, npm=npm_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "prefix-pi"
+
+
+def test_the_cache_still_wins_when_nothing_is_installed(tmp_path):
+    cache = tmp_path / "cache"
+    _cached(cache, marker="cached-pi")
+
+    result = _run(tmp_path, path_dirs=[], cache=cache)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "cached-pi"
+
+
+def test_a_pi_on_path_that_is_this_wrapper_is_not_executed_again(tmp_path):
+    """`pi` on PATH can be a symlink to this script; execing it would loop."""
+    bin_dir = tmp_path / "loop-bin"
+    bin_dir.mkdir()
+    (bin_dir / "pi").symlink_to(WRAPPER)
+    cache = tmp_path / "cache"
+    _cached(cache, marker="cached-pi")
+
+    result = _run(tmp_path, path_dirs=[bin_dir], cache=cache)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "cached-pi"
+
+
+def test_the_failure_message_names_both_places_it_looked(tmp_path):
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    npm_dir = tmp_path / "npm-stub"
+    npm_dir.mkdir()
+    # npx exits 0 without filling the cache, the shape that produced the bug.
+    for name in ("npx", "npm"):
+        stub = npm_dir / name
+        stub.write_text("#!/bin/sh\nexit 0\n")
+        stub.chmod(0o755)
+
+    result = _run(tmp_path, path_dirs=[], cache=cache, npm=npm_dir)
+
+    assert result.returncode != 0
+    assert "npm's global prefix" in result.stderr


### PR DESCRIPTION
用户现场：`curl .../dev/install.sh | bash` 直接失败并中止安装。

```
检查所需 CLI...
  ✓ 已检测到: Pi coding agent (/Users/wangpeiqi/.hermes/node/bin/pi)
...
正在准备 pi 运行环境，第一次会下载，请稍候...
✗ pi 运行时预热失败；Pilot 无法安全启动，本次安装已停止
✗ Pi 运行环境未就绪，未完成安装
```

**第一行明明检测到了 pi。**

## 链条

1. `warm_pi_runtime_cache` 先跑 `npx -y --cache <dir> <pkg> --version`，成功；
2. 再跑 `scripts/pi-cli-wrapper.sh --version` 做校验；
3. wrapper **从不查 PATH**：它只认 `MMS_PI_EXECUTABLE`（仅 MMS 启动时由 `_pi_global_executable()` 设置），安装脚本直接调它时该变量为空，于是直奔 npx 缓存；
4. 缓存是空的，wrapper 去预热；
5. **包已全局安装时 `npx --cache <dir>` 根本不往缓存装东西** —— 实测 exit 0、不生成 `_npx` 目录，加 `--ignore-existing` 也一样；
6. wrapper 报 `cache warmup did not produce an executable` 退出 1；
7. #204 把这一步从 `|| true` 改成致命错误 → 整个安装中止。

之前同一台机器在运行时报的也是同一句（终端 `mms` 启动时）。所以这是一个成因、两处症状。

## 改动

**`scripts/pi-cli-wrapper.sh`**：在缓存之前先找「已安装的 pi」——PATH 上的，或 `npm prefix -g` 下的 `bin/pi`。预热后仍无产出时再找一次，正好覆盖全局已安装这种情形。带自我递归保护：PATH 上的 `pi` 可能就是这个 wrapper（软链），此时跳过，不 exec 自己。

**`mms_pi_support._pi_global_executable()`**：同样补上 `npm prefix -g` 兜底，结果缓存一次。这样从访达或安装脚本起的会话也能拿到 `MMS_PI_EXECUTABLE`，wrapper 第一步就短路，不再依赖缓存。

**`mms_web/drivers/launch_bridge.pi_runtime()`**：改为复用 `_pi_global_executable()`，网页端的判定和命令行同一套真值（之前是各写各的 `which`）。

**`install.sh`**：失败文案改为如实说明「PATH、npm 全局目录、缓存三处都没有」，并给出补救命令。保留致命语义——走到这一步确实没有任何可运行的 pi。

## 验证

新增 `tests/test_pi_wrapper_finds_installed_pi.py` 5 条，全部以子进程真实执行 wrapper：

- PATH 上有 pi、缓存为空 → 用 PATH 上的（原来这里直接报错）
- PATH 没有、`npm prefix -g` 下有 → 用它（stub 掉 npm，复现「npm install -g 成功但 bin 不在 PATH」）
- 两者都没有、缓存里有 → 仍用缓存，原行为不变
- PATH 上的 `pi` 是本 wrapper 的软链 → 不递归，落到缓存
- 三处都没有 → 退出非零，且错误信息点名 npm 全局目录

`tests/test_launch_unavailable_reason.py` 增至 11 条，补了「已安装优先于缓存」和「网页端复用 launcher 的解析器、解析器异常时降级到 which」。

`test_pi_launcher.py` 的失败集合与干净 `origin/dev` **逐条一致（各 6 条，均为既有环境红项）**，无新增；`test_install_script_paths.py` 全通过。本机实测 `_pi_global_executable()` 与 `pi_runtime()` 都能解析到 pi。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
