### PR TITLE
test: reconcile the tests broken by #199/#204/#205 with the mms-next contract (#222)

### DIFF
--- a/mms_core.py
+++ b/mms_core.py
@@ -15917,7 +15917,9 @@ def _handle_session_info(session_id, cli_name):
 
 
 def _session_gateway_roots(cli_name):
-    real_home = resolve_real_user_home()
+    # Sessions are created under the selected config root (MMS_CONFIG_ROOT honoured),
+    # so prune must look at that same root instead of always at the real HOME one.
+    config_root = resolve_mms_config_dir()
     gateway_names = []
     if cli_name in {"all", "claude"}:
         gateway_names.append(("claude", "claude-gateway"))
@@ -15926,7 +15928,7 @@ def _session_gateway_roots(cli_name):
     if cli_name in {"all", "opencode"}:
         gateway_names.append(("opencode", "opencode-gateway"))
     return [
-        (cli, os.path.join(real_home, ".config", "mms-next", gateway_name, "s"))
+        (cli, os.path.join(config_root, gateway_name, "s"))
         for cli, gateway_name in gateway_names
     ]
 
@@ -16124,9 +16126,9 @@ def _codex_resume_roots():
 
     for env_name in ("MMS_CODEX_RESUME_WRITEBACK_ROOT", "CODEX_HOME"):
         add(os.environ.get(env_name))
-    real_home = resolve_real_user_home()
-    add(os.path.join(real_home, ".config", "mms-next", "codex-gateway", ".codex"))
-    add(os.path.join(real_home, ".codex"))
+    # Same root the gateway session was created under, not a hard-coded real-HOME one.
+    add(os.path.join(resolve_mms_config_dir(), "codex-gateway", ".codex"))
+    add(os.path.join(resolve_real_user_home(), ".codex"))
     return roots
 
 

--- a/mms_session_catalog.py
+++ b/mms_session_catalog.py
@@ -47,6 +47,14 @@ def _dedupe_paths(paths: Iterable[Path | str]) -> list[Path]:
     return result
 
 
+def _config_root() -> Path:
+    """The single MMS config root for this process (honours MMS_CONFIG_ROOT)."""
+    try:
+        return Path(resolve_mms_config_dir())
+    except Exception:
+        return _real_user_home() / ".config" / "mms-next"
+
+
 def claude_project_roots() -> list[Path]:
     home = _real_user_home()
     roots: list[Path] = []
@@ -73,32 +81,22 @@ def codex_roots() -> list[Path]:
         value = str(os.environ.get(env_name) or "").strip()
         if value:
             roots.append(Path(value))
+    config_root = _config_root()
     roots.extend(
         [
-            home / ".config" / "mms-next" / "codex-gateway" / ".codex",
+            config_root / "codex-gateway" / ".codex",
             home / ".codex",
         ]
     )
-    roots.extend((home / ".config" / "mms-next" / "codex-gateway" / "s").glob("*/.codex"))
-    roots.extend((home / ".config" / "mms-next" / "accounts").glob("*/.codex"))
-    roots.extend((home / ".config" / "mms-next" / "accounts").glob("*/s/*/.codex"))
+    roots.extend((config_root / "codex-gateway" / "s").glob("*/.codex"))
+    roots.extend((config_root / "accounts").glob("*/.codex"))
+    roots.extend((config_root / "accounts").glob("*/s/*/.codex"))
     return [path for path in _dedupe_paths(roots) if path.exists()]
 
 
 def pi_roots() -> list[Path]:
     """Return current Pi history roots without reading auth state."""
-    home = _real_user_home()
-    roots: list[Path] = []
-    try:
-        roots.append(Path(resolve_mms_config_dir()) / "pi-gateway")
-    except Exception:
-        pass
-    roots.extend(
-        [
-            home / ".config" / "mms-next" / "pi-gateway",
-            home / ".config" / "mms-next" / "pi-gateway",
-        ]
-    )
+    roots: list[Path] = [_config_root() / "pi-gateway"]
     return [path for path in _dedupe_paths(roots) if path.exists()]
 
 

--- a/tests/test_agy_launcher.py
+++ b/tests/test_agy_launcher.py
@@ -186,7 +186,10 @@ def test_agy_home_context_requires_isolated_session(tmp_path):
 
     assert result["session_home"] == str(session_home)
     assert result["xdg_config_home"] == str(session_home / ".config")
-    assert result["config_root"] == str(real_home / ".config" / "mms")
+    # `~/.config/mms/accounts/<id>/s/<pid>` is still a runtime session HOME, but the
+    # single config root it unwinds to is `~/.config/mms-next` (docs/AGENT_GUARDRAILS.md
+    # "Single Config Root"), never the retired `~/.config/mms`.
+    assert result["config_root"] == str(real_home / ".config" / "mms-next")
 
 
 def test_account_env_prepares_agy_isolated_home(monkeypatch, tmp_path):

--- a/tests/test_claude_hardening_regressions.py
+++ b/tests/test_claude_hardening_regressions.py
@@ -22,6 +22,26 @@ def _write_executable(path: Path, text: str = "#!/bin/sh\nexit 0\n") -> Path:
     return path
 
 
