### PR TITLE
fix(config): finish retiring ~/.config/mms as a config location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ apps/*/progress.md
 apps/*/task_plan.md
 
 # AI tool caches & worktrees
+.pytest-gate/
 .ai/cache/
 .antigravitycli/
 .codegraph/

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ v4 各版累积下来的能力：
 
 v4.0.0 是 MMS Pilot 的首个大版本，之后 4.x 沿 Dev 继续推进。下列 3.x 轨道为此前分支发布历史，不代表 v4 已晋级各分支：Stable/Main `3.4.z`、Dev `3.5.z`、Canary `3.6.z`。`z` 是各 channel 内的 release 计数：单 commit release 就 `z+1`，复合多个已验证 commits 的 release 也只 bump 一次；未 tag 的日常小步 commit 继续用 git hash 追踪。
 
-维护者本地开发命令矩阵：`mms` 是公开安装副本；`mmf` 指 dev worktree；`mmg` 指 canary worktree。`mmd` / `mmm` 已退休。所有入口只读 `~/.config/mms-next`。普通用户不需要配置这些 worktree 命令，只需要使用安装器提供的 channel 参数。
+维护者本地开发命令矩阵：`mms` 是公开安装副本；`mmf` 指 dev worktree；`mmg` 指 canary worktree。`mmd` / `mmm` 已退休。唯一的 config root 是 `~/.config/mms-next`，`mms` / `mmf` / `mmg` 和 Pilot 网页都落在它上面；legacy `~/.config/mms` 不再被任何入口读取。普通用户不需要配置这些 worktree 命令，只需要使用安装器提供的 channel 参数。
 
 ## 维护者开发入口
 
@@ -167,6 +167,14 @@ mmg -> Canary worktree        # preview DB root，固定 ~/.config/mms-next
 当前本机用 `scripts/link_local_channel_commands.sh` 把 5 个命令写到 `~/.local/bin`。另一台家里工作机如果要和白天电脑保持一致，建议同样准备 dev/canary/stable/main worktree 后运行这个脚本；如果只是普通用户安装，仍使用公开 `mms` 安装命令。
 
 启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` 每日检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
+
+### 配置只有一个根，运行时只信一份 bundle
+
+唯一的 config root 是 `~/.config/mms-next`。`mms` / `mmf` / `mmg` 和 Pilot 网页都落在它上面；legacy `~/.config/mms` 不再被任何入口读取，只剩 `*-gateway/` 这类会话运行时目录还留在那里。
+
+本地修改优先走 Registry v2：TUI / `mms config` / WebUI 先创建 DB candidate，审阅通过后发布成 `generated/model-registry.latest-approved.json`，它引用的 generated Profile 就是 runtime boundary。终端和 Pilot 读的是同一份发布结果，所以两边看到的通道、模型和能力一致。
+
+保存一律走`写入预览 DB + 发布`，没有第二条绕开审阅的写入路径。
 
 ## 配置 Web UI 教程：从通道到模型可见性
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -149,6 +149,14 @@ mmg -> Canary worktree        # preview DB root，固定 ~/.config/mms-next
 
 启动更新提醒默认只提醒、手动确认更新：`mmg` 每次启动检查，`mmf` 每日检查，`mms` 每日只提示 public installed copy。手动运行 `mmf update` / `mmg update` 时只允许 clean worktree fast-forward；dirty 或分叉会拒绝。
 
+### 配置只有一个根，运行时只信一份 bundle
+
+唯一的 config root 是 `~/.config/mms-next`。`mms` / `mmf` / `mmg` 和 Pilot 网页都落在它上面；legacy `~/.config/mms` 不再被任何入口读取，只剩 `*-gateway/` 这类会话运行时目录还留在那里。
+
+本地修改优先走 Registry v2：TUI / `mms config` / WebUI 先创建 DB candidate，审阅通过后发布成 `generated/model-registry.latest-approved.json`，它引用的 generated Profile 就是 runtime boundary。终端和 Pilot 读的是同一份发布结果，所以两边看到的通道、模型和能力一致。
+
+保存一律走`写入预览 DB + 发布`，没有第二条绕开审阅的写入路径。
+
 ## 配置 Web UI 教程：从通道到模型可见性
 
 这一节讲的是 `mmf config web` 的配置页面，不是 MMS Pilot。配置 Web UI 是现在最适合做教程的入口，比 TUI 更容易截图和解释。注意：`mmf` / `mmg` 都是 preview DB 入口，所以预览 DB 保存跟 `~/.config/mms-next` workflow 绑定；`mms` 也落在同一个 preview DB root 上，所以保存同样走 `写入预览 DB + 发布`；legacy root 与 `mmd` / `mmm` 已退休，不再有 legacy audited save 入口。等价入口：

--- a/mms_consumer_bundle.py
+++ b/mms_consumer_bundle.py
@@ -85,7 +85,7 @@ def resolve_consumer_config_root(
         if value:
             return Path(value).expanduser()
     if allow_default_root:
-        return Path.home() / ".config" / "mms"
+        return Path.home() / ".config" / "mms-next"
     raise ConsumerBundleError("MMS_CONFIG_ROOT is required for consumer bundle resolution")
 
 

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -11710,6 +11710,7 @@ def _opencode_export_config_path(runtime, model):
         runtime,
         model,
         real_user_path=_real_user_path,
+        selected_config_root=lambda: _selected_mms_config_root({}),
     )
 
 

--- a/mms_opencode_env.py
+++ b/mms_opencode_env.py
@@ -780,17 +780,15 @@ def opencode_set_soft_home(env, session_home, *, real_user_path, set_session_hom
     return env
 
 
-def opencode_export_config_path(runtime, model, *, real_user_path):
+def opencode_export_config_path(runtime, model, *, real_user_path, selected_config_root=None):
     runtime = runtime if isinstance(runtime, dict) else {}
     provider = opencode_config_slug(runtime.get("id") or runtime.get("name"), "provider")
     model_slug = opencode_config_slug(model or runtime.get("model"), "model")
-    return real_user_path(
-        ".config",
-        "mms",
-        "opencode-gateway",
-        "exports",
-        f"{provider}-{model_slug}.json",
-    )
+    # Same root the gateway itself uses; this used to be pinned to the retired
+    # ~/.config/mms, so every OpenCode launch wrote into a directory nothing
+    # else reads any more.
+    gateway_base = selected_config_root() if selected_config_root else real_user_path(".config", "mms-next")
+    return os.path.join(str(gateway_base), "opencode-gateway", "exports", f"{provider}-{model_slug}.json")
 
 
 def opencode_gateway_env(

--- a/mms_registry_cli.py
+++ b/mms_registry_cli.py
@@ -1383,24 +1383,20 @@ def config_v2_release_readiness(
             "public_readme_preview_docs",
             ROOT / "README.md",
             [
-                "Config V2 Preview Root",
-                "mms -> ~/.config/mms",
-                "mmf -> ~/.config/mms-next",
-                "mms migrate config-v2 --json",
-                "apply_enabled=false",
-                "Claude config",
+                "~/.config/mms-next",
+                "legacy `~/.config/mms`",
+                "不再被任何入口读取",
+                "预览 DB",
             ],
         ),
         _docs_terms_requirement(
             "public_readme_zh_preview_docs",
             ROOT / "README.zh-CN.md",
             [
-                "Config V2 Preview Root",
-                "mms -> ~/.config/mms",
-                "mmf -> ~/.config/mms-next",
-                "mms migrate config-v2 --json",
-                "apply_enabled=false",
-                "Claude config",
+                "~/.config/mms-next",
+                "legacy `~/.config/mms`",
+                "不再被任何入口读取",
+                "预览 DB",
             ],
         ),
         _docs_terms_requirement(
@@ -1444,7 +1440,7 @@ def config_v2_release_readiness(
         ),
         "notes": [
             "This audit proves readiness only up to the stable human gate.",
-            "It does not write stable ~/.config/mms/**, preview roots, DB, generated bundles, secret backends, or Claude config.",
+            "It does not write the retired ~/.config/mms tree, config roots, DB, generated bundles, secret backends, or Claude config.",
             "Do not mark the 4.0 migration complete until the human-gated stable promotion and post-promotion smoke are performed.",
         ],
     }

--- a/mms_review_dispatch.py
+++ b/mms_review_dispatch.py
@@ -255,7 +255,7 @@ def _selected_config_root() -> Path:
         value = str(os.environ.get(key) or "").strip()
         if value:
             return Path(value).expanduser()
-    return Path.home() / ".config" / "mms"
+    return Path.home() / ".config" / "mms-next"
 
 
 def _manifest_payload_path(config_root: Path, manifest: dict[str, Any], file_key: str) -> Path | None:

--- a/mms_router.py
+++ b/mms_router.py
@@ -10,7 +10,7 @@
 
 关键词来源（优先级：用户配置 > 自动学习 > 内置默认）：
 - 内置：代码中硬编码
-- 用户配置：~/.config/mms/route_keywords.json（手动编辑）
+- 用户配置：<配置根>/route_keywords.json（手动编辑，配置根默认 ~/.config/mms-next）
 - 自动学习：LLM 连续 N 次对相似 pattern 给出相同高置信分类 → 自动 promote 为关键词
 """
 
@@ -598,7 +598,7 @@ def _submit_async_llm_classify(text, api_url, api_key, light_model, provider_id=
 
 
 def log_route(level: str, reason: str, model_used: str, text_preview: str):
-    """写路由日志。tail -f ~/.config/mms/lb_route.log 查看。"""
+    """写路由日志。tail -f ~/.config/mms-next/lb_route.log 查看。"""
     try:
         os.makedirs(os.path.dirname(_LOG_PATH), exist_ok=True)
         ts = datetime.now().strftime("%H:%M:%S")

--- a/mms_session_assets.py
+++ b/mms_session_assets.py
@@ -858,7 +858,7 @@ def _global_sources_for_cli(cli: str, cli_rows: list[dict[str, Any]], *, home: s
             sources,
             surface="hooks",
             label="Pi session settings",
-            path="~/.config/mms/pi-gateway",
+            path="~/.config/mms-next/pi-gateway",
             count=0,
             items=[],
             note="Pi 目前由 MMS 生成 models/settings/retry extension；不继承 Skill/MCP/Hook 目录。",
@@ -1169,7 +1169,7 @@ def build_session_assets_snapshot(
         "disabled_defaults": _disabled_defaults(prefs),
         "preference_snippet": _preference_snippet(prefs),
         "configuration_contract": {
-            "persistent_path": preferences_path or "~/.config/mms/preferences.toml",
+            "persistent_path": preferences_path or "~/.config/mms-next/preferences.toml",
             "managed_assets_root": _managed_install_contract(home, mms_core).get("root"),
             "bundled_assets_root": _bundled_install_contract(home).get("root"),
             "launch_override": "TUI 启动确认页本次切换优先级最高，但不写回真实配置。",

--- a/scripts/ci_pytest_regression.py
+++ b/scripts/ci_pytest_regression.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TARGET = "tests"
+# Scratch checkouts live here, inside the repo, for the reason in base_worktree().
+GATE_DIR_NAME = ".pytest-gate"
 # Reruns of a candidate regression, to keep an order-dependent or port-flaky
 # test from blocking a PR that did not touch it.
 FLAKE_RERUNS = 2
@@ -115,8 +117,15 @@ def parse_report(report: Path, checkout: Path):
     return failures, collected
 
 
-def base_worktree(base_ref: str, workdir: Path) -> Path:
-    checkout = workdir / "base"
+def base_worktree(base_ref: str) -> Path:
+    """Check the base commit out *inside* the repository.
+
+    Not in a temp directory: some tests discover a sibling checkout by walking
+    up from their own file, so a base run in /tmp skips what the head run
+    executes, and the comparison invents regressions. Keeping both checkouts
+    under the same parent keeps that discovery identical.
+    """
+    checkout = REPO_ROOT / GATE_DIR_NAME / "base"
     proc = _run(["git", "worktree", "add", "--detach", str(checkout), base_ref], cwd=REPO_ROOT)
     if proc.returncode != 0:
         sys.stderr.write(proc.stdout + proc.stderr)
@@ -144,7 +153,7 @@ def main() -> int:
     try:
         head_checkout = REPO_ROOT
         if args.head.strip():
-            head_checkout = workdir / "head"
+            head_checkout = REPO_ROOT / GATE_DIR_NAME / "head"
             proc = _run(["git", "worktree", "add", "--detach", str(head_checkout), args.head], cwd=REPO_ROOT)
             if proc.returncode != 0:
                 sys.stderr.write(proc.stdout + proc.stderr)
@@ -152,7 +161,7 @@ def main() -> int:
             created.append(head_checkout)
 
         print(f"== base {args.base} ==", flush=True)
-        base_checkout = base_worktree(args.base, workdir)
+        base_checkout = base_worktree(args.base)
         created.append(base_checkout)
         base_failures, base_collected = run_suite(base_checkout, args.target, workdir / "base.xml")
         print(f"base: {len(base_failures)} failing of {base_collected}", flush=True)
@@ -205,6 +214,7 @@ def main() -> int:
     finally:
         for checkout in created:
             _run(["git", "worktree", "remove", "--force", str(checkout)], cwd=REPO_ROOT)
+        shutil.rmtree(REPO_ROOT / GATE_DIR_NAME, ignore_errors=True)
         shutil.rmtree(workdir, ignore_errors=True)
 
 

--- a/scripts/local_channel_update.py
+++ b/scripts/local_channel_update.py
@@ -269,7 +269,12 @@ def public_remind(args: argparse.Namespace) -> int:
     state = load_state()
     if not due(args, state):
         return 0
-    version_path = real_home() / ".config" / "mms" / "version.json"
+    version_path = real_home() / ".config" / "mms-next" / "version.json"
+    if not version_path.exists():
+        # Installs from before the single-root move still record it here.
+        legacy = real_home() / ".config" / "mms" / "version.json"
+        if legacy.exists():
+            version_path = legacy
     installed = "unknown"
     try:
         data = json.loads(version_path.read_text(encoding="utf-8"))

--- a/scripts/mms_health_watchdog.py
+++ b/scripts/mms_health_watchdog.py
@@ -138,7 +138,7 @@ def default_config_dir() -> Path:
         explicit = os.environ.get(key, "").strip()
         if explicit:
             return Path(explicit).expanduser()
-    return real_home() / ".config" / "mms"
+    return real_home() / ".config" / "mms-next"
 
 
 def _same_path(left: Path, right: Path) -> bool:
@@ -1058,7 +1058,7 @@ def format_feishu_card(report: dict[str, Any], reason: str) -> dict[str, Any]:
             "elements": [
                 {
                     "tag": "plain_text",
-                    "content": "本机结果：~/.config/mms/health-watchdog/latest.json",
+                    "content": "本机结果：~/.config/mms-next/health-watchdog/latest.json",
                 }
             ],
         }

--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -30,6 +30,12 @@ model_short=$(echo "$model" | sed 's/ (.*//')
 # installs that predate the move left gateway homes under ~/.config/mms, so a
 # session HOME has to be matched against both names before it can be walked
 # back out to its own root.
+# `stat -f %m` is BSD only. On Linux every timestamp read as 0, so every
+# freshness check below failed and the route/health display never appeared.
+file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
 MMS_ROOT_NAMES="mms-next mms"
 
 # Echo "<config root>" when $1 sits inside a gateway session home.
@@ -93,32 +99,32 @@ pick_route_status_file() {
     if [ "$is_gateway_session" -eq 1 ]; then
         if [ "$explicit_config_root" -eq 1 ] && [ -f "$primary_user" ]; then
             local mt age
-            mt=$(stat -f %m "$primary_user" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$primary_user")
             age=$(( now - mt ))
             [ "$age" -lt 600 ] && { echo "$primary_user"; return; }
         fi
         if [ -f "$primary_home" ]; then
             local mt age
-            mt=$(stat -f %m "$primary_home" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$primary_home")
             age=$(( now - mt ))
             [ "$age" -lt 600 ] && { echo "$primary_home"; return; }
         fi
         if [ "$explicit_config_root" -ne 1 ] && [ -f "$primary_user" ]; then
             local mt age
-            mt=$(stat -f %m "$primary_user" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$primary_user")
             age=$(( now - mt ))
             [ "$age" -lt 600 ] && { echo "$primary_user"; return; }
         fi
     else
         if [ -f "$primary_user" ]; then
             local mt age
-            mt=$(stat -f %m "$primary_user" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$primary_user")
             age=$(( now - mt ))
             [ "$age" -lt 600 ] && { echo "$primary_user"; return; }
         fi
         if [ -f "$primary_home" ]; then
             local mt age
-            mt=$(stat -f %m "$primary_home" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$primary_home")
             age=$(( now - mt ))
             [ "$age" -lt 600 ] && { echo "$primary_home"; return; }
         fi
@@ -130,7 +136,7 @@ pick_route_status_file() {
     for p in "$primary_user" "$primary_home"; do
         if [ -f "$p" ]; then
             local mt
-            mt=$(stat -f %m "$p" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$p")
             if [ "$mt" -gt "$best_mtime" ]; then
                 best_mtime="$mt"
                 best_path="$p"
@@ -141,7 +147,7 @@ pick_route_status_file() {
     if [ -d "$gateway_sessions" ]; then
         while IFS= read -r p; do
             local mt
-            mt=$(stat -f %m "$p" 2>/dev/null || echo 0)
+            mt=$(file_mtime "$p")
             if [ "$mt" -gt "$best_mtime" ]; then
                 best_mtime="$mt"
                 best_path="$p"
@@ -156,7 +162,7 @@ pick_route_status_file() {
 _ROUTE_STATUS="${MMS_ROUTE_STATUS_PATH:-$(pick_route_status_file)}"
 route_tag=""
 if mms_root_from_gateway_path "$HOME" >/dev/null && [ -n "$_ROUTE_STATUS" ] && [ -f "$_ROUTE_STATUS" ]; then
-    route_age=$(( $(date +%s) - $(stat -f %m "$_ROUTE_STATUS" 2>/dev/null || echo 0) ))
+    route_age=$(( $(date +%s) - $(file_mtime "$_ROUTE_STATUS") ))
     if [ "$route_age" -lt 600 ]; then
         r_model=$(jq -r '.model // empty' "$_ROUTE_STATUS" 2>/dev/null)
         r_ctx=$(jq -r '.context_window_tokens // .context_window_size // empty' "$_ROUTE_STATUS" 2>/dev/null)
@@ -174,7 +180,7 @@ fi
 health_icon=""
 _HEALTH_CACHE="$(mms_config_root)/health-cache.json"
 if [ -f "$_HEALTH_CACHE" ]; then
-    h_age=$(( $(date +%s) - $(stat -f %m "$_HEALTH_CACHE" 2>/dev/null || echo 0) ))
+    h_age=$(( $(date +%s) - $(file_mtime "$_HEALTH_CACHE") ))
     if [ "$h_age" -lt 120 ]; then
         _h_model="${r_model:-$model_short}"
         _h_status=$(jq -r --arg m "$_h_model" '.records[$m].status // empty' "$_HEALTH_CACHE" 2>/dev/null)
@@ -213,7 +219,7 @@ GIT_DIFF_CACHE="${TMPDIR}claude-statusline-gitdiff"
 git_diff_info=""
 if [ -n "$cwd" ] && [ -d "$cwd" ]; then
     now_s=$(date +%s)
-    cache_mt=$(stat -f %m "$GIT_DIFF_CACHE" 2>/dev/null || echo 0)
+    cache_mt=$(file_mtime "$GIT_DIFF_CACHE")
     if [ $(( now_s - cache_mt )) -gt 5 ]; then
         stat_line=$(git -C "$cwd" diff --stat 2>/dev/null | tail -1)
         echo "$stat_line" > "$GIT_DIFF_CACHE"
@@ -298,7 +304,7 @@ USAGE_LOCK="${TMPDIR}claude-usage-cache.lock"
 
 _refresh_usage_bg() {
     if [ -f "$USAGE_LOCK" ]; then
-        lock_age=$(( $(date +%s) - $(stat -f %m "$USAGE_LOCK" 2>/dev/null || echo 0) ))
+        lock_age=$(( $(date +%s) - $(file_mtime "$USAGE_LOCK") ))
         [ "$lock_age" -lt 30 ] && return
         rm -f "$USAGE_LOCK"
     fi
@@ -338,7 +344,7 @@ fmt_resets() {
 
 usage_info=""
 if [ -f "$USAGE_CACHE" ]; then
-    cache_age=$(( $(date +%s) - $(stat -f %m "$USAGE_CACHE" 2>/dev/null || echo 0) ))
+    cache_age=$(( $(date +%s) - $(file_mtime "$USAGE_CACHE") ))
     if [ "$cache_age" -lt 600 ]; then
         u_raw=$(jq -r '.five_hour.utilization // empty' "$USAGE_CACHE" 2>/dev/null)
         u_reset=$(jq -r '.five_hour.resets_at // empty' "$USAGE_CACHE" 2>/dev/null)

--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -26,6 +26,27 @@ fi
 COLS=$(tput cols 2>/dev/null || echo 100)
 model_short=$(echo "$model" | sed 's/ (.*//')
 
+# The config root is ~/.config/mms-next. Gateway homes live inside it, and
+# installs that predate the move left gateway homes under ~/.config/mms, so a
+# session HOME has to be matched against both names before it can be walked
+# back out to its own root.
+MMS_ROOT_NAMES="mms-next mms"
+
+# Echo "<config root>" when $1 sits inside a gateway session home.
+mms_root_from_gateway_path() {
+    local path="$1" name gateway
+    [ -n "$path" ] || return 1
+    for name in $MMS_ROOT_NAMES; do
+        for gateway in claude-gateway codex-gateway pi-gateway opencode-gateway; do
+            if [[ "$path" == *"/.config/$name/$gateway/"* ]]; then
+                echo "${path%%/.config/$name/$gateway/*}/.config/$name"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
 mms_config_root() {
     if [ -n "$MMS_CONFIG_ROOT" ]; then
         echo "$MMS_CONFIG_ROOT"
@@ -35,35 +56,32 @@ mms_config_root() {
         echo "$MMS_CONFIG_DIR"
         return
     fi
+    local from_gateway
     if [ -n "$XDG_CONFIG_HOME" ]; then
-        if [[ "$XDG_CONFIG_HOME" == *"/.config/mms/claude-gateway/"* ]]; then
-            echo "${XDG_CONFIG_HOME%%/.config/mms/claude-gateway/*}/.config/mms"
+        if from_gateway=$(mms_root_from_gateway_path "$XDG_CONFIG_HOME"); then
+            echo "$from_gateway"
             return
         fi
-        if [[ "$XDG_CONFIG_HOME" == *"/.config/mms/codex-gateway/"* ]]; then
-            echo "${XDG_CONFIG_HOME%%/.config/mms/codex-gateway/*}/.config/mms"
-            return
-        fi
-        echo "$XDG_CONFIG_HOME/mms"
+        echo "$XDG_CONFIG_HOME/mms-next"
         return
     fi
-    local user_home="$HOME"
-    if [[ "$HOME" == *"/.config/mms/claude-gateway/"* ]]; then
-        user_home="${HOME%%/.config/mms/claude-gateway/*}"
+    if from_gateway=$(mms_root_from_gateway_path "$HOME"); then
+        echo "$from_gateway"
+        return
     fi
-    echo "$user_home/.config/mms"
+    echo "$HOME/.config/mms-next"
 }
 
 pick_route_status_file() {
     local config_root
     config_root="$(mms_config_root)"
     local is_gateway_session=0
-    if [[ "$HOME" == *"/.config/mms/claude-gateway/"* ]]; then
+    if mms_root_from_gateway_path "$HOME" >/dev/null; then
         is_gateway_session=1
     fi
 
     local primary_user="$config_root/route_status.json"
-    local primary_home="$HOME/.config/mms/route_status.json"
+    local primary_home="$HOME/.config/mms-next/route_status.json"
     local gateway_sessions="$config_root/claude-gateway/s"
     local explicit_config_root=0
     if [ -n "$MMS_CONFIG_ROOT" ] || [ -n "$MMS_CONFIG_DIR" ]; then
@@ -137,7 +155,7 @@ pick_route_status_file() {
 # per-session 优先：MMS launch 时注入 MMS_ROUTE_STATUS_PATH 指向本 session 隔离文件
 _ROUTE_STATUS="${MMS_ROUTE_STATUS_PATH:-$(pick_route_status_file)}"
 route_tag=""
-if [[ "$HOME" == *"/.config/mms/claude-gateway/"* ]] && [ -n "$_ROUTE_STATUS" ] && [ -f "$_ROUTE_STATUS" ]; then
+if mms_root_from_gateway_path "$HOME" >/dev/null && [ -n "$_ROUTE_STATUS" ] && [ -f "$_ROUTE_STATUS" ]; then
     route_age=$(( $(date +%s) - $(stat -f %m "$_ROUTE_STATUS" 2>/dev/null || echo 0) ))
     if [ "$route_age" -lt 600 ]; then
         r_model=$(jq -r '.model // empty' "$_ROUTE_STATUS" 2>/dev/null)

--- a/tests/test_claude_isolation.py
+++ b/tests/test_claude_isolation.py
@@ -708,6 +708,71 @@ def test_statusline_strips_gateway_xdg_without_explicit_root(tmp_path):
     assert "●" in result.stdout
 
 
+def test_statusline_strips_single_root_gateway_xdg_without_explicit_root(tmp_path):
+    """A gateway session under ~/.config/mms-next must find its own root.
+
+    The script only knew how to walk out of a ~/.config/mms gateway home, so
+    after the config root moved it resolved to <session>/.config/mms and the
+    route status never showed up in the statusline.
+    """
+    script = Path(__file__).resolve().parents[1] / "statusline-command.sh"
+    real_home = tmp_path / "real-home"
+    stable_root = real_home / ".config" / "mms-next"
+    gateway_home = stable_root / "claude-gateway" / "s" / "12345"
+    stable_root.mkdir(parents=True)
+    gateway_home.mkdir(parents=True)
+    (stable_root / "route_status.json").write_text(
+        json.dumps({"tier": "heavy", "model": "claude-stable-20260101"}),
+        encoding="utf-8",
+    )
+    (stable_root / "health-cache.json").write_text(
+        json.dumps(
+            {
+                "records": {
+                    "claude-stable-20260101": {
+                        "status": "ok",
+                        "checked_at": datetime.now().astimezone().isoformat(),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = {
+        "model": {"display_name": "Sonnet"},
+        "workspace": {"current_dir": str(tmp_path)},
+        "context_window": {
+            "used_percentage": 1,
+            "total_input_tokens": 1000,
+            "total_output_tokens": 2000,
+            "context_window_size": 200000,
+        },
+        "cost": {"total_cost_usd": 0, "total_duration_ms": 0},
+    }
+    env = {
+        **os.environ,
+        "HOME": str(gateway_home),
+        "XDG_CONFIG_HOME": str(gateway_home / ".config"),
+        "MMS_REAL_HOME": str(real_home),
+        "REAL_HOME": str(real_home),
+        "ORIGINAL_HOME": str(real_home),
+        "TMPDIR": str(tmp_path) + os.sep,
+    }
+    env.pop("MMS_CONFIG_ROOT", None)
+    env.pop("MMS_CONFIG_DIR", None)
+    result = subprocess.run(
+        ["bash", str(script)],
+        input=json.dumps(payload),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert "stable" in result.stdout
+    assert "●" in result.stdout
+
 def test_claude_route_status_path_uses_selected_root_when_explicit(monkeypatch, tmp_path):
     import mms_launchers
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -5589,3 +5589,22 @@ def test_core_opencode_profile_menu_includes_lite_pro_health_summary(monkeypatch
     assert "health: 1/18 healthy" in agent["summary"]
     assert "1 degraded" in agent["summary"]
     assert "16 untested" in agent["summary"]
+
+
+def test_opencode_export_config_lands_in_the_selected_config_root(monkeypatch, tmp_path):
+    """The export config used to be pinned to the retired ~/.config/mms.
+
+    Every OpenCode launch wrote its generated config into a directory no other
+    entry point reads any more, which is how ~/.config/mms kept getting touched
+    long after it stopped being a config root.
+    """
+    import mms_launchers
+
+    root = tmp_path / "mms-next"
+    root.mkdir()
+    monkeypatch.setenv("MMS_CONFIG_ROOT", str(root))
+
+    path = mms_launchers._opencode_export_config_path({"id": "kimi", "name": "kimi"}, "k3")
+
+    assert path == str(root / "opencode-gateway" / "exports" / "kimi-k3.json")
+    assert "/.config/mms/" not in path

--- a/tests/test_registry_contract_docs.py
+++ b/tests/test_registry_contract_docs.py
@@ -225,23 +225,15 @@ def test_mmf_v2_docs_record_current_preview_boundaries() -> None:
 def test_public_readmes_explain_config_v2_preview_gate() -> None:
     text = _readme_text()
 
+    # #177 retired the preview -> stable promotion this list used to describe.
+    # What the READMEs owe a reader now is the single root and where runtime
+    # truth comes from.
     required_terms = [
-        "Config V2 Preview Root",
-        "mms -> ~/.config/mms",
-        "mmf -> ~/.config/mms-next",
-        "mmf preview doctor --json",
-        "mmf preview prepare --from ~/.config/mms --include-secrets --json",
-        "mmf config bundle --json",
+        "~/.config/mms-next",
+        "legacy `~/.config/mms`",
+        "不再被任何入口读取",
+        "预览 DB",
         "generated/model-registry.latest-approved.json",
-        "mms migrate config-v2 --json",
-        "mms config release-readiness --json",
-        "apply_enabled=false",
-        "READY_FOR_4_0_HUMAN_GATE",
-        "release_complete=false",
-        "stable_root_human_only",
-        "promotion_apply_not_implemented",
-        "silent fallback",
-        "Claude config",
     ]
 
     missing = [term for term in required_terms if term not in text]
@@ -307,12 +299,9 @@ def test_architecture_images_show_latest_approved_bundle_not_legacy_route_truth(
 def test_readmes_describe_registry_v2_profile_boundary() -> None:
     text = _readme_text()
 
+    # The English half of this list went away when the READMEs became Chinese.
+    # The boundary it guards did not.
     required_terms = [
-        "Registry v2 is the preferred path for local changes",
-        "TUI / `mms config` / WebUI",
-        "creates DB candidates",
-        "`generated/model-registry.latest-approved.json` bundle",
-        "generated Profile it references is the runtime boundary",
         "本地修改优先走 Registry v2",
         "TUI / `mms config` / WebUI 先创建 DB candidate",
         "它引用的 generated Profile 就是 runtime boundary",

--- a/tests/test_single_config_root.py
+++ b/tests/test_single_config_root.py
@@ -119,3 +119,97 @@ def test_retired_legacy_directory_is_still_refused_as_a_v2_root(tmp_path):
     assert mms_state_io.is_retired_legacy_root(tmp_path / ".config" / "mms-next") is False
     status = mms_state_io.mms_config_root_status(config_dir=str(tmp_path / ".config" / "mms"), env={})
     assert status["legacy_root"] is True and status["mode"] == "preview"
+
+
+# Every place in the runtime that still spells the retired ~/.config/mms, with
+# the reason it is allowed to. Anything not listed here is a new legacy-root
+# read or write, which is what this contract forbids.
+#
+# Adding an entry is a deliberate act: say why the retired root belongs there.
+_LEGACY_ROOT_ALLOWED = {
+    # Detects a dirty legacy install so it can be cleaned up.
+    ("mmc_core.py", '"/.config/mms/",'),
+    ("mms_launchers.py", 'forbidden_parts = ("/.mms/", "/.config/mms/", "/ccswitch", "/hive")'),
+    # Prose describing the retirement.
+    ("mms_consumer_bundle.py", "``~/.config/mms`` is opt-in so preview consumers do not silently cross root"),
+    ("mms_core.py", "Collects one channel interactively. The legacy ~/.config/mms root is never"),
+    ("mms_state_io.py", '"""True for the retired ~/.config/mms directory (or any root named like it).'),
+    ("mms_state_io.py", "The legacy stable root (~/.config/mms) is retired as a config source; the"),
+    ("mms_web/catalog.py", "real ``~/.config/mms*`` roots stay untouched."),
+    ("scripts/local_channel_update.py", "real MMS config tree under ~/.config/mms."),
+    # The descriptor that names the retired root so callers can report on it.
+    ("mms_state_io.py", '"stable_root": os.path.join(real_home, ".config", "mms"),'),
+    # Refuses to write either root, so it has to know both names.
+    ("mms_web/catalog.py", '_PROTECTED_ROOT_NAMES = (".config/mms", ".config/mms-next")'),
+    ("mms_web/catalog_worker.py", '_PROTECTED_ROOT_NAMES = (".config/mms", ".config/mms-next")'),
+    ("scripts/local_channel_update.py", 'for marker in ("/.config/mms-next", "/.config/mms"):'),
+    # A version.json an install from before the move left behind.
+    ("scripts/local_channel_update.py", 'legacy = real_home() / ".config" / "mms" / "version.json"'),
+    # One-time manual import of an old config into the DB. Human-run, never automatic.
+    ("mms_registry_cli.py", '"It does not write the retired ~/.config/mms tree, config roots, DB, generated bundles, secret backends, or Claude config.",'),
+    ("mms_registry_cli.py", '"command": "./mmf preview import-legacy --from ~/.config/mms --apply --include-secrets --json && ./mmf preview publish --json",'),
+    ("mms_registry_cli.py", '"human must approve any stable ~/.config/mms write",'),
+    ("mms_registry_cli.py", '"legacy `~/.config/mms`",'),
+    ("mms_registry_cli.py", 'command = "./mmf preview prepare --from ~/.config/mms --include-secrets --json"'),
+    ("mms_registry_cli.py", 'command = "./mmf preview prepare --from ~/.config/mms --include-secrets --json" if missing_keys > 0 else "./mmf preview prepare --from ~/.config/mms --json"'),
+    ("mms_registry_cli.py", 'command = "./mmf preview prepare --from ~/.config/mms --json"'),
+    ("mms_registry_cli.py", 'next_action = {"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"}'),
+    ("mms_registry_cli.py", 'next_actions.append({"label": "Import legacy config into preview DB", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --json"})'),
+    ("mms_registry_cli.py", 'next_actions.append({"label": "Optional: import keys into preview secret backend", "command": "./mmf preview import-legacy --from ~/.config/mms --apply --include-secrets --json && ./mmf preview publish --json"})'),
+}
+
+
+def _legacy_root_mentions():
+    """Every non-comment line in the runtime that names the retired root."""
+    import re
+
+    join = re.compile(r'["\']\.config["\']\s*[,/]\s*(?:\n\s*)?["\']mms["\']')
+    literal = re.compile(r"\.config/mms(?![\w-])")
+    targets = sorted(
+        set(
+            list(ROOT.glob("mms_*.py"))
+            + list(ROOT.glob("mms_web/**/*.py"))
+            + [
+                ROOT / "mmc_core.py",
+                ROOT / "statusline-command.sh",
+                ROOT / "scripts/mms_health_watchdog.py",
+                ROOT / "scripts/local_channel_update.py",
+            ]
+        )
+    )
+    found = []
+    seen = set()
+    for path in targets:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        lines = text.splitlines()
+        for pattern in (join, literal):
+            for match in pattern.finditer(text):
+                number = text[: match.start()].count("\n") + 1
+                if (path, number) in seen:
+                    continue
+                seen.add((path, number))
+                line = lines[number - 1].strip()
+                # A comment cannot read a directory.
+                if line.startswith("#"):
+                    continue
+                found.append((path.relative_to(ROOT).as_posix(), line, number))
+    return found
+
+
+def test_no_new_code_path_reads_or_writes_the_retired_legacy_root():
+    """~/.config/mms is not a config root any more, in any entry point.
+
+    Four places kept using it long after #177 said they should not: the
+    OpenCode export config, the health watchdog's whole config directory, the
+    public-copy update check, and two opt-in bundle fallbacks. None of them was
+    covered, because the old contract only inspected three named functions.
+    """
+    unexpected = [
+        f"{path}:{number}: {line}"
+        for path, line, number in _legacy_root_mentions()
+        if (path, line) not in _LEGACY_ROOT_ALLOWED
+    ]
+
+    assert not unexpected, "new reference(s) to the retired config root:\n  " + "\n  ".join(unexpected)


### PR DESCRIPTION
## 结论

**配置根本身早就是 `~/.config/mms-next`，但有五处代码一直还在用旧目录。** 你这台机器上 `~/.config/mms` 今天还在被写。

我先查了真实状态，再动手：

```
干净环境下解析（repo 代码）:
  mms_config_root_mode()   = preview
  resolve_mms_config_dir() = ~/.config/mms-next
  ACCOUNTS_DIR             = ~/.config/mms-next/accounts
  codex/claude gateway     = ~/.config/mms-next/*-gateway

~/.config/mms 今天被写的文件:
  opencode-gateway/exports/kimi-k3.json      ← 本 PR 修掉
  claude-gateway/s/{53759,63060}/.claude.json ← 旧会话进程留下的，非配置
```

## 还在用旧目录的五处

| 位置 | 影响 |
|---|---|
| `mms_opencode_env.opencode_export_config_path` | 每次 OpenCode 启动都把生成的配置写进 `~/.config/mms/opencode-gateway/exports`，而旁边的 gateway 早就用解析后的根了 |
| `scripts/mms_health_watchdog.default_config_dir` | 整个 watchdog 的配置目录默认旧根，state / log / latest.json 全落在那里 |
| `scripts/local_channel_update.py` | public copy 的更新检查只读旧根的 `version.json` |
| `mms_consumer_bundle` / `mms_review_dispatch` | 两处 opt-in 兜底把旧根写成默认值 |
| `statusline-command.sh` | 只会从 `~/.config/mms` 的 gateway home 往上走 |

statusline 那条影响最直接。当前布局下 Claude 会话的 HOME 是 `~/.config/mms-next/claude-gateway/s/<pid>`，脚本匹配不上，于是把配置根算成 `<session>/.config/mms`：

```
修复前: HOME=.../mms-next/claude-gateway/s/54126 -> .../s/54126/.config/mms   ← 不存在
修复后: HOME=.../mms-next/claude-gateway/s/54126 -> ~/.config/mms-next        ← route_status.json 在这里
        HOME=.../mms/claude-gateway/s/999        -> ~/.config/mms             ← 老 gateway home 仍然可用
        普通 shell                                -> ~/.config/mms-next
```

`version.json` 那条保留了回退：迁移之前装的机器只在旧根有这个文件，先读新根、没有才读旧的。

## 顺带修掉指错路径的文案

Pi session settings 路径、session assets 里显示的 preferences 路径、router 的关键词/日志 docstring、watchdog 的结果提示。这些都会直接展示给用户，写着一个不再被写入的目录。

## 这次补上真正的契约

旧的 `test_config_root_fallbacks_do_not_point_at_the_legacy_root` 只检查三个具名函数，所以上面五处全都漏了。新测试扫描所有 runtime 模块和 statusline，任何不在显式 allowlist 里的旧根引用都算失败，allowlist 每一条都写清楚为什么允许（清理逻辑、退休根描述、两个根都要保护的写入拦截、一次性人工导入命令）。

拿上一版代码跑，它报出全部六条：

```
mms_consumer_bundle.py:88: return Path.home() / ".config" / "mms"
mms_opencode_env.py:788: ".config",
mms_review_dispatch.py:258: return Path.home() / ".config" / "mms"
scripts/local_channel_update.py:272: version_path = real_home() / ".config" / "mms" / "version.json"
scripts/mms_health_watchdog.py:141: return real_home() / ".config" / "mms"
scripts/mms_health_watchdog.py:1061: "content": "本机结果：~/.config/mms/health-watchdog/latest.json",
```

## 两条长期红的文档契约

`test_public_readmes_explain_config_v2_preview_gate` 和 `test_readmes_describe_registry_v2_profile_boundary` 在 dev 上一直是红的。它们要求 README 写 preview → stable 晋升流程的文案，包括 `mms -> ~/.config/mms` —— 这句现在是假的，那套流程被 #177 取消了。16 个必需词里 14 个在 README 里根本不存在。

改成要求当前成立的契约，并在两份 README 里补了一小节，说明只有一个配置根、以及 runtime 真值从哪来（Registry v2 candidate → latest-approved bundle → generated Profile）。`mms_registry_cli.py` 里那份重复的要求列表一并改掉。

## 还修了我自己上一版的 CI gate

gate 把 `test_state_core_closeout_binding.py` 的五条报成本 PR 改坏的。它们没坏，是**一边跳过了**：这套测试靠从自身文件往上走找同级的 `state-core` checkout，head 用真实 checkout 找得到就执行，base 的 worktree 在系统临时目录找不到就 skip。skip 在 base、fail 在 head，看起来和回归一模一样。

现在两个 checkout 都放在仓库内同一层，发现逻辑一致。改完后这五条在 base 和 head 上同样失败，也就是它们的真实状态。

## 验证

`python3 scripts/ci_pytest_regression.py --base origin/dev` 全量：

```
base: 100 failing of 2115
head:  97 failing of 2118
Repaired (3): 上面两条文档契约 + test_mms_config_release_readiness_reaches_human_gate_for_ready_preview
No test that passes on the base commit fails here.
```

statusline 的新测试单独验过：在上一版脚本上失败，在本 PR 上通过。

## 你这台机器上剩下什么

`~/.config/mms` 里剩的是旧 gateway 会话目录、backups、旧 config.toml 和 cache。合并后没有任何入口会再写它（除了显式的清理和一次性人工导入）。安装脚本只把它当作旧 `version.json` 的读取回退，不会创建它。要不要删由你决定，我没有动。

https://claude.ai/code/session_01CzjcNSnzwadLDm99AVuypi
