### PR TITLE
fix(install): tell the user how to update while Pilot is running; drop the dead stop-and-reopen path (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。
 
+升级同样是重新粘贴这一条命令，但如果 Pilot 正在运行，安装器会暂停并拒绝，不会替你关闭它：请先在 Pilot 页面里点“更新”，或者执行 `mms web stop`（本机有多个实例用 `mms web stop --all`）退出后再重新执行安装命令。
+
 <details>
 <summary>其他安装方式</summary>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,6 +94,8 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 
 安装过程不问任何会影响安装内容的问题，默认走 stable 通道并把 `~/.local/bin` 写进 shell PATH。默认 UI 语言是中文，要英文加 `--lang en`。
 
+升级同样是重新粘贴这一条命令，但如果 Pilot 正在运行，安装器会暂停并拒绝，不会替你关闭它：请先在 Pilot 页面里点“更新”，或者执行 `mms web stop`（本机有多个实例用 `mms web stop --all`）退出后再重新执行安装命令。
+
 <details>
 <summary>其他安装方式</summary>
 

--- a/install.sh
+++ b/install.sh
@@ -52,9 +52,10 @@ INSTALL_CLI_EXPLICIT=0
 CHECK_ONLY=0
 CLEANUP_ONLY=0
 LAUNCH_WEB_MODE="ask"
+# --keep-running-pilot is accepted for compatibility only; it changes nothing
+# (see guard_live_pilot_install / usage text below). Installation never stops
+# a running Pilot, so there is no stop-and-reopen path to configure here.
 KEEP_RUNNING_PILOT=0
-STOPPED_PILOT=0
-STOPPED_PILOT_PORT=""
 PRINT_ONLY_VERSION=0
 DRY_RUN=0
 
@@ -289,7 +290,9 @@ $(t "说明:" "Notes:")
   - $(t "--lang 可设置默认 UI 语言（zh / en）" "--lang sets the default UI language (zh / en)")
   - $(t "安装过程零交互：不询问可选包，也不询问 UI 语言；唯一的提问是装完之后要不要打开 MMS Web" "The install is non-interactive: no optional-pack questions and no UI language prompt; the only question comes after everything is installed and just offers to open MMS Web")
   - $(t "--launch-web 跳过提问直接打开，--no-launch-web 完全不打开；没有终端时不提问，只打印命令" "--launch-web opens it without asking, --no-launch-web never opens it; with no terminal available nothing is asked and the command is printed instead")
-  - $(t "检测到 Pilot 正在运行时默认暂停安装，不关闭 Pilot 或其会话；--keep-running-pilot 保持兼容" "When a Pilot is running, installation pauses by default without stopping Pilot or its sessions; --keep-running-pilot is retained for compatibility")
+  - $(t "检测到 Pilot 正在运行时会暂停安装，不关闭 Pilot 或其会话" "When a Pilot is running, installation pauses without stopping Pilot or its sessions")
+  - $(t "请在 Pilot 页面里用“更新”，或先运行 mms web stop（多实例用 --all）退出后再重新执行本命令" "Use Update inside Pilot, or run mms web stop (--all for multiple instances) to exit it, then re-run this command")
+  - $(t "--keep-running-pilot 仅为兼容旧脚本保留，不改变任何行为：安装始终不会关闭正在运行的 Pilot" "--keep-running-pilot is kept only for compatibility with older scripts; it changes nothing — installation never stops a running Pilot either way")
   - $(t "MMS Web 在后台运行，安装进程随即退出；PATH 默认写入 shell 配置，--no-shell-rc 可关闭" "MMS Web runs in the background and the installer exits right after; PATH is written to your shell config by default and --no-shell-rc turns that off")
   - $(t "pi 是必装项，pilot web 端依赖它；缺失的 claude/codex/opencode 会自动补装，已安装的不会被改动" "pi is mandatory because the pilot web app depends on it; missing claude/codex/opencode are installed automatically while existing ones are left untouched")
   - $(t "内建能力（weber 网页路由、grill-me、TOON、NSR）随 MMS 一起安装，只在 MMS 启动的会话里生效" "Built-in tools (weber web routing, grill-me, TOON, NSR) ship with MMS and only apply inside sessions MMS starts")
@@ -1967,7 +1970,7 @@ PY
 )" || return 1
     exec 9>"$lock_path"
 
-    local report="" status=0 servers=""
+    local report="" status=0
     set +e
     report="$(inspect_live_pilot)"
     status=$?
@@ -1980,19 +1983,16 @@ PY
         return 1
     fi
 
