### PR TITLE
test(pilot): lock model fetch to replace the route, not merge into it

### DIFF
--- a/tests/test_mms_web_model_settings.py
+++ b/tests/test_mms_web_model_settings.py
@@ -436,3 +436,70 @@ def test_delete_last_channel_is_refused(settings):
             "fingerprint": snap["fingerprint"], "revision": snap["revision"],
             "providerId": "channel-a", "removeProviderId": "channel-a",
         })
+
+
+def test_fetching_models_replaces_the_route_instead_of_merging(settings, tmp_path):
+    """A model deleted upstream has to leave this machine, not just lose a tick.
+
+    Fetching used to union the remote list into the local one, so a model the
+    channel had dropped stayed selectable in the terminal forever. The remote
+    list is authoritative: saving it must remove what it no longer contains,
+    from the published routes and from a freshly launched session alike.
+    """
+    from mms_web.server import WebApplication
+
+    snapshot = settings.read()
+    seeded = settings.preview({
+        "fingerprint": snapshot["fingerprint"],
+        "revision": snapshot["revision"],
+        "providerId": "channel-a",
+        "models": ["gpt-5", "gpt-4.1", "retired-model"],
+        "efforts": {},
+    })
+    settings.apply({"previewId": seeded["previewId"], "confirmPhrase": "写入预览DB"})
+    snapshot = settings.read()
+    channel = next(p for p in snapshot["providers"] if p["id"] == "channel-a")
+    assert "retired-model" in {m["id"] for m in channel["models"] if m["visible"]}
+
+    # The upstream fixture never serves retired-model, so this is the real shape
+    # of "the channel deleted a model".
+    found = settings.discover({
+        "fingerprint": snapshot["fingerprint"],
+        "revision": snapshot["revision"],
+        "providerId": "channel-a",
+        "models": ["gpt-5"],
+    })
+    assert "retired-model" not in found["models"]
+
+    preview = settings.preview({
+        "fingerprint": snapshot["fingerprint"],
+        "revision": snapshot["revision"],
+        "providerId": "channel-a",
+        "models": sorted(found["models"]),
+        "efforts": {},
+    })
+    assert {"kind": "remove", "model": "retired-model"} in preview["changes"]
+    settings.apply({"previewId": preview["previewId"], "confirmPhrase": "写入预览DB"})
+
+    channel = next(p for p in settings.read()["providers"] if p["id"] == "channel-a")
+    # Not merely hidden: gone from the rows the page and the terminal read.
+    assert {m["id"] for m in channel["models"]} == set(found["models"])
+
+    published = json.loads((settings.root / "generated" / "model-routes.json").read_text(encoding="utf-8"))
+    assert "retired-model" not in json.dumps(published)
+    assert "retired-model" not in (settings.root / "config.toml").read_text(encoding="utf-8")
+
+    app = WebApplication(state_root=tmp_path / "web-overwrite", config_root=settings.root)
+    project = tmp_path / "project-overwrite"
+    project.mkdir()
+    try:
+        workspace = app.catalog.add_workspace({"path": str(project)})
+        with pytest.raises(WebError):
+            app.post(["launch-options"], {"presetId": "web:pi:channel-a:retired-model",
+                                          "workspaceId": workspace["id"]})
+        # The models that survived the fetch still launch.
+        options = app.post(["launch-options"], {"presetId": "web:pi:channel-a:gpt-5",
+                                                "workspaceId": workspace["id"]})
+        assert options["model"]["id"] == "gpt-5"
+    finally:
+        app.close()


### PR DESCRIPTION
## 背景

你反馈的是：「拉取模型后所有模型列表应该是覆盖而不是更新。比如某些模型我们的通道内已经删除了，拉取模型我们本地应该也删除才对。」

我先验证了 dev 上的实际行为，**这条已经修好了**，是 #204 改的 `apps/mms-web/src/ChannelModels.tsx`：拉取后 `setChosen(result.models)` 直接用远端列表替换勾选，保存时 `mms_web/model_settings_worker.py` 把 `target["models"]` 设为所选列表、清空 `extra_models` / `fallback_models`，被删的模型进 `hidden_models` 且不再进入路由。

我用真实路径探了一遍（种一个上游不提供的模型 → 拉取 → 保存）：

```
after seed, visible: ['gpt-4.1', 'gpt-5', 'retired-model']
discovered:          ['gpt-4.1', 'gpt-5', 'local-extra-model']
changes:             [{'kind': 'add', ...}, {'kind': 'remove', 'model': 'retired-model'}]
after fetch, rows:   ['gpt-4.1', 'gpt-5', 'local-extra-model']
model-routes.json has retired-model: False
config.toml has retired-model:        False
```

## 所以这个 PR 只加测试

这个值已经被三次改动反复推翻过，行为对但没有任何东西守着它。新测试走用户真实路径：种一个上游已删除的模型 → 拉取 → 保存拉取结果 → 断言它从已发布路由、`config.toml` 和**新启动的会话**里全部消失，同时活下来的模型仍然能启动。

测试在 dev 上直接通过。它存在的意义是让下一次改保存路径的人没法悄悄把 merge 改回来。

`tests/test_mms_web_model_settings.py` 全量 32 passed。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi