### PR TITLE
feat(config-web): step the configuration WebUI down to a maintenance entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - **一个入口启动多个 CLI**：`mms` 进入 TUI，或直接 `mms claude` / `mms codex` / `mms opencode`。
 - **一个地方管理模型来源**：provider、account、route、fallback、thinking、vision、cache-sensitive transport 都在启动前可见。
 - **隔离但可恢复**：Claude/Codex session 使用 MMS 管理的 HOME / config seed，减少污染真实全局配置，同时保留 resume。
-- **Web UI 配配置**：不想手写 TOML 时，用 `mmf config web` 添加通道、拉模型、隐藏噪音模型、预览保存计划。
+- **Web UI 配置**：加通道、拉模型、改能力开关都在 `mms web`（Pilot）里做，和终端写同一个配置根。`mmf config web` 已降级为维护入口。
 - **按 session 注入能力包**：CodeGraph、TOON、grill-me、Web automation bundle 等能力默认是 session-local，不改你的全局 hook；已移除 Caveman 与 token-saver 的内建安装。
 - **诊断优先**：在怀疑模型之前，先看 route、协议、cache、API Key、请求路径和 runtime exposure。
 
@@ -32,8 +32,11 @@ Pilot 和 `mmf config web` 是两个不同的页面，不要混：
 
 | | 打开方式 | 用来做什么 |
 |---|---|---|
-| MMS Pilot | `mms web --open` | 日常干活：开会话、选模型和通道、管工作文件夹、看执行过程和产出 |
-| 配置 Web UI | `mmf config web` | 配置：加通道、拉模型列表、隐藏噪音模型、生成保存预览并发布 |
+| MMS Pilot | `mms web --open` | 日常干活，以及全部日常配置：开会话、加通道、拉模型列表、改能力开关、管工作文件夹 |
+| 配置 Web UI（已降级） | `mmf config web` | 只剩 Pilot 尚未覆盖的部分：账号、偏好、Skill / MCP、迁移与人工确认动作 |
+
+Pilot 保存通道和模型后，终端读到的是同一份配置，不需要再去配置 Web UI 确认一遍。
+配置 Web UI 启动时会打印这条降级提示；它仍然可用，但不再是配置 MMS 的推荐方式。
 
 Pilot 当前的 harness 是 Pi。Claude、Codex、OpenCode、agy 仍从 MMS CLI 启动，尚未接入 Pilot 的统一会话。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 - **一个入口启动多个 CLI**：`mms` 进入 TUI，或直接 `mms claude` / `mms codex` / `mms opencode`。
 - **一个地方管理模型来源**：provider、account、route、fallback、thinking、vision、cache-sensitive transport 都在启动前可见。
 - **隔离但可恢复**：Claude/Codex session 使用 MMS 管理的 HOME / config seed，减少污染真实全局配置，同时保留 resume。
-- **Web UI 配配置**：不想手写 TOML 时，用 `mmf config web` 添加通道、拉模型、隐藏噪音模型、预览保存计划。
+- **Web UI 配置**：加通道、拉模型、改能力开关都在 `mms web`（Pilot）里做，和终端写同一个配置根。`mmf config web` 已降级为维护入口。
 - **按 session 注入能力包**：CodeGraph、TOON、grill-me、Web automation bundle 等能力默认是 session-local，不改你的全局 hook；已移除 Caveman 与 token-saver 的内建安装。
 - **诊断优先**：在怀疑模型之前，先看 route、协议、cache、API Key、请求路径和 runtime exposure。
 
@@ -32,8 +32,11 @@ Pilot 和 `mmf config web` 是两个不同的页面，不要混：
 
 | | 打开方式 | 用来做什么 |
 |---|---|---|
-| MMS Pilot | `mms web --open` | 日常干活：开会话、选模型和通道、管工作文件夹、看执行过程和产出 |
-| 配置 Web UI | `mmf config web` | 配置：加通道、拉模型列表、隐藏噪音模型、生成保存预览并发布 |
+| MMS Pilot | `mms web --open` | 日常干活，以及全部日常配置：开会话、加通道、拉模型列表、改能力开关、管工作文件夹 |
+| 配置 Web UI（已降级） | `mmf config web` | 只剩 Pilot 尚未覆盖的部分：账号、偏好、Skill / MCP、迁移与人工确认动作 |
+
+Pilot 保存通道和模型后，终端读到的是同一份配置，不需要再去配置 Web UI 确认一遍。
+配置 Web UI 启动时会打印这条降级提示；它仍然可用，但不再是配置 MMS 的推荐方式。
 
 Pilot 当前的 harness 是 Pi。Claude、Codex、OpenCode、agy 仍从 MMS CLI 启动，尚未接入 Pilot 的统一会话。
 

--- a/docs/WEB_UI_QUICKSTART.md
+++ b/docs/WEB_UI_QUICKSTART.md
@@ -1,10 +1,13 @@
 # MMS Web UI Quickstart
 
-Web UI 是 MMS 当前最适合做教程的配置入口。它比 TUI 更适合截图、录屏和逐步解释，也更适合用 Playwright 做回归截图。
+> **这个页面已降级。** 日常配置请用 `mms web`（Pilot）：加通道、拉模型列表、改能力开关都在那里，
+> 和终端写同一个配置根。本文保留给 Pilot 尚未覆盖的部分，以及需要看旧配置页的场景。
+
+Web UI 比 TUI 更适合截图、录屏和逐步解释，也更适合用 Playwright 做回归截图。
 
 ## 启动
 