-    # Only Pilot servers are stoppable. Agent sessions Pilot spawned mention
-    # the same paths but stopping them would kill the user's conversation.
-    servers="$(printf '%s\n' "$report" | sed -n 's/^server //p')"
-    if [ "$KEEP_RUNNING_PILOT" -eq 1 ] || [ -z "$servers" ]; then
-        echo "⚠ $(t "Pilot 正在使用此安装目录，已暂停安装；没有关闭进程或清理会话。请在页面的‘更新’入口完成安全更新，或自行退出服务后再运行本命令。" "Pilot is using this installation. Nothing was stopped or removed. Use Update in Pilot, or exit the service yourself before rerunning this command.")"
-        printf '%s\n' "$report" | sed -n 's/^other /  /p'
-        return 1
-    fi
-
     # Installation must never terminate a running Pilot: doing so also kills
-    # conversations it owns. The user can exit it explicitly and retry.
-    echo "⚠ $(t "Pilot 正在运行，已暂停安装；没有关闭进程或清理会话。请先自行退出后重试。" "Pilot is running. Installation paused; no process or session was stopped. Exit Pilot yourself and retry.")"
-    printf '%s\n' "$report" | sed -n 's/^server /  /p'
+    # conversations it owns. This holds for every case status 3 reports,
+    # whether or not a stoppable server was found, and regardless of
+    # --keep-running-pilot (accepted for compatibility only; it never changes
+    # this outcome). The user must use Update inside Pilot, or stop it
+    # themselves and retry.
+    echo "⚠ $(t "Pilot 正在运行，已暂停安装；没有关闭进程或清理会话。" "Pilot is running. Installation paused; nothing was stopped or removed.")"
+    echo "  $(t "请在 Pilot 页面里用“更新”完成安全升级，或先执行 mms web stop 退出后再重新运行本命令。" "Use Update inside Pilot for a safe upgrade, or run mms web stop to exit it, then re-run this install command.")"
+    echo "  $(t "本机有多个实例时用 mms web stop --all" "Use mms web stop --all when several local instances are running")"
+    printf '%s\n' "$report" | sed -n 's/^server /  /p;s/^other /  /p'
     return 1
 }
 
@@ -2159,22 +2159,6 @@ for port in range(start, start + limit):
 PY
 }
 
-# True when nothing holds the port, so a restart can return to where the Pilot
-# the installer just stopped was answering.
-web_port_is_free() {
-    "$(_python_bin)" - "$1" <<'PY'
-import socket
-import sys
-
-with socket.socket() as probe:
-    try:
-        probe.bind(("127.0.0.1", int(sys.argv[1])))
-    except (OSError, ValueError):
-        raise SystemExit(1)
-raise SystemExit(0)
-PY
-}
-
 # mms-web binds a fixed port and fails hard when it is taken, so the installer
 # picks a free one instead of letting the last install step die on an OSError.
 find_free_web_port() {
@@ -2250,11 +2234,7 @@ start_mms_web_detached() {
         return 0
     fi
 
-    if [ -n "$STOPPED_PILOT_PORT" ] && web_port_is_free "$STOPPED_PILOT_PORT"; then
-        port="$STOPPED_PILOT_PORT"
-    else
-        port="$(find_free_web_port || true)"
-    fi
+    port="$(find_free_web_port || true)"
     if [ -z "$port" ]; then
         echo "⚠ $(t "找不到可用端口，跳过打开；稍后可手动运行" "No free port found, skipping launch; run it manually later"): mms-web --open"
         return 1
@@ -2519,6 +2499,8 @@ while [[ $# -gt 0 ]]; do
             LAUNCH_WEB_MODE="always"
             ;;
         --keep-running-pilot)
+            # Compatibility no-op: installation never stops a running Pilot
+            # regardless of this flag. Setting it changes nothing.
             KEEP_RUNNING_PILOT=1
             ;;
         --no-launch-web)
@@ -2869,13 +2851,6 @@ if [ -x "$BIN_DIR/mms" ]; then
         echo "$(t "检测到首次使用，启动配置向导..." "First-time setup detected, launching setup wizard...")"
         echo ""
         "$BIN_DIR/mms" || true
-        DID_LAUNCH=1
-    fi
-
-    # Pilot was running before this install, so put it back without asking.
-    if [ "$STOPPED_PILOT" -eq 1 ] && [ "$DID_LAUNCH" -eq 0 ] && [ "$LAUNCH_WEB_MODE" != "never" ]; then
-        echo "• $(t "安装前请 Pilot 退出过，现在重新打开" "Pilot was asked to exit before installing; reopening it now")"
-        start_mms_web_detached || true
         DID_LAUNCH=1
     fi
 

--- a/tests/test_mms_web_install_lock.py
+++ b/tests/test_mms_web_install_lock.py
@@ -17,7 +17,7 @@ def guard(home, command='guard_live_pilot_install', keep_running=0, port=0):
     body=_extract_shell_function_body(text,'guard_live_pilot_install')
     inspect=_extract_shell_function_body(text,'inspect_live_pilot')
     script=('_python_bin() { command -v python3; }\nt() { printf "%s" "$1"; }\n'
-            f'KEEP_RUNNING_PILOT={keep_running}\nSTOPPED_PILOT=0\nMMS_WEB_DEFAULT_PORT={port}\n'
+            f'KEEP_RUNNING_PILOT={keep_running}\nMMS_WEB_DEFAULT_PORT={port}\n'
             'guard_live_pilot_install() {'+body+'\n}\n'
             'inspect_live_pilot() {'+inspect+'\n}\n'+command)
     return subprocess.run(['bash','-ec',script],env={**os.environ,'MMS_HOME':str(home)},capture_output=True,text=True)
@@ -49,7 +49,7 @@ def test_installer_pauses_for_a_live_pilot_without_stopping_it(tmp_path):
     (home/'mms_web/__main__.py').write_text('fixture')
     process=_fake_pilot_server(home)
     try:
-        result=guard(home,command='guard_live_pilot_install\necho "STOPPED=$STOPPED_PILOT"')
+        result=guard(home,command='guard_live_pilot_install')
         assert result.returncode != 0,result.stderr
         assert '没有关闭进程或清理会话' in result.stdout
         assert process.poll() is None
@@ -65,9 +65,42 @@ def test_keep_running_pilot_refuses_and_leaves_the_server_alone(tmp_path):
     try:
         result=guard(home,keep_running=1)
         assert result.returncode!=0 and '没有关闭进程或清理会话' in result.stdout
+        # #223: the flag is a compatibility no-op, so it must not change the
+        # refusal outcome or wording versus the default (keep_running=0) run.
+        assert 'mms web stop' in result.stdout
+        default_result=guard(home,keep_running=0)
+        assert default_result.returncode!=0
+        assert result.stdout==default_result.stdout
         assert process.poll()is None
     finally:
         process.kill();process.wait(timeout=10)
+
+
+def test_refusal_message_names_mms_web_stop(tmp_path):
+    """#223: the refusal must tell the user the real commands to run instead
+    of a vague 'exit the service yourself', since the installer itself never
+    stops a running Pilot."""
+    home=tmp_path/'installation';(home/'mms_web').mkdir(parents=True)
+    (home/'mms_web/__main__.py').write_text('fixture')
+    process=_fake_pilot_server(home)
+    try:
+        result=guard(home)
+        assert result.returncode!=0
+        assert 'mms web stop' in result.stdout
+        assert 'mms web stop --all' in result.stdout
+        assert '更新' in result.stdout
+    finally:
+        process.kill();process.wait(timeout=10)
+
+
+def test_no_stop_and_reopen_debris_remains():
+    """#223: PR #199 stopped the installer from ever stopping a running Pilot,
+    but left the STOPPED_PILOT plumbing and the reopen message behind as dead
+    code. Neither should still be present."""
+    text=(ROOT/'install.sh').read_text()
+    assert 'STOPPED_PILOT' not in text
+    assert '重新打开' not in text
+    assert 'reopening it now' not in text
 
 
 def test_install_lease_outlives_python_and_prevents_concurrent_runtime(tmp_path):
@@ -88,7 +121,7 @@ def test_installer_pauses_for_a_pilot_started_with_the_mms_web_subcommand(tmp_pa
                              stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
     time.sleep(1)
     try:
-        result=guard(home,command='guard_live_pilot_install\necho "STOPPED=$STOPPED_PILOT"')
+        result=guard(home,command='guard_live_pilot_install')
         assert result.returncode != 0,result.stdout+result.stderr
         assert '没有关闭进程或清理会话' in result.stdout
         assert process.poll() is None
@@ -126,7 +159,7 @@ def test_installer_pauses_for_a_pilot_from_another_install_holding_the_port(tmp_
                              stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
     time.sleep(1)
     try:
-        result=guard(home,command='guard_live_pilot_install\necho "STOPPED=$STOPPED_PILOT"',port=port)
+        result=guard(home,command='guard_live_pilot_install',port=port)
         assert result.returncode != 0,result.stdout+result.stderr
         assert '没有关闭进程或清理会话' in result.stdout
         assert process.poll() is None


### PR DESCRIPTION
## Summary

PR #199 (commit 18f74b3c) correctly reversed #163/#183's "ask Pilot to exit, install, reopen it" flow — stopping a running Pilot kills the user's conversations, so that decision stands. But #199 left debris behind:

- Both branches of `guard_live_pilot_install` already `return 1`, so `--keep-running-pilot` was a no-op that still read as if it changed behavior.
- `STOPPED_PILOT` / `STOPPED_PILOT_PORT` were declared but never set, so the port-reuse branch in `start_mms_web_detached` and the "Pilot was asked to exit before installing; reopening it now" block after install were dead code that could never run.
- The refusal message told the user to "exit the service yourself" without naming the actual commands (`mms web stop` / `mms web stop --all`, added in #189) or the in-Pilot Update entry (#195). A user following the README's "re-run the same curl command to upgrade" hit this vague refusal every time, because the installer leaves Pilot running in the background.

## Before -> after

**Before**: refusing message said only "已暂停安装；没有关闭进程或清理会话。请先自行退出后重试" (or, in the lease-holder case, mentioned an unnamed "更新" entry) — no concrete command. `--keep-running-pilot` looked load-bearing. Dead `STOPPED_PILOT*` plumbing and a dead reopen block sat unreachable after every refusal path.

**After**: every refusal (server, session/lease-holder, or a Pilot on the same port from another install) prints the same three lines: nothing was stopped, use Update inside Pilot for a safe upgrade, or run `mms web stop` (`mms web stop --all` for multiple local instances) then re-run the install command. `--keep-running-pilot` is still accepted (help text says so explicitly) but is documented and implemented as a pure compatibility no-op — it does not change the refusal outcome or message.

## Removed dead code

- `STOPPED_PILOT` / `STOPPED_PILOT_PORT` variables (never set after #199).
- The `STOPPED_PILOT_PORT` port-reuse branch inside `start_mms_web_detached`.
- `web_port_is_free()` — its only caller was the block above.
- The "Pilot was asked to exit before installing; reopening it now" block at the end of the install flow.
- Collapsed the two near-duplicate refusal branches in `guard_live_pilot_install` (previously split on `KEEP_RUNNING_PILOT`/whether a stoppable server was found) into one, since both already produced the same "refuse, stop nothing" outcome.

## Docs

- README.md / README.zh-CN.md: the "安装 / 升级" section now says that re-running the install command to upgrade will pause and refuse if Pilot is running, and names `mms web stop` (`--all` for multiple instances) / the in-Pilot Update entry as the way through.
- `docs/AGENT_GUARDRAILS.md` line 147 still describes the old #163/#183 stop-and-reopen behavior and is now stale, but that file is owned by another in-flight branch, so it was intentionally left untouched here. Suggested replacement text (for whoever lands that branch):

  > 安装脚本从不会关闭正在运行的 Pilot（包括占用默认端口的实例）：检测到时会暂停并拒绝安装，不停止进程、不清理会话；提示用户在 Pilot 页面用"更新"，或执行 `mms web stop`（多实例用 `mms web stop --all`）退出后再重新运行安装命令，`--keep-running-pilot` 仅为兼容保留，不改变这个结果。`source|config_root|version` 身份哈希仍用于 `running_mms_web_port` 判断已有实例并直接打开浏览器，避免第二个 8766 实例，但不再服务于"先请退出、装完重开"的流程。

## Tests

- `tests/test_mms_web_install_lock.py`: removed the now-meaningless `STOPPED_PILOT` scaffolding from the test harness; added `test_refusal_message_names_mms_web_stop` (refusal output must contain `mms web stop` and `mms web stop --all` and mention Update `更新`), extended `test_keep_running_pilot_refuses_and_leaves_the_server_alone` to assert `--keep-running-pilot` produces byte-identical refusal output to the default run, and added `test_no_stop_and_reopen_debris_remains` (no `STOPPED_PILOT` symbol or reopen text left in `install.sh`).

## Verification

- `bash -n install.sh` — OK
- `python3 -m pytest -q -p no:cacheprovider tests/test_mms_web_install_lock.py tests/test_install_script_paths.py tests/test_install_script*.py` — 78 passed
- `python3 scripts/ci_pytest_regression.py --base origin/dev` — base: 95 failing of 2248, head: 96 failing of 2250, 1 candidate reran and cleared → "No test that passes on the base commit fails here." (exit 0)
- `bash install.sh --dry-run --no-launch-web --no-shell-rc` — exits 0, no error, prints the standard dry-run report; `git status --short` unchanged apart from this PR's own edits

https://claude.ai/code/session_01Q7g7jpHK2ikM4mWcpLuWKX
