### PR TITLE
fix(capability): settle K3 on one context truth and repair the red tests

### DIFF
--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -1301,7 +1301,8 @@
         "k2.6-code-preview": 262144,
         "kimi-k2.7-code": 262144,
         "kimi-for-code": 262144,
-        "k3[1m]": 1048576
+        "k3[1m]": 1048576,
+        "k3-256k": 262144
       },
       "api_formats": {
         "openai_chat": {
@@ -1315,7 +1316,7 @@
       },
       "max_output_tokens": {
         "kimi-k3": 1048576,
-        "k3": 1048576,
+        "k3": 131072,
         "kimi-k2.7-code": 32768,
         "kimi-for-code": 32768,
         "kimi-for-coding": 32768,
@@ -1339,7 +1340,8 @@
         "k2.6": true,
         "k2.6-code-preview": true,
         "kimi-k2.7-code": true,
-        "k3[1m]": true
+        "k3[1m]": true,
+        "k3-256k": true
       },
       "input_modalities": {
         "kimi-k3": [
@@ -1393,6 +1395,10 @@
           "video"
         ],
         "k3[1m]": [
+          "text",
+          "image"
+        ],
+        "k3-256k": [
           "text",
           "image"
         ]

--- a/docs/reference/MODEL_CAPABILITY_SOURCES.md
+++ b/docs/reference/MODEL_CAPABILITY_SOURCES.md
@@ -71,6 +71,10 @@ python3 scripts/openrouter_recent_models.py --missing   # 只看 profile 里还�
 
 **Kimi Code 的 k3 原生支持 1M。** `k3` 是新的默认入口；`k3[1m]` 仅为历史 MMS compatibility selector，不能直接发给 provider，也不再作为新的产品入口。OpenRouter 仍然只是 catalog evidence，不能单独证明当前 route/account 的实际能力。
 
+**k3 的 context 不要再改回 262144。** 这个值在 profile 里被来回改过三轮，每轮都漏掉一个 alias，导致同一个模型在 terminal 和 Pilot 上读出不同的窗口。`k3` / `k3[1m]` / `kimi-k3` 现在由 `tests/test_provider_profiles.py::test_kimi_k3_aliases_agree_on_one_million_context` 一起锁住。`k3-256k` 是官方另一个 256K 变体，不是被降级的 k3，它有自己的 profile 条目。
+
+**k3 的输出上限没有官方来源。** 2026-09-02 的标定记录里 `official_max_output_tokens` 是 `null`。profile 保留 131072，不要在没有来源的情况下把它抬到 context 那么大：上游会直接拒绝超限的 `max_tokens`。`tests/test_provider_profiles.py::test_profile_max_output_never_exceeds_its_context_window` 覆盖这条。
+
 **OpenAI 已经下架的模型仍在 profile 里。** `gpt-5`、`gpt-5-pro`、`gpt-5.4`、`gpt-5.4-mini` 不在官方当前列表上了,但很多中转通道还在提供。它们的值保持原样,不要因为官方页面查不到就删。
 
 **Anthropic 的 4.6 系列已是 legacy。** 当前是 Opus 5 / Sonnet 5 / Fable 5.1 / Haiku 4.5。旧模型页仍在,规格照样能查。

--- a/tests/test_codex_reasoning_effort_launch.py
+++ b/tests/test_codex_reasoning_effort_launch.py
@@ -23,7 +23,8 @@ def test_runtime_reasoning_helpers_normalize_values():
     assert mms_launchers._claude_code_effort_env_value("gpt-5.4", {"reasoning_effort": "xhigh"}) == ""
 
 
-def test_claude_kimi_k3_context_env_uses_selector_window(monkeypatch):
+def test_claude_kimi_k3_context_env_follows_user_policy(monkeypatch):
+    """K3 has no MMS-specific ``[1m]`` selector: user policy wins for every alias."""
     import mms_launchers
 
     monkeypatch.setattr(
@@ -40,10 +41,11 @@ def test_claude_kimi_k3_context_env_uses_selector_window(monkeypatch):
     monkeypatch.setattr(mms_launchers, "_capability_context_window", fake_capability_context_window)
 
     assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 1_000_000
-    assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_048_576
+    assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_000_000
 
 
-def test_claude_kimi_k3_without_policy_keeps_default_tier_window(monkeypatch):
+def test_claude_kimi_k3_without_policy_uses_profile_one_million_window(monkeypatch):
+    """Without a policy the provider profile decides, and it records K3 as native 1M."""
     import mms_launchers
 
     monkeypatch.setattr(
@@ -53,7 +55,8 @@ def test_claude_kimi_k3_without_policy_keeps_default_tier_window(monkeypatch):
     )
     monkeypatch.setattr(mms_launchers, "_capability_context_window", lambda *_a, **_k: None)
 
-    assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 262_144
+    assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 1_048_576
+    assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_048_576
 
 
 def test_get_export_env_for_claude_kimi_k3_sets_effort_and_context(monkeypatch):

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -1201,7 +1201,7 @@ def test_pi_kimi_k3_exports_1m_context_and_openai_protocol(monkeypatch, tmp_path
     assert model_by_id["k3[1m]"]["maxTokens"] == 1_048_576
     assert model_by_id["k3[1m]"]["reasoning"] is True
     assert model_by_id["k3"]["input"] == ["text", "image"]
-    assert model_by_id["k3"]["contextWindow"] == 262_144
+    assert model_by_id["k3"]["contextWindow"] == 1_048_576
     assert model_by_id["k3"]["maxTokens"] == 131_072
     assert model_by_id["k3"]["reasoning"] is True
     assert model_by_id["kimi-for-coding-highspeed"]["contextWindow"] == 262_144

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -319,7 +319,7 @@ def test_kimi_k3_profile_uses_reasoning_effort_without_k2_thinking_patch(monkeyp
         "k3",
         provider_id="kimi",
         base_url="https://api.kimi.com/coding/",
-    ) == 262_144
+    ) == 1_048_576
     assert profiles.profile_context_window(
         "k3[1m]",
         provider_id="kimi",
@@ -724,3 +724,56 @@ def test_legacy_root_without_latest_bundle_ignores_legacy_profile_overlay(monkey
 
     assert mms_provider_profiles.resolve_provider_profile(provider_id="stable-overlay-provider")[0] == ""
     assert mms_provider_profiles.profile_context_window("any-model", provider_id="stable-overlay-provider") is None
+
+
+def test_kimi_k3_aliases_agree_on_one_million_context(monkeypatch, tmp_path):
+    """Every K3 alias must report the same window.
+
+    K3 shipped 1M natively, but the value has been changed back and forth in the
+    profile three times, each round leaving one alias behind. Pin the whole
+    family so a partial edit fails here instead of downgrading a live channel.
+    """
+    profiles = _profiles(monkeypatch, tmp_path)
+
+    for alias in ("k3", "k3[1m]", "kimi-k3"):
+        assert profiles.profile_context_window(
+            alias,
+            provider_id="kimi",
+            base_url="https://api.kimi.com/coding/",
+        ) == 1_048_576, alias
+
+    # The 256K variant is a separate official model, not a downgraded K3.
+    assert profiles.profile_context_window(
+        "k3-256k",
+        provider_id="kimi",
+        base_url="https://api.kimi.com/coding/",
+    ) == 262_144
+
+
+def test_profile_max_output_never_exceeds_its_context_window():
+    """A max-output larger than the context window is always a data error.
+
+    ``k3`` was raised to a 1M max output with no source behind it; that shape of
+    mistake produces requests the upstream rejects, so catch it in the data.
+    """
+    import json
+    from pathlib import Path
+
+    profiles = json.loads(
+        (Path(__file__).resolve().parent.parent / "config" / "provider-profiles.json").read_text(
+            encoding="utf-8"
+        )
+    )["profiles"]
+
+    offenders = []
+    for profile_id, profile in profiles.items():
+        windows = profile.get("context_windows") or {}
+        outputs = profile.get("max_output_tokens") or {}
+        for model, max_output in outputs.items():
+            window = windows.get(model)
+            if window is None:
+                continue
+            if int(max_output) > int(window):
+                offenders.append(f"{profile_id}:{model} output={max_output} > context={window}")
+
+    assert not offenders, "max_output_tokens exceeds context_window: " + "; ".join(offenders)


### PR DESCRIPTION
## 为什么

k3 的 context window 两天内在 `config/provider-profiles.json` 里被改了三次，两个 agent 各改一半：

| commit | 作者 | 做了什么 |
|---|---|---|
| `2c56ca89` | pi / glm-5.3 | profile 改成 1048576，同步三个测试 |
| `18f74b3c` | Codex / gpt-5 | profile 和测试**全部改回** 262144 |
| `839f8f2c` (#204) | Codex / gpt-5 | profile 再改成 1048576，测试没动 |

所以 dev 现在的 profile 说 1M、测试说 256K，四个测试是红的：

- `tests/test_provider_profiles.py::test_kimi_k3_profile_uses_reasoning_effort_without_k2_thinking_patch`
- `tests/test_pi_launcher.py::test_pi_kimi_k3_exports_1m_context_and_openai_protocol`
- `tests/test_codex_reasoning_effort_launch.py::test_claude_kimi_k3_context_env_uses_selector_window`
- `tests/test_codex_reasoning_effort_launch.py::test_claude_kimi_k3_without_policy_keeps_default_tier_window`

CI 没有发现，因为 CI 不跑测试。那个洞单独提在 `claude/ci-pytest-gate`。

## 改了什么

**取 1M，并让整个 k3 家族一致。** 2026-09-02 的官方标定 (`2026-09-02-kimi-k3-official.json`) 记录 `official_context_window_tokens = 1048576`。`k3` / `k3[1m]` / `kimi-k3` 现在都解析到 1048576，由新测试 `test_kimi_k3_aliases_agree_on_one_million_context` 一起锁住，避免下一轮又漏掉一个 alias。

**恢复 #204 删掉的 `k3-256k`。** 它是 Moonshot 自己的 256K 变体（标定文件原话：`1M context is gated to Allegretto+ membership; k3-256k is the 256K variant`），不是被降级的 k3。profile 条目被删后它会掉到 200K 默认值。

**把 k3 的 `max_output_tokens` 从 1048576 改回 131072。** #204 抬高了这个值，但没有来源：标定文件里 `official_max_output_tokens` 是 `null`，仓库里原有的两处测试契约都写 131072。输出上限报大不会被上游截断，而是直接拒绝请求。新增 `test_profile_max_output_never_exceeds_its_context_window` 覆盖这类数据错误。

**更新四个仍然编码旧 selector 契约的测试。** `[1m]` 的 safe-base 表已经不含 k3（#204 清掉了，这是对的），所以 plain `k3` 现在先看用户 policy、再看 provider profile，每个 alias 都一样。两个测试相应改名。

## 验证

跑过：`tests/test_provider_profiles.py`、`tests/test_pi_launcher.py`、`tests/test_config_web.py`、`tests/test_codex_reasoning_effort_launch.py`、`tests/test_capability_resolver.py`。四个红测试转绿，没有新增失败。

实际探针确认 k3 在各 harness 上的解析值：

| harness | 读到的 k3 context |
|---|---|
| Claude Code (`CLAUDE_CODE_MAX_CONTEXT_TOKENS`) | 1048576 |
| Pi (`models.json` 导出) | 1048576，maxTokens 131072 |
| Pilot / 配置页 capability payload | 1048576 |
| OpenCode | 走同一个 `_lookup_context_window` |

fresh-user gate：改动前 16 failed / 629 passed，改动后 15 failed / 630 passed，减少的正是 k3 那条，没有新增。

## 还没解决的一件事

**Codex 根本没有从 MMS 拿到任何 context window。** `_codex_gateway_env` 生成的 `config.toml` 不写 `model_context_window`，所以 Codex 用的是它自己对未知 custom 模型的默认值 —— 这不是 k3 特有的，是所有模型都这样。要让 k3 在 Codex 里也是 1M 需要单独改 launcher，属于 protected surface，另开 PR。

另外 `kimi-k3` 这个 alias 的 `max_output_tokens` 是 1048576（自 #90 起就是），和 `k3` 的 131072 不一致。两个值都没有官方来源，我没有顺手统一，留给 owner 定。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi