### PR TITLE
fix(config-web): survive a second Ctrl-C during shutdown cleanup

### DIFF
--- a/mms_config_web_server.py
+++ b/mms_config_web_server.py
@@ -11,6 +11,7 @@ import argparse
 import copy
 import errno
 import json
+import signal
 import threading
 import traceback
 import webbrowser
@@ -585,9 +586,13 @@ def serve_config_web(app_or_snapshot: ConfigWebApp | dict[str, Any], *, host: st
         thread.join()
     except KeyboardInterrupt:
         print("\nStopping MMS setup WebUI.")
-        # shutdown() must run from a different thread than serve_forever();
-        # use a short-lived daemon helper so Ctrl-C never enters a second
-        # interruptible wait in the main thread.
+        # Ignore SIGINT for the rest of the cleanup: the waits below are still
+        # interruptible, and a second Ctrl-C used to escape as a traceback.
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+        # shutdown() must run from a different thread than serve_forever().
         stopper = threading.Thread(target=server.shutdown, daemon=True)
         stopper.start()
         stopper.join(timeout=5)

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -1,4 +1,5 @@
 import json
+import signal
 import threading
 from http.server import ThreadingHTTPServer
 from urllib.request import Request, urlopen
@@ -5179,3 +5180,41 @@ def test_config_web_save_preserves_openrouter_vision_when_mmf_overlay_is_partial
     assert caps["tool_use"] is True
     assert caps["reasoning"] is True
     assert caps["thinking"] is True
+
+
+def test_config_web_shutdown_survives_repeat_sigint(monkeypatch):
+    """Regression: a second Ctrl-C during cleanup must not escape as a traceback.
+
+    The cleanup path keeps the main thread in an interruptible wait for the
+    shutdown helper. A SIGINT landing there used to be raised out of the
+    ``except KeyboardInterrupt`` clause, so it escaped ``serve_config_web`` as a
+    traceback instead of exiting cleanly.
+    """
+    original_handler = signal.getsignal(signal.SIGINT)
+    real_join = threading.Thread.join
+
+    def join_with_second_sigint(self, timeout=None):
+        if self.name == "mms-setup-web":
+            # First Ctrl-C: interrupts the wait for the serving thread.
+            raise KeyboardInterrupt
+        # Second Ctrl-C: lands while the main thread waits for cleanup.
+        signal.raise_signal(signal.SIGINT)
+        return real_join(self, timeout)
+
+    # Pin the handler so the test does not depend on ambient signal state.
+    signal.signal(signal.SIGINT, signal.default_int_handler)
+    monkeypatch.setattr(threading.Thread, "join", join_with_second_sigint)
+    try:
+        app = mms_config_web_server.ConfigWebApp({}, command_name="mms")
+        try:
+            url = mms_config_web_server.serve_config_web(
+                app, host="127.0.0.1", port=0, open_browser=False
+            )
+        except BaseException as exc:
+            raise AssertionError(
+                f"second SIGINT escaped the cleanup path as {type(exc).__name__}"
+            ) from exc
+    finally:
+        signal.signal(signal.SIGINT, original_handler)
+
+    assert url.startswith("http://127.0.0.1:")


### PR DESCRIPTION
## Summary

`mms config web` 停止时连按两次 Ctrl-C 仍会打印 traceback。PR #204 把 `server.shutdown()` 挪出了主线程，但清理路径**仍然在主线程留了一个可被 SIGINT 中断的等待**，所以症状没有改善——只是栈的行号变了。

本 PR 在进入那个等待之前把 `SIGINT` 置为 `SIG_IGN`，补上 #204 缺的那一半。#204 的线程改造保留不动。

- 修复：`mms_config_web_server.py`，捕获到第一次 Ctrl-C 后、进入清理等待前忽略 SIGINT
- 回归测试：`tests/test_config_web.py::test_config_web_shutdown_survives_repeat_sigint`

Refs #207

## Root Cause

#204 之后：

```python
    try:
        thread.join()
    except KeyboardInterrupt:
        print("\nStopping MMS setup WebUI.")
        stopper = threading.Thread(target=server.shutdown, daemon=True)
        stopper.start()
        stopper.join(timeout=5)      # ← 主线程仍然阻塞在这个可中断等待上
    finally:
        server.server_close()
    return url
```

`stopper.join()` 要等 `serve_forever` 察觉停止标志（`socketserver` 的 poll interval 为 0.5s）。落在这个窗口里的第二次 Ctrl-C 从 `except` 子句内部抛出，穿过 `finally` 冒到 `main()`。

把阻塞点从 `finally` 里的 `server.shutdown()` 换成 `except` 里的 `stopper.join()`，**阻塞时长的量级和可中断性都没有变化**。

## Change

```python
    except KeyboardInterrupt:
        print("\nStopping MMS setup WebUI.")
        # Ignore SIGINT for the rest of the cleanup: the waits below are still
        # interruptible, and a second Ctrl-C used to escape as a traceback.
        try:
            signal.signal(signal.SIGINT, signal.SIG_IGN)
        except (ValueError, OSError):
            pass
        # shutdown() must run from a different thread than serve_forever().
        stopper = threading.Thread(target=server.shutdown, daemon=True)
        stopper.start()
        stopper.join(timeout=5)
```

`signal.signal` 只能在主线程调用，因此用 `except (ValueError, OSError)` 兜底，避免该函数被从子线程调用时抛错。

同时把 #204 那段注释里 "so Ctrl-C never enters a second interruptible wait in the main thread" 的说法删掉了——`stopper.join` 正是这样一个等待，原注释不成立；现在由 SIGINT 守卫来保证。

## Verification

**回归测试（真实 pytest，Python 3.14 + pytest 9.1.1）**。用例在「主线程等待清理结束时投递第二次 SIGINT」这一点上忠实复现原始场景：

| 代码 | `test_config_web_shutdown_survives_repeat_sigint` | `tests/test_config_web.py` 全量 |
|---|---|---|
| `dev` @ `696fffd5`（PR #204，未加守卫） | **FAIL** — `second SIGINT escaped the cleanup path as KeyboardInterrupt` | 4 failed, 116 passed, 3 skipped |
| 本 PR | **PASS** | 3 failed, 117 passed, 3 skipped |

加守卫后剩下的 3 个失败为**既有失败**，在 `dev` @ `696fffd5` 上同样失败，与本改动无关（看起来依赖本机 profile 配置）：

- `test_config_web_model_capability_defaults_are_profile_backed_not_hardcoded`
- `test_config_web_provider_model_fetch_returns_policy_capabilities`
- `test_config_web_mmf_official_overrides_use_provider_profiles`

**探针（确定性复现）**：不撑开窗口时清理窗口只有 ~1.5ms，信号打不中，因此把 `serve_forever` 的 poll interval 撑大以确定性命中该窗口：

- `dev` @ `08cfd140`（#204 之前）：逃逸，栈与 issue 中完全一致（`socketserver.py:255` → `threading.py:659`）
- `dev` @ `696fffd5`（#204）：**仍然逃逸**，栈移到 `mms_config_web_server.py:593 stopper.join(timeout=5)`
- 本 PR：干净返回

## Notes

- 目标分支：`dev`
- 本分支推送自 fork `wangpq-git/multi-model-switch`（当前账号对上游仓库只有 `pull` 权限）
- 按 `AGENT.md` 的 Issue / PR / Committee Gate，本 PR 不自行合并，等待 committee review
- `mms_config_web_server.py` 不在 `AGENT.md` / `docs/AGENT_GUARDRAILS.md` 的高风险清单内，改动只影响关机路径
