### PR TITLE
fix(codex): tell Codex the context window of a 1M model it cannot know

### DIFF
--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -10947,6 +10947,40 @@ def _codex_gateway_root():
     return os.path.join(_selected_mms_config_root({}), "codex-gateway")
 
 
+_CODEX_CONTEXT_WINDOW_FLOOR = 1_000_000
+
+
+def _codex_gateway_context_window(runtime, model_info):
+    """Return a context window worth telling Codex about, or None.
+
+    Codex ships a catalog for the models it knows and falls back to its own
+    default for anything routed through a custom provider, so a 1M model
+    behaves like a small one and compacts far too early. ``model_context_window``
+    in the gateway config.toml is how Codex takes our number instead.
+
+    Only widen, and only for models Codex cannot already know. Its catalog
+    carries OpenAI's own models with an effective window below their maximum,
+    so overriding those would push requests past a limit Codex was respecting
+    on purpose. A window we overstate becomes a rejected request, not an early
+    compaction.
+    """
+    model = str((model_info or {}).get("model") or "").strip()
+    if not model:
+        return None
+    normalized = model.lower()
+    if normalized.startswith(("gpt-", "o1", "o3", "o4")) or "codex" in normalized:
+        return None
+    try:
+        window = _coerce_context_window(
+            _lookup_context_window(model, provider_id=(runtime or {}).get("id"))
+        )
+    except Exception:
+        return None
+    if window is None or window < _CODEX_CONTEXT_WINDOW_FLOOR:
+        return None
+    return window
+
+
 def _codex_gateway_env(runtime, base_url, model_info=None):
     """为 gateway api_key 模式创建隔离 session，并复用稳定 CODEX_HOME。"""
     import json as _json
@@ -11051,6 +11085,15 @@ def _codex_gateway_env(runtime, base_url, model_info=None):
             if preamble and not preamble.endswith("\n"):
                 preamble += "\n"
             preamble += f"{replacement}\n"
+        return preamble + rest
+
+    def _remove_top_level_scalar(text, key):
+        import re
+        section_match = re.search(r'^\[', text, flags=re.MULTILINE)
+        preamble_end = section_match.start() if section_match else len(text)
+        preamble = text[:preamble_end]
+        rest = text[preamble_end:]
+        preamble = re.sub(rf'^{re.escape(key)}\s*=\s*.+$\n?', '', preamble, flags=re.MULTILINE)
         return preamble + rest
 
     def _set_project_base_url(text, project_path, value):
@@ -11177,6 +11220,7 @@ def _codex_gateway_env(runtime, base_url, model_info=None):
     # may contain stale custom sections from previous buggy generations.
     source_config = real_config if os.path.exists(real_config) else gateway_config_template
     gateway_config = os.path.join(codex_dir, "config.toml")
+    codex_context_window = _codex_gateway_context_window(runtime, model_info)
     if os.path.exists(source_config):
         try:
             with open(source_config, "r", encoding="utf-8") as f:
@@ -11184,6 +11228,12 @@ def _codex_gateway_env(runtime, base_url, model_info=None):
             config_text = _set_top_level_scalar(config_text, "forced_login_method", "api")
             config_text = _set_top_level_scalar(config_text, "disable_response_storage", True)
             config_text = _set_top_level_scalar(config_text, "base_url", base_url)