-Preview root 推荐用 `mmf`。如果保存页显示的是 `保存配置`，说明你打开的是 `mms config web` stable root；要写 `预览 DB + latest-approved bundle` 必须用 `mmf`：
+只有一个配置根 `~/.config/mms-next`，`mms` 和 `mmf` 都落在它上面，保存一律走 `写入预览 DB + 发布`：
 
 ```bash
 mmf config web

--- a/mms_config_web.py
+++ b/mms_config_web.py
@@ -5568,7 +5568,7 @@ def _preferences_target_path(*, config_path: str = "", preferences_path: str = "
     paths = getattr(mms_core, "PREFERENCES_PATHS", None)
     if isinstance(paths, list) and paths:
         return os.path.abspath(os.path.expanduser(str(paths[0])))
-    return os.path.abspath(os.path.expanduser("~/.config/mms/preferences.toml"))
+    return os.path.abspath(os.path.expanduser("~/.config/mms-next/preferences.toml"))
 
 
 def _preferences_lock_path(*, config_path: str = "", preferences_path: str = "") -> str:

--- a/mms_config_web_server.py
+++ b/mms_config_web_server.py
@@ -12,6 +12,7 @@ import copy
 import errno
 import json
 import signal
+import sys
 import threading
 import traceback
 import webbrowser
@@ -601,6 +602,21 @@ def serve_config_web(app_or_snapshot: ConfigWebApp | dict[str, Any], *, host: st
     return url
 
 
+def deprecation_notice(command_name: str = "mms") -> str:
+    """Tell the user this page is no longer the way to configure MMS.
+
+    Pilot writes the same config root, so channels, models and capabilities
+    edited there reach the terminal directly. This page stays for what Pilot
+    does not cover yet, and for reading a machine's setup.
+    """
+    command = str(command_name or "mms").strip() or "mms"
+    return "\n".join((
+        f"提示：{command} config web 已降级为维护入口，不再是配置 MMS 的推荐方式。",
+        f"  配置通道、拉取模型、改能力开关请用 {command} web（Pilot）；它和终端写同一个配置根，改完即时生效。",
+        "  这个页面保留给 Pilot 尚未覆盖的部分：账号、偏好、Skill / MCP、迁移，以及需要人工确认的动作。",
+    ))
+
+
 def run_config_web(
     cfg: dict[str, Any] | None,
     argv: list[str] | None = None,
@@ -616,6 +632,8 @@ def run_config_web(
     parser.add_argument("--print-summary", action="store_true", help="Print redacted setup JSON and exit")
     parser.add_argument("--print-markdown", action="store_true", help="Print setup markdown and exit")
     args = parser.parse_args(argv or [])
+    # stderr, so a piped --print-summary stays valid JSON.
+    print(deprecation_notice(command_name), file=sys.stderr)
     app = ConfigWebApp(cfg, config_path=config_path, preferences_path=preferences_path, command_name=command_name)
     if args.print_summary:
         snapshot = app.snapshot()

--- a/mms_config_web_settings.py
+++ b/mms_config_web_settings.py
@@ -771,8 +771,8 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
     webui = f"{command} config web"
     interactive = command
     account_writes = [
-        "~/.config/mms/config.toml accounts/account.defaults",
-        "~/.config/mms/accounts/** OAuth/account state",
+        "<MMS_CONFIG_ROOT>/config.toml accounts/account.defaults",
+        "<MMS_CONFIG_ROOT>/accounts/** OAuth/account state",
         "可能涉及外部浏览器或 CLI login side effects",
     ]
     registry_writes = [
@@ -826,7 +826,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "确认 backup、目标 root、secret 处理和 human-only config 边界。",
                 "只有人工确认后才运行实际迁移命令。",
             ],
-            "writes": ["~/.config/mms/** stable config tree", "<MMS_CONFIG_ROOT>/registry/** preview DB/root artifacts", "config backups / audit logs"],
+            "writes": ["<MMS_CONFIG_ROOT>/registry/** preview DB/root artifacts", "config backups / audit logs"],
             "safe_alternative": "在 WebUI 保存页生成 preview plan，不直接迁移 stable。",
         },
         "family_autosort_gate": {
@@ -862,7 +862,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "Claude account/remove 必须停在 human-only gate。",
                 "手动 remove 后回 WebUI accounts report 和保存预览核对。",
             ],
-            "writes": ["~/.config/mms/config.toml accounts/account.defaults", "~/.config/mms/accounts/<account-id>/**"],
+            "writes": ["<MMS_CONFIG_ROOT>/config.toml accounts/account.defaults", "<MMS_CONFIG_ROOT>/accounts/<account-id>/**"],
             "safe_alternative": "先在 WebUI 将非 Claude account disabled/default 草稿调整并 review。",
         },
         "account_rename_gate": {
@@ -874,7 +874,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "该动作可能移动 account home 目录并重写 usage/defaults；必须人工确认备份和目标目录不存在。",
                 "完成后回 WebUI accounts report，核对 id/default/usage 是否一致。",
             ],
-            "writes": ["~/.config/mms/config.toml accounts/account.defaults", "~/.config/mms/accounts/<old-id>/** -> <new-id>/**", "~/.config/mms/usage.json account usage keys"],
+            "writes": ["<MMS_CONFIG_ROOT>/config.toml accounts/account.defaults", "<MMS_CONFIG_ROOT>/accounts/<old-id>/** -> <new-id>/**", "<MMS_CONFIG_ROOT>/usage.json account usage keys"],
             "safe_alternative": "WebUI 已支持非 Claude account 显示名、启用状态、priority、family、timezone、note 的草稿/保存预览。",
         },
         "account_network_gate": {
@@ -886,7 +886,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "Claude account config 是 human-only；任何 Claude proxy/home_dir/no_proxy 变化都必须停止并人工确认。",
                 "非 Claude 账号如需改 proxy/no_proxy，请在终端人工运行 account.edit 并随后回 WebUI 做只读核对。",
             ],
-            "writes": ["~/.config/mms/config.toml accounts[*].proxy/no_proxy/home_dir/timezone", "~/.config/mms/accounts/** account state can be affected by launch/login"],
+            "writes": ["<MMS_CONFIG_ROOT>/config.toml accounts[*].proxy/no_proxy/home_dir/timezone", "<MMS_CONFIG_ROOT>/accounts/** account state can be affected by launch/login"],
             "safe_alternative": "WebUI 只显示 proxy/no_proxy 是否已配置；非敏感 timezone/note 可在账号表中走保存预览。",
         },
         "provider_network_gate": {
@@ -898,7 +898,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "修改前先确认目标 provider、expected proxy、no_proxy 不会命中 Claude/OpenAI 域名造成直连泄漏。",
                 "人工执行 provider.edit 后回到 WebUI 生成保存预览或 provider_usage_summary 核对非敏感字段。",
             ],
-            "writes": ["~/.config/mms/config.toml providers[*].proxy/no_proxy", "provider network policy for future launches"],
+            "writes": ["<MMS_CONFIG_ROOT>/config.toml providers[*].proxy/no_proxy", "provider network policy for future launches"],
             "safe_alternative": "WebUI 支持通道 URL/API Key/protocol/CLI/timezone/note/Claude 1M 的草稿/保存预览；只把 proxy/no_proxy 留给人工确认。",
         },
         "refresh_due_sources_gate": {
@@ -994,7 +994,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "确认写入 repo-local .mms/rescue demo artifacts。",
                 "完成后在 WebUI 点击 rescue_events 查看 artifact path。",
             ],
-            "writes": ["<repo>/.mms/rescue/**", "~/.config/mms/rescue/index.jsonl metadata"],
+            "writes": ["<repo>/.mms/rescue/**", "<MMS_CONFIG_ROOT>/rescue/index.jsonl metadata"],
             "safe_alternative": "WebUI 只读 rescue_events；不生成 demo artifact。",
         },
         "rescue_handover_gate": {
@@ -1018,7 +1018,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "该动作可能访问 GitHub/npm 并更新本地 version cache。",
                 "WebUI about report 默认只读 cached 状态，不自动联网刷新。",
             ],
-            "writes": ["~/.config/mms/version.json update cache"],
+            "writes": ["<MMS_CONFIG_ROOT>/version.json update cache"],
             "safe_alternative": "WebUI 点击关于状态读取缓存版本状态。",
         },
         "about_upgrade_gate": {
@@ -1041,7 +1041,7 @@ def _settings_gate_catalog(command_name: str = "mms") -> dict[str, dict[str, Any
                 "WebUI 当前已提供 typed confirm 草稿删除；优先使用 WebUI 保存预览。",
                 "CLI remove 属于 legacy mutating path，执行前先确认 provider 不再被默认/route/fallback 使用。",
             ],
-            "writes": ["~/.config/mms/config.toml providers/provider.default", "credentials/model-policy related entries"],
+            "writes": ["<MMS_CONFIG_ROOT>/config.toml providers/provider.default", "credentials/model-policy related entries"],
             "safe_alternative": "WebUI typed confirm -> 生成保存预览 -> confirm save。",
         },
     }

--- a/tests/test_config_web.py
+++ b/tests/test_config_web.py
@@ -5218,3 +5218,45 @@ def test_config_web_shutdown_survives_repeat_sigint(monkeypatch):
         signal.signal(signal.SIGINT, original_handler)
 
     assert url.startswith("http://127.0.0.1:")
+
+
+def test_config_web_announces_that_pilot_replaced_it(capsys):
+    """The page still runs, but it must stop presenting itself as the way in.
+
+    Pilot writes the same config root, so channels and models edited there are
+    already what the terminal launches with. Users kept configuring here and
+    then wondering which of the two pages was real.
+    """
+    rc = mms_config_web.run_config_web(
+        {"providers": []},
+        ["--print-summary"],
+        command_name="mmf",
+        config_path="/tmp/config.toml",
+        preferences_path="/tmp/preferences.toml",
+    )
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    # The notice goes to stderr so a piped --print-summary stays valid JSON.
+    assert json.loads(captured.out)["schema"] == "mms.setup_web.snapshot.v2"
+    assert "mmf config web 已降级" in captured.err
+    assert "mmf web" in captured.err
+
+
+def test_config_web_gate_cards_do_not_name_the_retired_config_root():
+    """A gate card tells the user which files an action writes.
+
+    Config moved to ~/.config/mms-next; these cards still named ~/.config/mms,
+    so the human gate was disclosing a path nothing writes any more.
+    """
+    import mms_config_web_settings
+
+    catalog = mms_config_web_settings._settings_gate_catalog("mms")
+    offenders = [
+        f"{gate_id}: {target}"
+        for gate_id, gate in catalog.items()
+        for target in gate.get("writes", [])
+        if "~/.config/mms/" in target
+    ]
+
+    assert not offenders, "gate cards name the retired config root: " + "; ".join(offenders)


### PR DESCRIPTION
## 背景

你问的是：「我们这次双向绑定改好后，其实我 `mms config web` 的功能应该就降级下线了对吧？」

对。Pilot 和终端现在写同一个配置根，Pilot 里保存的通道就是 `mms claude` 启动时用的那份。旧的配置 Web UI 是第二个编辑同一份数据的页面，用户在一个里改、去另一个里核对，分不清哪个是真的。

## 降级，不删除

它仍然覆盖 Pilot 还没做的部分：账号、偏好、Skill / MCP、迁移，以及需要人工确认的动作。所以保留可用，只是不再作为配置入口：

- `mms config web` 启动时打印降级提示，指向 `mms web`，并说明它还剩什么用途。提示走 **stderr**，所以 `--print-summary` 管道出来仍然是合法 JSON。
- README（中英两份）和 `docs/WEB_UI_QUICKSTART.md` 同步改口径。

如果你想要的是彻底下线（命令直接拒绝启动，或者从入口表里删掉），告诉我，我再提一个。

## 顺带修了两处 user-facing 的过期路径

这两处都是 single config root 迁移的遗留，都会直接展示给用户：

**human gate 卡片写错了要写入的文件。** 这些卡片的作用就是告诉用户「这个动作会写哪些文件」，然后请用户确认。它们仍然写着 `~/.config/mms/config.toml`、`usage.json`、`version.json`、`rescue/index.jsonl`、`accounts/**`。配置早就在 `~/.config/mms-next`，所以 gate 在请用户批准一个根本不会被写的路径。我核对了每一个的真实位置（`mms_core.PRIMARY_CONFIG_DIR` / `mms_rescue.resolve_real_mms_config_dir`）后改成 `<MMS_CONFIG_ROOT>/...`，和旁边的 registry 条目一致，并加测试禁止任何卡片再写退休的根。

`migrate_config_gate` 还承诺会写一棵已经退休的 "stable config tree"，一并删掉。

**preferences 的兜底路径指向 legacy root。** `_preferences_target_path` 最后一档返回 `~/.config/mms/preferences.toml`。只有在调用方和 `mms_core` 都拿不到路径时才会走到，但兜底兜错根本身就是个雷。

## 验证

`tests/test_config_web.py` 121 passed，两条新测试通过。剩下的 `test_config_web_mmf_official_overrides_use_provider_profiles` 是 k3 那条既有失败，由 #209 修。

`tests/test_registry_contract_docs.py` 的两条失败在 dev 上就是红的（它们找的是已经不存在的英文 README 章节），和本 PR 无关。

## 一个需要你定的事

`docs/AGENT_GUARDRAILS.md` 的 Single Config Root 一节说 `~/.config/mms/accounts/` 仍然是运行时目录。代码不是这样：`mms_core.ACCOUNTS_DIR` 解析到 `~/.config/mms-next/accounts`，`_codex_gateway_root()` 也在 mms-next 下。文档这句已经和实现不符，我没有改 guardrails，等你确认口径。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi