### PR TITLE
release(pilot): prepare v4.19.0

### DIFF
--- a/apps/mms-web/package-lock.json
+++ b/apps/mms-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mms/web",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mms/web",
-      "version": "4.18.0",
+      "version": "4.19.0",
       "dependencies": {
         "lucide-react": "0.468.0",
         "qrcode-generator": "2.0.4",

--- a/apps/mms-web/package.json
+++ b/apps/mms-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mms/web",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/mms-web/RELEASE-v4.19.0.md
+++ b/docs/mms-web/RELEASE-v4.19.0.md
@@ -1,0 +1,25 @@
+# v4.19.0 · 旁问直答与消息控制
+
+## Pilot 旁问
+
+- **`/btw` 直接回答当前问题**：旁问使用当前 session 的状态快照或 session-owned route，答案留在旁问卡片中，不写入主任务 transcript，也不改变主任务队列和 runtime。
+- **状态与模型来源可见**：卡片显示回答来源、上下文 revision、路由和失败原因；没有可用模型时明确失败，不伪造 endpoint 或成功结果。
+- **审批期间仍然可问状态**：主任务等待 approval 时，状态旁问仍可回答；`steer` 不绕过审批，返回明确的 `APPROVAL_PENDING`。
+
+## 消息控制
+
+- **`followUp` 与 `steer` 分开**：follow-up 按 lane 排队；steer 在当前工具步骤完成后，通过 Pi 原生 steer 边界送达。
+- **`interrupt` 是明确停止路径**：停止会处理中断审批、清理队列并保留已经完成的历史；未送达消息显示为 interrupted 或 cancelled，取决于实际操作。
+- **队列可读、可控、可恢复**：支持 steering/follow-up lane 展示、promote、remove、reorder，并在恢复或进程退出时准确标记无法送达的消息。
+- **请求幂等**：重复 request 不重复写入 wire command；不同 mode 属于不同请求指纹。
+
+## 升级须知
+
+- 本次包含 Pilot 前端、session backend、消息控制和静态 bundle 更新。
+- 升级前建议等待正在执行的任务结束；更新期间 Pilot 会重启，页面会自动刷新。
+- 已有 session history、旁问记录和队列结果保留在原 state-root；真实配置、账号和 API key 不会被更新流程改写。
+
+## 验证范围
+
+- 完整 `mms_web` 回归、frontend tests、compile/build、approval-waiting HTTP smoke、OpenAI-only transport smoke、Pi wire steer/interrupt smoke 和 normal URL bundle smoke 均通过。
+- 本版仍只宣传 Pi Web adapter；Grok、Claude、Codex、OpenCode 的统一 harness 接入不包含在本版。

--- a/mms_version.py
+++ b/mms_version.py
@@ -1,2 +1,2 @@
 """Version of the packaged MMS source and Web client."""
-VERSION = "4.18.0"
+VERSION = "4.19.0"

--- a/mms_web_static/build.json
+++ b/mms_web_static/build.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.18.0",
-  "sourceSha256": "b06f8074ec1c34293b2d78f2035a093dc7872842af752c82e816b914c405e505",
+  "version": "4.19.0",
+  "sourceSha256": "b44e2c8f46e2f1a687a31c0284081aa94a127a46e56c213ce3fad565756c670c",
   "files": {
     "assets/index-CItyy92K.js": "8a99b6f9e266df722a6467a11794a2e14831d895afb05058a617ed2c3a6b3a9c",
     "assets/index-hWMt9dHW.css": "e7f3b08d70704b3cf6a965c87c67c56f4f8a7df020f224fe35f0f81145ff4e28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-model-switch",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## 发布内容

准备 Pilot `v4.19.0`，包含已合并到 `dev` 的 T1 `/btw` 和 T2 message control：

- `/btw` session-owned 旁问直答、状态/模型来源和 fail-closed 行为
- `followUp` / `steer` / `interrupt` 语义与审批边界
- queue lane 展示、promote/remove/reorder、恢复和中断状态
- 静态 bundle、Python/npm 版本元数据和 release note 同步为 `4.19.0`

## 验证

- `python3 -m pytest -q -k mms_web`：510 passed，1738 deselected，4 subtests passed
- frontend `node --test 'tests/*.test.mjs'`：55 passed
- `python3 -m compileall -q mms_web tests/fixtures/mms_web`：passed
- approval-waiting HTTP smoke：旁问 completed；steer `APPROVAL_PENDING`；follow-up queued
- pure OpenAI-only transport smoke：`/v1/chat/completions`，`stream=false`
- Pi wire steer/interrupt smoke：5 passed
- normal URL bootstrap/static identity smoke：passed
- `python3 scripts/build_mms_web_release.py --skip-install`：passed
- `git diff --check`：passed

## 发布边界

本 PR 只准备版本和 release artifact，不修改真实 MMS config、账号、OAuth 或 provider credentials。PR checks 通过后再创建 `v4.19.0` tag 和 GitHub Release。