+            if codex_context_window:
+                config_text = _set_top_level_scalar(config_text, "model_context_window", codex_context_window)
+            else:
+                # A previous session may have written a window for a different
+                # model; this config is reused, so stale must mean removed.
+                config_text = _remove_top_level_scalar(config_text, "model_context_window")
             config_text = _set_project_base_url(config_text, _safe_getcwd(), base_url)
             config_text = _set_project_scalar(config_text, _safe_getcwd(), "trust_level", "trusted")
             config_text = _rewrite_table_block(
@@ -11217,6 +11267,8 @@ def _codex_gateway_env(runtime, base_url, model_info=None):
             f.write('forced_login_method = "api"\n')
             f.write('disable_response_storage = true\n')
             f.write(f'base_url = "{base_url}"\n')
+            if codex_context_window:
+                f.write(f'model_context_window = {codex_context_window}\n')
             f.write('\n[model_providers.custom]\n')
             f.write('name = "custom"\n')
             f.write('wire_api = "responses"\n')

--- a/tests/test_codex_reasoning_effort_launch.py
+++ b/tests/test_codex_reasoning_effort_launch.py
@@ -322,3 +322,73 @@ def test_gpt_explicit_model_effort_precedes_checkout_default(monkeypatch):
     monkeypatch.setattr(mms_capability_resolver, "load_default_model_policy", lambda: {"models": {"gpt-5": {"capabilities": {"reasoning_effort": "low"}}}})
     assert mms_core._default_reasoning_effort_for_model_info({"model": "gpt-5"}) == "low"
     assert mms_core._default_reasoning_effort_for_model_info({"model": "gpt-unconfigured"}) == mms_core._default_gpt_reasoning_effort()
+
+
+def _isolated_codex_gateway(monkeypatch, tmp_path):
+    """Run the Codex gateway writer against a throwaway config root."""
+    import mms_launchers
+
+    real_home = tmp_path / "real-home"
+    config_root = real_home / ".config" / "mms-next"
+    config_root.mkdir(parents=True)
+    monkeypatch.setenv("MMS_CONFIG_ROOT", str(config_root))
+    monkeypatch.setattr(mms_launchers, "_real_user_path", lambda *parts: str(real_home.joinpath(*parts)))
+    for name in (
+        "_cleanup_stale_sessions",
+        "_link_shared_dotfiles",
+        "_sync_codex_session_claude_json",
+        "_install_session_command_wrappers",
+        "_install_session_packet_env",
+    ):
+        monkeypatch.setattr(mms_launchers, name, lambda *a, **k: None)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_network_profile", lambda env, runtime, validate_proxy=False: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_locale_profile", lambda env, runtime: env)
+    monkeypatch.setattr(mms_launchers, "_apply_runtime_ip_stack_profile", lambda env, runtime: env)
+    monkeypatch.setattr(mms_launchers, "_install_host_context_env", lambda *a, **k: {})
+    monkeypatch.setattr(mms_launchers, "_build_codex_session_hooks", lambda *a, **k: {"hooks": {}})
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.chdir(repo)
+    return mms_launchers
+
+
+def test_codex_gateway_context_window_only_widens_unknown_models():
+    import mms_launchers
+
+    kimi = {"id": "kimi"}
+    for alias in ("k3", "k3[1m]", "kimi-k3"):
+        assert mms_launchers._codex_gateway_context_window(kimi, {"model": alias}) == 1_048_576, alias
+
+    # Codex knows its own catalog, including an effective window below the
+    # model's maximum. Overriding those would push past a deliberate limit.
+    for openai_model in ("gpt-5.5", "gpt-5.3-codex", "GPT-5.4"):
+        assert mms_launchers._codex_gateway_context_window(kimi, {"model": openai_model}) is None, openai_model
+
+    # Below 1M Codex's own default stands; we only ever widen.
+    assert mms_launchers._codex_gateway_context_window(kimi, {"model": "kimi-for-coding"}) is None
+    assert mms_launchers._codex_gateway_context_window(kimi, {"model": ""}) is None
+    assert mms_launchers._codex_gateway_context_window(kimi, None) is None
+
+
+def test_codex_gateway_config_carries_the_one_million_window(monkeypatch, tmp_path):
+    """K3 is a 1M model, and Codex has no way to know that on its own.
+
+    Every other harness is told: Claude Code through its context env, Pi
+    through models.json. Codex was the one that received nothing, so it fell
+    back to its default for an unknown routed model and compacted early.
+    """
+    from pathlib import Path
+
+    mms_launchers = _isolated_codex_gateway(monkeypatch, tmp_path)
+    runtime = {"id": "kimi", "api_key": "sk-test", "nsr_mode": "disable"}
+
+    env = mms_launchers._codex_gateway_env(runtime, "https://relay.example.com", model_info={"model": "k3"})
+    config = Path(env["CODEX_HOME"], "config.toml").read_text(encoding="utf-8")
+    assert "model_context_window = 1048576" in config
+
+    # The gateway config is reused across sessions, so switching models must
+    # take the window back out rather than leave K3's 1M on a GPT session.
+    env = mms_launchers._codex_gateway_env(runtime, "https://relay.example.com", model_info={"model": "gpt-5.4"})
+    config = Path(env["CODEX_HOME"], "config.toml").read_text(encoding="utf-8")
+    assert "model_context_window" not in config
+    assert 'base_url = "https://relay.example.com"' in config