+def _use_real_home_config_root(monkeypatch, real_home):
+    """Make the single config root derive from this test's real HOME.
+
+    Precedence in mms_state_io.resolve_mms_config_dir, which every launcher path
+    goes through: MMS_CONFIG_ROOT > MMS_CONFIG_DIR > XDG_CONFIG_HOME > one of
+    MMS_REAL_HOME / REAL_HOME / ORIGINAL_HOME / HOME. tests/conftest.py parks
+    XDG_CONFIG_HOME in one shared temp dir, so without dropping it every gateway
+    test would share (and pollute) the same codex-gateway.
+    """
+    monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
+    monkeypatch.delenv("MMS_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("MMS_REAL_HOME", str(real_home))
+    # Pointing the real HOME at a fixture also makes the gateway dir look like it
+    # lives under the real HOME, which is what gates the app-server hook-hash
+    # refresh. A unit test must not shell out to the installed Codex binary.
+    monkeypatch.setenv("MMS_CODEX_HOOK_TRUST_REFRESH", "0")
+    return Path(real_home) / ".config" / "mms-next"
+
+
 def test_build_claude_session_settings_only_inherits_allowlisted_keys(monkeypatch):
     import mms_launchers
 
@@ -1106,11 +1126,12 @@ def test_build_codex_session_hooks_removes_retired_caveman_hooks(monkeypatch, tm
         for item in group["hooks"]
     ]
     assert "/tmp/notify.sh" in enabled_commands
-    caveman_commands = [command for command in enabled_commands if "caveman-activate.js" in command]
-    assert len(caveman_commands) == 1
-    assert "CAVEMAN_DEFAULT_MODE=lite" in caveman_commands[0]
-    assert "CAVEMAN_HOOK_EVENT=SessionStart" in caveman_commands[0]
-    assert f'node "{caveman_root / "hooks" / "caveman-activate.js"}"' in caveman_commands[0]
+    # Caveman is retired globally (_resolve_caveman_root returns ""), so the legacy
+    # enable_caveman=True toggle must still inject nothing, and the inherited global
+    # caveman hook must be filtered out on both paths.
+    assert [command for command in enabled_commands if "caveman" in command.lower()] == []
+    assert [command for command in disabled_commands if "caveman" in command.lower()] == []
+    assert (caveman_root / "hooks" / "caveman-activate.js").exists()
     assert "PreToolUse" not in enabled["hooks"]
 
 
@@ -1367,10 +1388,29 @@ def test_mms_caveman_legacy_helpers_are_inert(tmp_path):
     assert mms_launchers._runtime_caveman_enabled({"caveman_mode": "enable"}) is False
     assert mms_launchers._runtime_caveman_level({"caveman_level": "lite"}) == "light"
     assert mms_launchers._resolve_caveman_root() == ""
-    assert mms_launchers._configure_claude_caveman_hooks(
-        {"SessionStart": [{"hooks": [{"type": "command", "command": "echo caveman"}]}]},
+    inherited_caveman_hook = (
+        "CAVEMAN_HOOK_COMPACT=1 CAVEMAN_HOOK_EVENT=SessionStart "
+        f'node "{hooks_dir / "caveman-activate.js"}"'
+    )
+    rendered = mms_launchers._configure_claude_caveman_hooks(
+        {
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "/tmp/keep.sh"},
+                        {"type": "command", "command": inherited_caveman_hook},
+                    ]
+                }
+            ]
+        },
         enable_caveman=True,
-    )["SessionStart"] == []
+    )
+    assert [hook["command"] for group in rendered["SessionStart"] for hook in group["hooks"]] == ["/tmp/keep.sh"]
+    # An all-caveman group leaves the event with nothing to run at all.
+    assert mms_launchers._configure_claude_caveman_hooks(
+        {"SessionStart": [{"hooks": [{"type": "command", "command": inherited_caveman_hook}]}]},
+        enable_caveman=True,
+    ) == {}
 
 
 def test_map_auto_index_hook_keeps_codex_stdout_empty(tmp_path):
@@ -1854,6 +1894,7 @@ def test_codex_gateway_env_refreshes_durable_hook_trust_cache_from_sibling(monke
         "_real_user_path",
         lambda *parts: str(real_home.joinpath(*parts)),
     )
+    _use_real_home_config_root(monkeypatch, real_home)
 
     mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime", "nsr_mode": "disable"},
@@ -1914,6 +1955,7 @@ def test_codex_gateway_env_reuses_stable_codex_home_for_hook_trust(monkeypatch, 
     monkeypatch.setattr(mms_launchers, "_install_session_packet_env", lambda *args, **kwargs: None)
     monkeypatch.setattr(mms_launchers, "_build_codex_session_hooks", lambda *args, **kwargs: hooks_payload)
     monkeypatch.setattr(mms_launchers, "_real_user_path", lambda *parts: str(real_home.joinpath(*parts)))
+    _use_real_home_config_root(monkeypatch, real_home)
 
     env1 = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime", "nsr_mode": "disable"},
@@ -1944,7 +1986,7 @@ def test_codex_gateway_env_reuses_stable_codex_home_for_hook_trust(monkeypatch, 
     assert "/s/2222/.codex/hooks.json:session_start:0:0" not in target_config
 
 
-def test_overlay_caveman_session_entries_merges_session_and_caveman_assets(monkeypatch, tmp_path):
+def test_overlay_caveman_session_entries_no_longer_exposes_caveman_assets(monkeypatch, tmp_path):
     import mms_launchers
 
     session_home = tmp_path / "session"
@@ -1969,18 +2011,21 @@ def test_overlay_caveman_session_entries_merges_session_and_caveman_assets(monke
 
     monkeypatch.setenv("MMS_CAVEMAN_ROOT", str(caveman_root))
 
-    mms_launchers._overlay_caveman_session_entries(
+    assert mms_launchers._overlay_caveman_session_entries(
         str(parent_dir),
         str(session_home),
         enable_caveman=True,
-    )
+    ) is None
 
+    # Caveman is retired: the session keeps the untouched shared asset links and the
+    # legacy enable_caveman=True toggle adds nothing, not even an overlay dir.
     assert os.path.islink(parent_dir / "commands")
     assert os.path.islink(parent_dir / "skills")
-    assert os.path.islink(parent_dir / "commands" / "keep.toml")
-    assert os.path.islink(parent_dir / "commands" / "caveman.toml")
-    assert os.path.islink(parent_dir / "skills" / "keep-skill")
-    assert os.path.islink(parent_dir / "skills" / "caveman")
+    assert (parent_dir / "commands" / "keep.toml").is_file()
+    assert (parent_dir / "skills" / "keep-skill").is_dir()
+    assert not (parent_dir / "commands" / "caveman.toml").exists()
+    assert not (parent_dir / "skills" / "caveman").exists()
+    assert not (session_home / ".mms-caveman-overlay").exists()
 
 
 def _session_skill_dir(tmp_path, cli_dir):
@@ -2055,7 +2100,7 @@ def test_overlay_agent_browser_session_entries_no_longer_exposes_a_separate_skil
     assert mms_launchers._resolve_agent_browser_root() == str(agent_browser_root)
 
 
-def test_codex_gateway_env_materializes_session_caveman_hooks_and_assets(monkeypatch, tmp_path):
+def test_codex_gateway_env_materializes_session_hooks_and_assets_without_caveman(monkeypatch, tmp_path):
     import mms_launchers
 
     real_home = tmp_path / "real-home"
@@ -2137,7 +2182,6 @@ def test_codex_gateway_env_materializes_session_caveman_hooks_and_assets(monkeyp
         "_real_user_path",
         lambda *parts: str(real_home.joinpath(*parts)),
     )
-
     env = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime", "caveman_mode": "enable"},
         "https://relay.example.com",
@@ -2152,14 +2196,15 @@ def test_codex_gateway_env_materializes_session_caveman_hooks_and_assets(monkeyp
         for item in group["hooks"]
     ]
     assert "/tmp/notify.sh" in commands
-    caveman_commands = [command for command in commands if "caveman-activate.js" in command]
-    assert caveman_commands == []
+    assert [command for command in commands if "caveman" in command.lower()] == []
+    # The real ~/.codex assets stay reachable from the stable CODEX_HOME; caveman is
+    # retired, so nothing from MMS_CAVEMAN_ROOT is merged in.
     assert os.path.islink(session_codex / "commands")
     assert os.path.islink(session_codex / "skills")
-    assert os.path.islink(session_codex / "commands" / "keep.toml")
-    assert os.path.islink(session_codex / "commands" / "caveman.toml")
+    assert (session_codex / "commands" / "keep.toml").is_file()
     assert os.path.islink(session_codex / "skills" / "keep-skill")
-    assert os.path.islink(session_codex / "skills" / "caveman")
+    assert not (session_codex / "commands" / "caveman.toml").exists()
+    assert not (session_codex / "skills" / "caveman").exists()
     packet = json.loads(Path(env["MMS_SESSION_PACKET_JSON"]).read_text(encoding="utf-8"))
     assert packet["cli"] == "codex"
     assert packet["model"]["primary"] == "gpt-5.4"
@@ -2167,7 +2212,7 @@ def test_codex_gateway_env_materializes_session_caveman_hooks_and_assets(monkeyp
     assert env["MMS_SESSION_PACKET_FORMAT"] == "toon"
 
 
-def test_codex_gateway_env_materializes_session_web_access_skill(monkeypatch, tmp_path):
+def test_codex_gateway_env_no_longer_materializes_a_separate_web_access_skill(monkeypatch, tmp_path):
     import mms_launchers
 
     real_home = tmp_path / "real-home"
@@ -2193,6 +2238,7 @@ def test_codex_gateway_env_materializes_session_web_access_skill(monkeypatch, tm
         "_real_user_path",
         lambda *parts: str(real_home.joinpath(*parts)),
     )
+    _use_real_home_config_root(monkeypatch, real_home)
 
     env = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime"},
@@ -2200,9 +2246,12 @@ def test_codex_gateway_env_materializes_session_web_access_skill(monkeypatch, tm
     )
 
     session_codex = Path(env["CODEX_HOME"])
+    # web-access is a Weber backend now, not a skill of its own: the root still
+    # resolves, but the session never exposes it as a separate skill entry.
     assert os.path.islink(session_codex / "skills" / "keep-skill")
-    assert os.path.islink(session_codex / "skills" / "web-access")
-    assert (session_codex / "skills" / "web-access" / "SKILL.md").read_text(encoding="utf-8") == "# web-access\n"
+    assert not (session_codex / "skills" / "web-access").exists()
+    assert not (session_codex / "skills" / "web-access").is_symlink()
+    assert mms_launchers._resolve_web_access_root() == str(web_access_root)
 
 
 def test_codex_gateway_env_seeds_plugin_marketplace_cache(monkeypatch, tmp_path):
@@ -2237,6 +2286,7 @@ def test_codex_gateway_env_seeds_plugin_marketplace_cache(monkeypatch, tmp_path)
         "_real_user_path",
         lambda *parts: str(real_home.joinpath(*parts)),
     )
+    _use_real_home_config_root(monkeypatch, real_home)
 
     env = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime"},
@@ -2253,7 +2303,7 @@ def test_codex_gateway_env_seeds_plugin_marketplace_cache(monkeypatch, tmp_path)
     assert not (session_tmp / "diagrams").exists()
 
 
-def test_codex_gateway_env_materializes_session_agent_browser_skill(monkeypatch, tmp_path):
+def test_codex_gateway_env_no_longer_materializes_a_separate_agent_browser_skill(monkeypatch, tmp_path):
     import mms_launchers
 
     real_home = tmp_path / "real-home"
@@ -2280,6 +2330,7 @@ def test_codex_gateway_env_materializes_session_agent_browser_skill(monkeypatch,
         "_real_user_path",
         lambda *parts: str(real_home.joinpath(*parts)),
     )
+    _use_real_home_config_root(monkeypatch, real_home)
 
     env = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime"},
@@ -2287,9 +2338,11 @@ def test_codex_gateway_env_materializes_session_agent_browser_skill(monkeypatch,
     )
 
     session_codex = Path(env["CODEX_HOME"])
+    # agent-browser is a Weber backend now, not a skill of its own.
     assert os.path.islink(session_codex / "skills" / "keep-skill")
-    assert os.path.islink(session_codex / "skills" / "agent-browser")
-    assert (session_codex / "skills" / "agent-browser" / "SKILL.md").read_text(encoding="utf-8") == "# agent-browser\n"
+    assert not (session_codex / "skills" / "agent-browser").exists()
+    assert not (session_codex / "skills" / "agent-browser").is_symlink()
+    assert mms_launchers._resolve_agent_browser_root() == str(agent_browser_root)
 
 
 def test_overlay_toon_session_entries_merges_existing_session_skills(monkeypatch, tmp_path):
@@ -2438,6 +2491,7 @@ def test_codex_gateway_env_materializes_session_toon_skill_and_wrapper(monkeypat
     monkeypatch.setattr(mms_launchers, "_real_user_path", lambda *parts: str(real_home.joinpath(*parts)))
     monkeypatch.setattr(mms_launchers, "_mms_toon_script_path", lambda: str(toon_script))
     monkeypatch.setattr(mms_launchers, "_SESSION_REAL_HOME_WRAPPER_COMMANDS", ())
+    _use_real_home_config_root(monkeypatch, real_home)
 
     env = mms_launchers._codex_gateway_env(
         {"id": "relay-a", "api_key": "sk-runtime"},
@@ -3533,10 +3587,11 @@ def test_claude_guard_runtime_uses_gateway_home_for_api_key(monkeypatch, tmp_pat
         "_real_user_path",
         lambda *parts: str(tmp_path.joinpath(*parts)),
     )
+    config_root = _use_real_home_config_root(monkeypatch, tmp_path)
 
     result = mms_launchers._claude_guard_runtime({"id": "relay-a", "auth_mode": "api_key"})
 
-    assert result["home_dir"] == str(tmp_path / ".config" / "mms" / "claude-gateway")
+    assert os.path.realpath(result["home_dir"]) == os.path.realpath(str(config_root / "claude-gateway"))
 
 
 def test_launch_cli_enforces_network_guard_for_sensitive_claude_api_key_bypass(monkeypatch):

--- a/tests/test_command_smoke.py
+++ b/tests/test_command_smoke.py
@@ -94,8 +94,9 @@ def test_handle_session_command_initializes_rich_before_listing(monkeypatch):
 def test_handle_session_prune_dry_run_lists_stale_gateway_sessions(monkeypatch, tmp_path):
     import mms_core
 
-    real_home = tmp_path / "home"
-    stale = real_home / ".config" / "mms" / "claude-gateway" / "s" / "999999"
+    # Gateway sessions live under the single config root, so prune scans that root.
+    config_root = tmp_path / "home" / ".config" / "mms-next"
+    stale = config_root / "claude-gateway" / "s" / "999999"
     stale.mkdir(parents=True)
     (stale / "payload.txt").write_text("stale session\n", encoding="utf-8")
     console = _CollectingConsole()
@@ -108,7 +109,7 @@ def test_handle_session_prune_dry_run_lists_stale_gateway_sessions(monkeypatch, 
     monkeypatch.setattr(mms_core, "Text", None)
     monkeypatch.setattr(mms_core, "_ensure_rich", _fake_ensure_rich)
     monkeypatch.setattr(mms_core, "console", console)
-    monkeypatch.setattr(mms_core, "resolve_real_user_home", lambda: str(real_home))
+    monkeypatch.setenv("MMS_CONFIG_ROOT", str(config_root))
 
     mms_core.handle_session_command(["prune", "--cli", "claude"])
 
@@ -117,6 +118,33 @@ def test_handle_session_prune_dry_run_lists_stale_gateway_sessions(monkeypatch, 
     assert tables[0].rows[0][0][0] == "claude"
     assert tables[0].rows[0][0][1] == "999999"
     assert stale.exists()
+
+
+def test_session_gateway_roots_follow_explicit_config_root(monkeypatch, tmp_path):
+    """Pilot 用 --config-root 起来时，prune/backfill 必须跟着同一个 root 走。"""
+    import mms_core
+
+    pilot_root = tmp_path / "pilot-root"
+    real_home = tmp_path / "home"
+    (real_home / ".config" / "mms-next" / "claude-gateway" / "s").mkdir(parents=True)
+    (pilot_root / "claude-gateway" / "s").mkdir(parents=True)
+    monkeypatch.setenv("MMS_REAL_HOME", str(real_home))
+    monkeypatch.setenv("MMS_CONFIG_ROOT", str(pilot_root))
+
+    roots = dict(mms_core._session_gateway_roots("all"))
+    resume_roots = mms_core._codex_resume_roots()
+
+    assert roots["claude"] == str(pilot_root / "claude-gateway" / "s")
+    assert roots["codex"] == str(pilot_root / "codex-gateway" / "s")
+    assert str(pilot_root / "codex-gateway" / ".codex") in resume_roots
+    assert all(str(real_home / ".config" / "mms-next") not in item for item in resume_roots)
+
+    monkeypatch.delenv("MMS_CONFIG_ROOT")
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    fallback_roots = dict(mms_core._session_gateway_roots("all"))
+
+    assert fallback_roots["claude"] == str(real_home / ".config" / "mms-next" / "claude-gateway" / "s")
 
 
 def test_select_provider_for_models_initializes_rich_before_render(monkeypatch):

--- a/tests/test_fake_upstream.py
+++ b/tests/test_fake_upstream.py
@@ -18,7 +18,7 @@ def test_fake_upstream_runtime_httpx_request_and_log(monkeypatch, tmp_path):
     body = response.json()
     assert any(item["id"] == "claude-sonnet-4-6" for item in body["data"])
 
-    log_path = tmp_path / ".config" / "mms" / "fake-upstream" / "requests.jsonl"
+    log_path = tmp_path / ".config" / "mms-next" / "fake-upstream" / "requests.jsonl"
     assert log_path.exists()
     assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
     rows = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]

--- a/tests/test_legacy_surface_cleanup.py
+++ b/tests/test_legacy_surface_cleanup.py
@@ -201,44 +201,42 @@ def test_rescue_fallback_candidates_use_recent_models_before_config(monkeypatch)
 def test_rescue_fallback_candidates_include_routed_models(monkeypatch, tmp_path: Path) -> None:
     import mms_core
 
-    generated = tmp_path / "generated"
-    generated.mkdir()
-    (generated / "model-routes.json").write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "routes": {
-                    "failed-model": {
-                        "primary": {
-                            "provider_id": "broken",
-                            "openai_base_url": "https://broken.example/v1",
-                            "api_key": "sk-test-failed",
-                            "model_id": "failed-model",
-                        },
-                        "fallbacks": [],
+    # Route candidates only come from the verified latest-approved bundle: every config
+    # root is a preview root now (single config root, MMS_CONFIG_ROOT_MODE ignored).
+    _write_latest_approved_router_manifest(
+        tmp_path,
+        router_payload={
+            "version": 1,
+            "routes": {
+                "failed-model": {
+                    "primary": {
+                        "provider_id": "broken",
+                        "openai_base_url": "https://broken.example/v1",
+                        "api_key": "sk-test-failed",
+                        "model_id": "failed-model",
                     },
-                    "deepseek-v4-flash": {
-                        "primary": {
-                            "provider_id": "deepseek",
-                            "openai_base_url": "https://deepseek.example/v1",
-                            "api_key": "sk-test-deepseek",
-                            "model_id": "deepseek-v4-flash",
-                        },
-                        "fallbacks": [],
-                    },
-                    "no-openai-route": {
-                        "primary": {
-                            "provider_id": "anthropic-only",
-                            "anthropic_base_url": "https://anthropic.example",
-                            "api_key": "sk-test-anthropic",
-                            "model_id": "no-openai-route",
-                        },
-                        "fallbacks": [],
-                    },
+                    "fallbacks": [],
                 },
-            }
-        ),
-        encoding="utf-8",
+                "deepseek-v4-flash": {
+                    "primary": {
+                        "provider_id": "deepseek",
+                        "openai_base_url": "https://deepseek.example/v1",
+                        "api_key": "sk-test-deepseek",
+                        "model_id": "deepseek-v4-flash",
+                    },
+                    "fallbacks": [],
+                },
+                "no-openai-route": {
+                    "primary": {
+                        "provider_id": "anthropic-only",
+                        "anthropic_base_url": "https://anthropic.example",
+                        "api_key": "sk-test-anthropic",
+                        "model_id": "no-openai-route",
+                    },
+                    "fallbacks": [],
+                },
+            },
+        },
     )
     monkeypatch.setattr(mms_core, "CONFIG_DIR", str(tmp_path))
     monkeypatch.setattr(mms_core, "_load_usage_stats", lambda: {"last_by_cli": {}, "sources": {}})

--- a/tests/test_mms_context.py
+++ b/tests/test_mms_context.py
@@ -86,7 +86,9 @@ def test_mms_context_gain_discovers_recent_session_store_when_cwd_store_empty(mo
     home = tmp_path / "home"
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
-    session_store = home / ".config" / "mms" / "codex-gateway" / "s" / "123" / ".mms" / "context-store"
+    # Session stores live under the single config root (~/.config/mms-next), which is
+    # also the only place `mms context gain` auto-discovery scans.
+    session_store = home / ".config" / "mms-next" / "codex-gateway" / "s" / "123" / ".mms" / "context-store"
     for key in ("MMS_CONTEXT_DIR", "MMS_SESSION_HOME", "MMS_REAL_HOME", "REAL_HOME", "ORIGINAL_HOME"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("HOME", str(home))
@@ -386,7 +388,8 @@ def test_overlay_auto_github_contributor_session_entries_respects_disabled_skill
     assert not (parent_dir / "commands" / "auto-contribute.md").is_symlink()
 
 
-def test_resolve_token_saver_root_prefers_bundled_vendor(monkeypatch, tmp_path):
+def test_resolve_token_saver_root_is_retired(monkeypatch, tmp_path):
+    """token-saver 已从产品退休：即便 bundled/shared 资产都在，也不再被发现。"""
     home = tmp_path / "home"
     install_root = tmp_path / "mms-install"
     bundled_root = install_root / "vendor" / "token-saver"
@@ -401,7 +404,7 @@ def test_resolve_token_saver_root_prefers_bundled_vendor(monkeypatch, tmp_path):
     mms_launchers = _import_mms_launchers(monkeypatch, tmp_path)
     monkeypatch.setattr(mms_launchers, "__file__", str(install_root / "mms_launchers.py"))
 
-    assert Path(mms_launchers._resolve_token_saver_root()) == bundled_root
+    assert mms_launchers._resolve_token_saver_root() == ""
 
 
 def test_resolve_codegraph_root_prefers_bundled_vendor(monkeypatch, tmp_path):

--- a/tests/test_mms_rescue.py
+++ b/tests/test_mms_rescue.py
@@ -189,19 +189,19 @@ def test_rescue_config_root_uses_real_home_not_gateway_session(monkeypatch, tmp_
     from mms_rescue import resolve_real_mms_config_dir
 
     real_home = tmp_path / "home"
-    session_home = real_home / ".config" / "mms" / "codex-gateway" / "s" / "12345"
+    session_home = real_home / ".config" / "mms-next" / "codex-gateway" / "s" / "12345"
     monkeypatch.delenv("MMS_REAL_HOME", raising=False)
     monkeypatch.delenv("REAL_HOME", raising=False)
     monkeypatch.delenv("ORIGINAL_HOME", raising=False)
     monkeypatch.setenv("HOME", str(session_home))
 
-    assert resolve_real_mms_config_dir() == real_home / ".config" / "mms"
+    assert resolve_real_mms_config_dir() == real_home / ".config" / "mms-next"
 
 
 def test_rescue_config_root_prefers_real_home_env(tmp_path):
     from mms_rescue import resolve_real_mms_config_dir
 
-    session_home = tmp_path / ".config" / "mms" / "codex-gateway" / "s" / "12345"
+    session_home = tmp_path / ".config" / "mms-next" / "codex-gateway" / "s" / "12345"
     mms_real = tmp_path / "mms-real"
     real = tmp_path / "real"
     original = tmp_path / "original"
@@ -211,16 +211,16 @@ def test_rescue_config_root_prefers_real_home_env(tmp_path):
         "MMS_REAL_HOME": str(mms_real),
         "REAL_HOME": str(real),
         "ORIGINAL_HOME": str(original),
-    }) == mms_real / ".config" / "mms"
+    }) == mms_real / ".config" / "mms-next"
     assert resolve_real_mms_config_dir({
         "HOME": str(session_home),
         "REAL_HOME": str(real),
         "ORIGINAL_HOME": str(original),
-    }) == real / ".config" / "mms"
+    }) == real / ".config" / "mms-next"
     assert resolve_real_mms_config_dir({
         "HOME": str(session_home),
         "ORIGINAL_HOME": str(original),
-    }) == original / ".config" / "mms"
+    }) == original / ".config" / "mms-next"
 
 
 def test_bridge_rescue_config_root_failure_does_not_fallback_to_stable(monkeypatch, tmp_path):
@@ -524,27 +524,26 @@ def test_responses_proxy_hot_fallback_prefers_anthropic_messages_for_deepseek(mo
 
     repo = tmp_path / "repo"
     config_root = tmp_path / "mms-config"
-    (config_root / "generated").mkdir(parents=True)
     repo.mkdir()
-    (config_root / "generated" / "model-routes.json").write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "routes": {
-                    "deepseek-v4-flash": {
-                        "primary": {
-                            "provider_id": "newapi-deepseek",
-                            "anthropic_base_url": "https://deepseek.example",
-                            "openai_base_url": "https://deepseek.example",
-                            "api_key": "sk-deepseek-test",
-                            "model_id": "deepseek-v4-flash",
-                        },
-                        "fallbacks": [],
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
+    # Routes only come from the verified latest-approved bundle: every config root is
+    # a preview root now (single config root, MMS_CONFIG_ROOT_MODE ignored).
+    _write_latest_approved_router_manifest(
+        config_root,
+        router_payload={
+            "version": 1,
+            "routes": {
+                "deepseek-v4-flash": {
+                    "primary": {
+                        "provider_id": "newapi-deepseek",
+                        "anthropic_base_url": "https://deepseek.example",
+                        "openai_base_url": "https://deepseek.example",
+                        "api_key": "sk-deepseek-test",
+                        "model_id": "deepseek-v4-flash",
+                    },
+                    "fallbacks": [],
+                }
+            },
+        },
     )
 
     class FakeResponse:
@@ -628,28 +627,27 @@ def test_responses_proxy_hot_fallback_uses_messages_for_cache_sensitive_openai_o
 
     repo = tmp_path / "repo"
     config_root = tmp_path / "mms-config"
-    (config_root / "generated").mkdir(parents=True)
     repo.mkdir()
-    (config_root / "generated" / "model-routes.json").write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "routes": {
-                    "deepseek-v4-flash": {
-                        "primary": {
-                            "provider_id": "newapi-deepseek",
-                            "openai_base_url": "https://deepseek.example/v1",
-                            "api_key": "sk-deepseek-test",
-                            "model_id": "deepseek-v4-flash",
-                            "protocol": "openai_chat_completions",
-                            "cache_sensitive_transport": True,
-                        },
-                        "fallbacks": [],
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
+    # Routes only come from the verified latest-approved bundle: every config root is
+    # a preview root now (single config root, MMS_CONFIG_ROOT_MODE ignored).
+    _write_latest_approved_router_manifest(
+        config_root,
+        router_payload={
+            "version": 1,
+            "routes": {
+                "deepseek-v4-flash": {
+                    "primary": {
+                        "provider_id": "newapi-deepseek",
+                        "openai_base_url": "https://deepseek.example/v1",
+                        "api_key": "sk-deepseek-test",
+                        "model_id": "deepseek-v4-flash",
+                        "protocol": "openai_chat_completions",
+                        "cache_sensitive_transport": True,
+                    },
+                    "fallbacks": [],
+                }
+            },
+        },
     )
 
     class FakeResponse:
@@ -1110,26 +1108,25 @@ def test_generate_rescue_summary_uses_anthropic_messages_route(monkeypatch, tmp_
 
     config_root = tmp_path / "mms-config"
     rescue_dir = tmp_path / "repo" / ".mms" / "rescue" / "event"
-    (config_root / "generated").mkdir(parents=True)
-    (config_root / "generated" / "model-routes.json").write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "routes": {
-                    "deepseek-v4-flash": {
-                        "primary": {
-                            "provider_id": "newapi-deepseek",
-                            "anthropic_base_url": "https://deepseek.example",
-                            "openai_base_url": "https://deepseek.example/v1",
-                            "api_key": "sk-deepseek-test",
-                            "model_id": "deepseek-v4-flash",
-                        },
-                        "fallbacks": [],
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
+    # Routes only come from the verified latest-approved bundle: every config root is
+    # a preview root now (single config root, MMS_CONFIG_ROOT_MODE ignored).
+    _write_latest_approved_router_manifest(
+        config_root,
+        router_payload={
+            "version": 1,
+            "routes": {
+                "deepseek-v4-flash": {
+                    "primary": {
+                        "provider_id": "newapi-deepseek",
+                        "anthropic_base_url": "https://deepseek.example",
+                        "openai_base_url": "https://deepseek.example/v1",
+                        "api_key": "sk-deepseek-test",
+                        "model_id": "deepseek-v4-flash",
+                    },
+                    "fallbacks": [],
+                }
+            },
+        },
     )
     calls = []
 

--- a/tests/test_opencode_launcher.py
+++ b/tests/test_opencode_launcher.py
@@ -401,7 +401,9 @@ def test_opencode_kimi_k3_uses_profile_effort_not_stale_generic_thinking(monkeyp
     )
     model_config = payload["provider"]["mms"]["models"]["k3"]
 
-    assert model_config["limit"]["context"] == 262_144
+    # kimi-code 的 profile calibration 是 1_048_576（PR #209），
+    # 仍然压过上面 stub 出来的 1_000_000 generic policy。
+    assert model_config["limit"]["context"] == 1_048_576
     assert model_config["options"] == {"reasoningEffort": "max"}
     assert "thinking" not in json.dumps(model_config)
 

--- a/tests/test_pi_launcher.py
+++ b/tests/test_pi_launcher.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import textwrap
 
@@ -165,7 +166,37 @@ def test_pi_skill_overlay_keeps_project_skill_over_global_duplicate(monkeypatch,
     assert (overlay / "global-only").resolve() == global_only_skill
 
 
-def test_pi_wrapper_prefers_a_cached_pi_binary(tmp_path):
+def _pi_wrapper_env(tmp_path, cache_dir, *, bin_dir=None, **extra):
+    """A PATH with node/npm/npx but no installed pi anywhere.
+
+    The wrapper prefers an installed Pi over its npx cache (#205), and on a
+    developer machine both `command -v pi` and `npm prefix -g` find the real
+    one. Inheriting os.environ therefore made these cache tests exec the real
+    pi instead. npm_config_prefix points at an empty prefix so `npm prefix -g`
+    answers honestly that pi is not installed there.
+    """
+    bin_dir = Path(bin_dir) if bin_dir else (tmp_path / "bin")
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("node", "npm", "npx"):
+        target = bin_dir / name
+        real = shutil.which(name)
+        if real and not target.exists():
+            target.symlink_to(real)
+    npm_prefix = tmp_path / "npm-prefix"
+    (npm_prefix / "bin").mkdir(parents=True, exist_ok=True)
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    env = {
+        "PATH": os.pathsep.join([str(bin_dir), "/usr/bin", "/bin"]),
+        "HOME": str(home),
+        "npm_config_prefix": str(npm_prefix),
+        "MMS_PI_NPX_CACHE": str(cache_dir),
+    }
+    env.update(extra)
+    assert shutil.which("pi", path=env["PATH"]) is None
+    return env
+
+def test_pi_wrapper_uses_the_cache_when_no_pi_is_installed(tmp_path):
     wrapper = Path(__file__).resolve().parents[1] / "scripts" / "pi-cli-wrapper.sh"
     cache_dir = tmp_path / "pi-npx"
     cached_pi = cache_dir / "_npx" / "cached" / "node_modules" / ".bin" / "pi"
@@ -182,7 +213,7 @@ def test_pi_wrapper_prefers_a_cached_pi_binary(tmp_path):
         check=True,
         capture_output=True,
         text=True,
-        env={**os.environ, "MMS_PI_NPX_CACHE": str(cache_dir)},
+        env=_pi_wrapper_env(tmp_path, cache_dir),
     )
 
     assert result.stdout == "cached-pi:--version\n"
@@ -215,11 +246,7 @@ def test_pi_wrapper_warms_a_missing_cache_before_running(tmp_path):
         check=True,
         capture_output=True,
         text=True,
-        env={
-            **os.environ,
-            "MMS_PI_NPX_CACHE": str(cache_dir),
-            "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
-        },
+        env=_pi_wrapper_env(tmp_path, cache_dir, bin_dir=fake_bin),
     )
 
     assert result.stdout == "warmed-pi:--version\n"
@@ -307,15 +334,13 @@ def test_pi_wrapper_serializes_cold_npx_prewarm(tmp_path):
         encoding="utf-8",
     )
     fake_npx.chmod(0o755)
-    env = os.environ.copy()
-    env.update(
-        {
-            "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
-            "MMS_PI_NPX_CACHE": str(cache_dir),
-            "MMS_PI_NPX_INSTALL_LOCK_TIMEOUT": "10",
-            "FAKE_NPX_LOG": str(log_path),
-            "FAKE_PI_CACHE": str(cache_dir),
-        }
+    env = _pi_wrapper_env(
+        tmp_path,
+        cache_dir,
+        bin_dir=bin_dir,
+        MMS_PI_NPX_INSTALL_LOCK_TIMEOUT="10",
+        FAKE_NPX_LOG=str(log_path),
+        FAKE_PI_CACHE=str(cache_dir),
     )
 
     processes = [

--- a/tests/test_route_status_session_isolation.py
+++ b/tests/test_route_status_session_isolation.py
@@ -26,7 +26,10 @@ def test_ignores_ambient_session_home_env(monkeypatch):
     result = _paths(gateway_home="/tmp/explicit-gateway-home/1111")
 
     assert len(result) == 1
-    assert result[0] == "/tmp/explicit-gateway-home/1111/.config/mms/route_status.json"
+    # 单一 config root 之后，gateway session 目录本身就是落点，
+    # 不再在里面再挂一层退休的 `.config/mms`。
+    assert result[0] == "/tmp/explicit-gateway-home/1111/route_status.json"
+    assert "/.config/mms/" not in result[0]
     # ambient env 绝不能渗进来
     assert "ambient-session-home" not in result[0]
     assert "ambient-config-root" not in result[0]
@@ -41,8 +44,8 @@ def test_multi_session_isolation():
     paths_b = _paths(gateway_home=pid_b)
 
     assert paths_a != paths_b
-    assert paths_a[0].endswith("/s/7180/.config/mms/route_status.json")
-    assert paths_b[0].endswith("/s/98400/.config/mms/route_status.json")
+    assert paths_a[0].endswith("/s/7180/route_status.json")
+    assert paths_b[0].endswith("/s/98400/route_status.json")
 
 
 def test_fallback_without_gateway_home_uses_config_root(monkeypatch):


### PR DESCRIPTION
Closes #222.

A base-vs-head comparison between v4.11.1 (`f17b11eb`) and `dev` found 27 tests that pass on the base and fail at head. They were introduced by #199 (`fa540b88`), #204 (`696fffd5`) and #205 (`f051bdcf`), all merged before the CI pytest gate existed. Every failure was reproduced individually before anything was changed.

**Result: 26 test fixes, 1 product fix, 1 new test. No test that passes on `origin/dev` fails here.**

## The config-root precedence I found

`mms_state_io.resolve_mms_config_dir(env)` is the one resolver every path goes through:

1. `MMS_CONFIG_ROOT` (if it is exactly the retired real-home `~/.config/mms`, it is rewritten to `~/.config/mms-next`)
2. `MMS_CONFIG_DIR` (same rewrite)
3. `XDG_CONFIG_HOME` — `<XDG>/mms-next`, unless the value sits inside a gateway/account session marker (`.config/{mms,mms-next}/{codex,claude}-gateway/s/`, `.config/*/accounts/`), in which case it unwinds to `<base home>/.config/mms-next`
4. real user home — `MMS_REAL_HOME` > `REAL_HOME` > `ORIGINAL_HOME` > `HOME` (with the same session-marker unwinding) — plus `/.config/mms-next`

`mms_launchers._selected_mms_config_root(env)` is a thin wrapper: it merges `env` over `os.environ`, drops an ambient `XDG_CONFIG_HOME` when the caller passed a HOME-ish key but no XDG, then calls the resolver.

Two consequences drove most of this PR: `~/.config/mms` is never a config root any more, and `tests/conftest.py` parks `XDG_CONFIG_HOME` in a single shared temp dir — which outranks the real HOME and therefore silently pointed every gateway test at the same directory.

## Product fix (1)

`mms_core._session_gateway_roots`, `mms_core._codex_resume_roots` and `mms_session_catalog.codex_roots` hard-coded `<real home>/.config/mms-next`, while the launchers create sessions under `_selected_mms_config_root(env)`, which honours `MMS_CONFIG_ROOT`. A Pilot started with `--config-root` therefore created sessions under one root and pruned/backfilled under another — and `_session_gateway_roots` drives `mms session prune`, so this was a destructive-path mismatch, not only a cosmetic one. All three now call `resolve_mms_config_dir()` at call time; the diff to `mms_core.py` is three lines plus comments, no refactor. `mms_session_catalog.pi_roots` also carried the same `mms-next` literal twice; it now derives its single root from a shared `_config_root()` helper.

New test `tests/test_command_smoke.py::test_session_gateway_roots_follow_explicit_config_root` pins prune/backfill to `MMS_CONFIG_ROOT` and checks the no-override fallback still lands on the real HOME root. `tests/test_single_config_root.py` stays green (no new legacy-root code path).

## Test fixes, per group

**Config-root and layout expectations** (`test_agy_launcher`, `test_mms_rescue` x2, `test_fake_upstream`, `test_command_smoke`, `test_mms_context`)
Old expectation: `~/.config/mms` for config roots, gateway homes, the fake-upstream request log, session context stores. Current contract: a single config root at `~/.config/mms-next` (docs/AGENT_GUARDRAILS.md "Single Config Root", #183/#215); `~/.config/mms` keeps only runtime/session state. The assertions moved to `mms-next`; what each test proves is unchanged (a gateway/account session HOME still unwinds to the real root, `MMS_REAL_HOME > REAL_HOME > ORIGINAL_HOME` still holds, `mms context gain` still auto-discovers a recent session store when the cwd store is empty).

**`route_status.json` isolation** (`test_route_status_session_isolation` x2)
Old expectation: `<gateway_home>/.config/mms/route_status.json`. `839f8f2c` (#204) dropped that inner legacy directory, so the file now lands directly in the gateway session dir. Both tests still prove what they were written for: an explicit `gateway_home` beats an ambient `MMS_SESSION_HOME`/`MMS_CONFIG_ROOT`, and two sessions get two distinct paths.

**Rescue routes** (`test_mms_rescue` x3, `test_legacy_surface_cleanup` x1)
Old expectation: a bare `generated/model-routes.json` is a route source. Because every config root is a preview root now, `_rescue_requires_latest_approved_bundle` is always true and routes come only from a verified latest-approved bundle. These fixtures got zero routes and failed with `IndexError`. They now seed through the `_write_latest_approved_router_manifest` helper the newer sibling tests already use, with the same route payloads, so the Anthropic `/v1/messages` preference, the cache-sensitive openai-only routing, the rescue-summary transport and the routed fallback candidates are all still the thing being asserted.

**Pi wrapper cache** (`test_pi_launcher` x3)
Since #205 the wrapper prefers an installed Pi (on PATH, or under `npm prefix -g`) over its npx cache. All three tests passed `env={**os.environ, ...}`, so on any machine with a global pi they exec the real binary and never reach the cache mechanics they then assert on. They now run under a temp bin dir carrying node/npm/npx but no pi, with `npm_config_prefix` pointing at an empty prefix so `npm prefix -g` cannot reach the installed copy either; the helper asserts pi is absent from that PATH before running. `test_pi_wrapper_prefers_a_cached_pi_binary` is renamed to `test_pi_wrapper_uses_the_cache_when_no_pi_is_installed`, which is what it proves now that an installed pi legitimately wins. `scripts/pi-cli-wrapper.sh` is unchanged and `tests/test_pi_wrapper_finds_installed_pi.py` still passes.

**kimi-code k3 context** (`test_opencode_launcher` x1)
Old expectation 262144; the official calibration is 1048576 (#209). The stubbed generic policy in the test says 1000000, so the assertion still distinguishes the profile value from the stale generic one.

**Codex gateway hardening** (`test_claude_hardening_regressions` x10)
Two problems. First, the shared `XDG_CONFIG_HOME` from `conftest.py`: every `_codex_gateway_env` test built its gateway in the same directory and saw the previous test's leftovers. A new `_use_real_home_config_root` helper drops `XDG_CONFIG_HOME` and points `MMS_REAL_HOME` at each test's own real-home fixture — which is what the two hook-trust tests already assumed their paths were. It also sets `MMS_CODEX_HOOK_TRUST_REFRESH=0`: once the gateway dir looks like it is under the real HOME, the refresh path shells out to the installed Codex app-server and overwrites the seeded hashes those tests assert on (at the base that path was skipped by the non-real-home guard, so nothing is lost). Second, the real layout: `CODEX_HOME` is the stable `<root>/codex-gateway/.codex`, `commands` is a direct link to the real `~/.codex/commands` (so `keep.toml` is a file, not a symlink), `skills` links to the session's managed-skills overlay, and caveman / web-access / agent-browser are retired as separate session assets. The tests that asserted those assets get injected now pin the retirement, matching the sibling tests that already do so for the web-access and agent-browser overlays, and were renamed accordingly.

**The two tests that never passed on this machine** — `test_build_codex_session_hooks_removes_retired_caveman_hooks` and `test_mms_caveman_legacy_helpers_are_inert`, both added by #199 — are **broken tests, not a product bug**. Caveman is deliberately and consistently retired: `_resolve_caveman_root()` returns `""` (pinned by the passing `test_resolve_caveman_root_is_retired`), `_runtime_caveman_enabled()` returns `False`, `_configure_{claude,codex}_caveman_hooks` only filter, `_overlay_caveman_session_entries` returns `None`, and nothing in the tree still writes a caveman hook. Yet both bodies asserted a caveman hook gets injected while their names said "retired"/"inert", and the inert one fed `_configure_claude_caveman_hooks` a command (`echo caveman`) that the retirement filter deliberately does not match — the filter is narrow on purpose (`caveman-activate.js`, `caveman-mode-tracker.js`, `caveman mode active`) so it cannot eat unrelated user hooks. Both now assert the retirement, with a non-caveman hook kept alive so the filter cannot pass by dropping everything.

`tests/test_config_web.py` was not touched: its two mimo failures pre-date this window.

## Verification

- Each of the 27 tests run individually with `env -u MMS_CONFIG_ROOT -u REAL_HOME -u ORIGINAL_HOME -u MMS_REAL_HOME -u XDG_CONFIG_HOME -u MMS_SESSION_HOME python3 -m pytest -q -p no:cacheprovider <id>`: 27/27 green.
- `pytest tests/test_pi_launcher.py tests/test_pi_wrapper_finds_installed_pi.py tests/test_single_config_root.py tests/test_claude_hardening_regressions.py tests/test_mms_rescue.py tests/test_command_smoke.py`: **288 passed**.
- `python3 scripts/ci_pytest_regression.py --base origin/dev`: base 96 failing of 2248, head 68 failing of 2249, 28 repaired, and **"No test that passes on the base commit fails here."**
- `python3 -m py_compile` on every changed Python file: clean.

Not run: no CLI/launcher behaviour was changed beyond the three root lookups, so no fresh-user gate or live launch was executed. Residual risk is limited to consumers of `_session_gateway_roots` / `_codex_resume_roots` / `mms_session_catalog.codex_roots` in a session where `MMS_CONFIG_ROOT` differs from the real HOME root: they now follow that explicit root, which is the intended behaviour, and a default session resolves to exactly the same path as before.

https://claude.ai/code/session_01Q7g7jpHK2ikM4mWcpLuWKX