### PR DESCRIPTION
## 为什么

你问的第一个问题是「k3 在全局，不管是 pilot claudecode codex 还是 pi 里，到底是不是 1M 的 context 了」。#209 之后前三个是了，**Codex 不是** —— 而且原因不是 k3 特殊，是 MMS 从来没有告诉过 Codex 任何模型的 context window。

| harness | 怎么拿到 context |
|---|---|
| Claude Code | `CLAUDE_CODE_MAX_CONTEXT_TOKENS` / `AUTO_COMPACT_WINDOW` |
| Pi | `models.json` 导出的 `contextWindow` |
| OpenCode | `opencode_model_config` 的 `limit.context` |
| **Codex** | **什么都没有** |

`_codex_gateway_env` 生成的 `config.toml` 只写 `base_url`、`forced_login_method`、`model_providers.custom` 和 project trust。Codex 对走自定义 provider 的模型只能用它自己的默认值，所以 1M 模型按小模型的节奏 compact。

## 做法

`model_context_window` 是 Codex 自己 `ConfigToml` 里的真实字段（在 0.153.1 的二进制里确认过，和 `model_auto_compact_token_limit` 并列在 99 个字段中）。选中的模型解析到 ≥1M 时，把它写进 gateway config。

三条收窄，都是保守方向：

- **低于 1M 不写。** Codex 自己的数字继续生效。窗口报大换来的是请求被拒，而不是提前 compact。
- **跳过 OpenAI 自己的模型。** Codex 的 catalog 给它们的 `context_window` 低于 `max_context_window`（例如 272000 vs 1000000），那是刻意的有效上限，覆盖掉会顶穿它。
- **换模型时把 key 删掉。** gateway `config.toml` 是跨 session 复用的，不删的话一次 k3 会话留下的 1M 会变成下一次 gpt 会话的窗口。这条是写测试时发现的。

解析结果：

```
k3           -> 1048576      gpt-5.5       -> None
k3[1m]       -> 1048576      gpt-5.3-codex -> None
kimi-k3      -> 1048576      kimi-for-coding -> None
glm-5.2      -> 1000000
```

## 验证

- `tests/test_codex_reasoning_effort_launch.py` 17 passed，含两条新测试：一条覆盖解析规则，一条真正跑 `_codex_gateway_env` 并读生成的 `config.toml`（k3 写入 1048576；随后切到 gpt-5.4 时该 key 被移除）。
- 测试用 `MMS_CONFIG_ROOT` 指向 tmp，不碰真实配置根。
- `scripts/ci_pytest_regression.py --base origin/dev --target tests/test_claude_hardening_regressions.py`：base 10 failing / 192，head 10 failing / 192，没有新增失败。

**没有验证到的部分**：我能确认这个 key 在 Codex 的 config 结构里、也能确认值写进了生成的 config，但**没能观察到 Codex 实际按它行动** —— `codex doctor` 和 `codex debug prompt-input` 都不回显这个值，要证明需要拿一个 1M 模型真跑一轮。这是 protected surface 改动，按 guardrails 明确写出来。

## 边界

只动 `_codex_gateway_env` 里写 config.toml 的两条分支和一个新的纯函数。没有改模型/来源解析顺序、bridge 路由、hook trust、CODEX_HOME 契约，也没有改任何默认启动行为。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
