### PR TITLE
feat(capability): one context-window truth for every harness; [1m] becomes input normalization (#230)

### DIFF
--- a/config/model-context-windows.json
+++ b/config/model-context-windows.json
@@ -109,12 +109,12 @@
     },
     "mimo-v2.5": {
       "context_window_tokens": 1048576,
-      "source": "Xiaomi MiMo v2.5 is a 1M model; every MiMo provider profile agrees, and the [1m] selector is the same model under another name",
+      "source": "Xiaomi MiMo v2.5 on an OpenAI-style route, where the plain name is the 1M model; the Anthropic endpoint's 256K plain mode is provider-specific and lives in the mimo profile",
       "checked": "2026-09"
     },
     "mimo-v2.5-pro": {
       "context_window_tokens": 1048576,
-      "source": "Xiaomi MiMo v2.5 is a 1M model; every MiMo provider profile agrees, and the [1m] selector is the same model under another name",
+      "source": "Xiaomi MiMo v2.5 on an OpenAI-style route, where the plain name is the 1M model; the Anthropic endpoint's 256K plain mode is provider-specific and lives in the mimo profile",
       "checked": "2026-09"
     },
     "mimo-v2-pro": {

--- a/config/model-context-windows.json
+++ b/config/model-context-windows.json
@@ -1,0 +1,211 @@
+{
+  "schema_version": 1,
+  "description": "Vendor-documented context windows for models no provider profile covers. Data, not code (issue #230): a provider profile in config/provider-profiles.json answers first and this file only catches a model served by a channel whose profile says nothing about it — the relays that resell several vendors. Every row names where the number came from. Keys are lower-case leaf model names; a `[1m]` key is listed only where the vendor really treats the selector as a different model, and is matched before the plain name.",
+  "models": {
+    "k3": {
+      "context_window_tokens": 1048576,
+      "source": "Moonshot Kimi K3 API docs",
+      "checked": "2026-09"
+    },
+    "kimi-k3": {
+      "context_window_tokens": 1048576,
+      "source": "Moonshot Kimi K3 API docs",
+      "checked": "2026-09"
+    },
+    "kimi-for-coding": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot coding plan docs",
+      "checked": "2026-03"
+    },
+    "kimi-for-coding-highspeed": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot coding plan docs",
+      "checked": "2026-03"
+    },
+    "kimi-k2.7-code": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot coding plan docs",
+      "checked": "2026-03"
+    },
+    "kimi-k2.7-code-highspeed": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot coding plan docs",
+      "checked": "2026-03"
+    },
+    "kimi-k2.5": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot API docs",
+      "checked": "2026-03"
+    },
+    "kimi-k2.6": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot API docs",
+      "checked": "2026-03"
+    },
+    "kimi-k2.6-code-preview": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot API docs",
+      "checked": "2026-03"
+    },
+    "k2.6": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot API docs",
+      "checked": "2026-03"
+    },
+    "k2.6-code-preview": {
+      "context_window_tokens": 262144,
+      "source": "Moonshot API docs",
+      "checked": "2026-03"
+    },
+    "qwen3.5-plus": {
+      "context_window_tokens": 1000000,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-03"
+    },
+    "qwen3.6-plus": {
+      "context_window_tokens": 1000000,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-03"
+    },
+    "qwen3.6-flash": {
+      "context_window_tokens": 1000000,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-05"
+    },
+    "qwen3.7-max": {
+      "context_window_tokens": 1000000,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-05"
+    },
+    "qwen3-coder-plus": {
+      "context_window_tokens": 1000000,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-03"
+    },
+    "qwen3-max": {
+      "context_window_tokens": 262144,
+      "source": "DashScope hosted Qwen docs",
+      "checked": "2026-03"
+    },
+    "glm-5": {
+      "context_window_tokens": 200000,
+      "source": "Zhipu GLM API docs",
+      "checked": "2026-03"
+    },
+    "glm-5-turbo": {
+      "context_window_tokens": 200000,
+      "source": "Zhipu GLM API docs",
+      "checked": "2026-03"
+    },
+    "glm-5.1": {
+      "context_window_tokens": 200000,
+      "source": "Zhipu GLM API docs",
+      "checked": "2026-03"
+    },
+    "glm-4.7": {
+      "context_window_tokens": 200000,
+      "source": "Zhipu GLM API docs",
+      "checked": "2026-03"
+    },
+    "mimo-v2.5": {
+      "context_window_tokens": 1048576,
+      "source": "Xiaomi MiMo v2.5 is a 1M model; every MiMo provider profile agrees, and the [1m] selector is the same model under another name",
+      "checked": "2026-09"
+    },
+    "mimo-v2.5-pro": {
+      "context_window_tokens": 1048576,
+      "source": "Xiaomi MiMo v2.5 is a 1M model; every MiMo provider profile agrees, and the [1m] selector is the same model under another name",
+      "checked": "2026-09"
+    },
+    "mimo-v2-pro": {
+      "context_window_tokens": 262144,
+      "source": "Xiaomi MiMo docs",
+      "checked": "2026-03"
+    },
+    "mimo-v2-omni": {
+      "context_window_tokens": 262144,
+      "source": "Xiaomi MiMo docs",
+      "checked": "2026-03"
+    },
+    "mimo-v2-flash": {
+      "context_window_tokens": 262144,
+      "source": "Xiaomi MiMo docs",
+      "checked": "2026-03"
+    },
+    "minimax-m2.5": {
+      "context_window_tokens": 196608,
+      "source": "MiniMax API docs",
+      "checked": "2026-03"
+    },
+    "minimax-m2.7": {
+      "context_window_tokens": 200000,
+      "source": "MiniMax API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5-mini": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5-nano": {
+      "context_window_tokens": 256000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5-codex": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.1-codex": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.1-codex-max": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.1-codex-mini": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.2": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.2-codex": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.3-codex": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.3-codex-spark": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.4": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    },
+    "gpt-5.4-pro": {
+      "context_window_tokens": 1000000,
+      "source": "OpenAI API docs",
+      "checked": "2026-03"
+    }
+  }
+}

--- a/config/provider-profiles.json
+++ b/config/provider-profiles.json
@@ -889,8 +889,8 @@
       "context_windows": {
         "mimo-v2.5-pro[1m]": 1048576,
         "mimo-v2.5[1m]": 1048576,
-        "mimo-v2.5-pro": 1048576,
-        "mimo-v2.5": 1048576,
+        "mimo-v2.5-pro": 262144,
+        "mimo-v2.5": 262144,
         "mimo-v2-pro": 262144,
         "mimo-v2-omni": 262144,
         "mimo-v2-flash": 262144
@@ -956,7 +956,8 @@
           "audio",
           "video"
         ]
-      }
+      },
+      "note": "MiMo documents the [1m] suffix as what enables extended context on the Anthropic-compatible endpoint Claude Code uses, so the plain model id there runs in 256K mode: https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode . This profile answers for that endpoint and for any MiMo channel that does not say which endpoint it is, so its plain entries stay at 256K — a channel that turns out to be the Anthropic one must never be told a window the server will not honour. The OpenAI-style routes serve 1M under the plain name and record it in their own profiles (mimo-openai, openrouter-xiaomi-mimo)."
     },
     "minimax": {
       "label": "MiniMax",

--- a/docs/AGENT_GUARDRAILS.md
+++ b/docs/AGENT_GUARDRAILS.md
@@ -209,6 +209,8 @@ MMS-managed Codex launch must not repeatedly stop on `Hooks need review` in isol
 6. `config/model-context-windows.json`：没有任何 profile 覆盖时的兜底数据，每行写明来源。
 7. Claude 家族规则：Anthropic 自家模型 opus/sonnet 记 1M、haiku 记 200K。查不到就返回 `None`，由调用方套自己的默认值（launcher 是 200K）。
 
+用户在 Pilot 模型页给某个模型设了 context，就当他确认过（2026-09-12 owner 决定）：不校准、不封顶、不给 wire 名加 `[1m]`，四个 harness 原样带过去；Pilot 的自动刷新（`ModelSettings.auto_refresh`）跳过 `userSet` 字段。以后不要再为 `[1m]` 开讨论：非 Claude 模型它只是输入归一化。
+
 不允许的做法：
 
 - 在代码里新增按模型名映射 context 的 dict 或特判（Claude 家族规则和默认常量除外）。要补数据就写 provider profile；profile 覆盖不到再写 `config/model-context-windows.json`，并填上 `source`。

--- a/docs/AGENT_GUARDRAILS.md
+++ b/docs/AGENT_GUARDRAILS.md
@@ -195,6 +195,29 @@ MMS-managed Codex launch must not repeatedly stop on `Hooks need review` in isol
 - 把 `conservative_fallback` 当成「这个模型不支持图片」。它的含义是没有任何来源声明过。
 - 新增第五份硬编码 vision 名单。要补数据就写 provider profile。
 
+## Context Window Single Truth
+
+一个模型在某个 provider 下的 context window 只有一条链，四个 harness 都调同一个 resolver。改这条链之前先读这段。
+
+`mms_context_window.resolve_context_window(model, provider_id=..., runtime=...)` 的优先级，从高到低：
+
+1. `~/.config/mms-next/model-context-overrides.json`：用户自己写的文件，最高。
+2. `manual_override` / `model_policy`：Pilot 模型页写的那层。
+3. `approved_facts`：已发布的 capability bundle。
+4. `provider_profile`：`config/provider-profiles.json` 的 `context_windows`。
+5. provider 自己 `/models` 上报并被缓存的窗口（`<config root>/cache/models_<provider>.json` 的 `model_details`）。
+6. `config/model-context-windows.json`：没有任何 profile 覆盖时的兜底数据，每行写明来源。
+7. Claude 家族规则：Anthropic 自家模型 opus/sonnet 记 1M、haiku 记 200K。查不到就返回 `None`，由调用方套自己的默认值（launcher 是 200K）。
+
+不允许的做法：
+
+- 在代码里新增按模型名映射 context 的 dict 或特判（Claude 家族规则和默认常量除外）。要补数据就写 provider profile；profile 覆盖不到再写 `config/model-context-windows.json`，并填上 `source`。
+- 让某个 harness 绕过 resolver 自己算窗口。Claude Code 的 `_effective_context_window` / `_apply_claude_context_env_overrides`、Codex 的 `_codex_gateway_context_window`、Pi 的 `_pi_model_capabilities`、OpenCode 的 `limit.context` 都必须落到同一个数。
+- 为 `[1m]` 维护重复条目。非 Claude 模型的 `[1m]` 只是输入归一化：`k3[1m]` 等价 `k3`，除非某个来源显式声明了带后缀的名字（先按原名查，查不到再剥后缀）。Claude 家族的 `[1m]` 语义不变，`_with_1m_suffix` / `_apply_claude_shell_context_slots` 不要动。
+- 改 `_runtime_supports_claude_1m` 或让敏感 Claude provider 默认开 1M。
+
+改这条链路要跑 `tests/test_context_window_single_truth.py`（含一条禁止代码内 context 表的扫描断言）和 `tests/test_provider_profiles.py`。
+
 ## Vision Relay Contract
 
 Pi 用 `--model` 启动，扩展看不到这个参数，所以主模型能力由 mmf 在启动前算好注入：

--- a/docs/reference/MODEL_CAPABILITY_SOURCES.md
+++ b/docs/reference/MODEL_CAPABILITY_SOURCES.md
@@ -88,6 +88,8 @@ python3 scripts/openrouter_recent_models.py --missing   # 只看 profile 里还�
 
 **k3 的输出上限没有官方来源。** 2026-09-02 的标定记录里 `official_max_output_tokens` 是 `null`。profile 保留 131072，不要在没有来源的情况下把它抬到 context 那么大：上游会直接拒绝超限的 `max_tokens`。`tests/test_provider_profiles.py::test_profile_max_output_never_exceeds_its_context_window` 覆盖这条。
 
+**MiMo 的 `[1m]` 在 Anthropic 端点是真的 selector，不是别名。** 官方 Claude Code 接入文档写明：在 Anthropic 兼容端点上，支持 1M 的 MiMo 模型要把 `[1m]` 后缀加在 model id 上才启用扩展上下文，平名跑的是 256K 档。所以通用 `mimo` profile（它同时服务 Anthropic 端点和"没说是哪个端点"的通道）记平名 262144、`[1m]` 1048576；OpenAI 风格路由（`mimo-openai`、`openrouter-xiaomi-mimo`）平名就是 1M，各自记在自己的 profile 里。不要把这两种路由合并成一个数字：宁可早 compact，也不能告诉 harness 一个服务端不认的窗口。来源：https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode
+
 **OpenAI 已经下架的模型仍在 profile 里。** `gpt-5`、`gpt-5-pro`、`gpt-5.4`、`gpt-5.4-mini` 不在官方当前列表上了,但很多中转通道还在提供。它们的值保持原样,不要因为官方页面查不到就删。
 
 **Anthropic 的 4.6 系列已是 legacy。** 当前是 Opus 5 / Sonnet 5 / Fable 5.1 / Haiku 4.5。旧模型页仍在,规格照样能查。

--- a/docs/reference/MODEL_CAPABILITY_SOURCES.md
+++ b/docs/reference/MODEL_CAPABILITY_SOURCES.md
@@ -67,6 +67,19 @@ python3 scripts/openrouter_recent_models.py --limit 50
 python3 scripts/openrouter_recent_models.py --missing   # 只看 profile 里还没有的
 ```
 
+## 一个新模型的窗口写在哪里
+
+代码里已经没有按模型名的 context 表了（#230）。查到数字之后按这个顺序落地：
+
+1. **能对上某个 provider profile**：写进 `config/provider-profiles.json` 对应 profile 的 `context_windows`。这是常规位置。
+2. **没有任何 profile 覆盖**（典型是同时转售多家的中转通道）：写进 `config/model-context-windows.json`，每行必须带 `source` 和 `checked`。
+3. **provider 的 `/models` 已经自己上报了窗口**：什么都不用写。探测结果会缓存到 `<config root>/cache/models_<provider>.json` 的 `model_details`，resolver 直接读。
+4. **用户想临时改自己那台机器上的值**：`~/.config/mms-next/model-context-overrides.json`，它在链的最上面，agent 不代写。
+
+`[1m]` 不需要单独一行。非 Claude 模型的后缀只是输入归一化，`k3[1m]` 和 `k3` 解析到同一个数；只有某个来源显式写了带后缀的名字，那一行才会生效。
+
+完整链路和禁止事项见 `docs/AGENT_GUARDRAILS.md` 的 “Context Window Single Truth”，不变量测试是 `tests/test_context_window_single_truth.py`。
+
 ## 已知的坑
 
 **Kimi Code 的 k3 原生支持 1M。** `k3` 是新的默认入口；`k3[1m]` 仅为历史 MMS compatibility selector，不能直接发给 provider，也不再作为新的产品入口。OpenRouter 仍然只是 catalog evidence，不能单独证明当前 route/account 的实际能力。

--- a/mms_config_web.py
+++ b/mms_config_web.py
@@ -93,20 +93,19 @@ _MIGRATION_CREDENTIAL_BOX_AESGCM_SCHEMA = "mms.config_migration_credentials.aesg
 _MIGRATION_CREDENTIAL_BOX_OPENSSL_SCHEMA = "mms.config_migration_credentials.openssl-cbc-hmac.v1"
 _MIGRATION_CREDENTIAL_BOX_SCHEMA = _MIGRATION_CREDENTIAL_BOX_AESGCM_SCHEMA
 
+# Keys are `[1m]`-free: a selector is the same model as its base name, so it
+# never needs a duplicate row (issue #230).
 _KNOWN_VISION_MODELS = {
     "gpt-5.3-codex",
     "gpt-5.4",
     "gpt-5.5",
     "k3",
-    "k3[1m]",
     "kimi-k3",
     "k2.6",
     "k2.6-code-preview",
     "kimi-k2.5",
     "kimi-k2.6",
     "mimo-v2.5",
-    # A `[1m]` selector is the same model as its base name.
-    "mimo-v2.5[1m]",
     "mimo-v2-omni",
     "minimax-m2.7",
     "minimax-m3",

--- a/mms_context_window.py
+++ b/mms_context_window.py
@@ -1,0 +1,477 @@
+"""The one place that answers "how large is this model's context window?".
+
+Issue #230: the same number used to be decided in several places — a model-name
+table in ``mms_launchers``, a second one in ``mms_pi_support``, per-model
+special cases for Kimi K3 and MiMo, plus the provider profiles and the approved
+capability facts. Four harnesses (Claude Code, Codex, Pi, OpenCode) read
+whichever of those happened to be nearest, so one model could be 1M in one
+harness and 256K in the next, and every new long-context model needed a code
+change in several files.
+
+Everything now flows through :func:`resolve_context_window`. The chain, highest
+first:
+
+1. ``model-context-overrides.json`` in the selected config root — the user's own
+   file, so it wins outright.
+2. ``manual_override`` / ``model_policy`` capability sources — what the Pilot's
+   model page writes when a human sets a value.
+3. ``approved_facts`` — the published capability bundle.
+4. The provider profile for that provider (``config/provider-profiles.json``).
+5. The provider's cached ``/models`` listing, when the upstream reported a
+   window for the model.
+6. ``config/model-context-windows.json`` — vendor-documented windows for models
+   that no profile covers.
+7. The Claude-family rule: an Anthropic model is 1M unless it is a Haiku.
+
+Anything else returns ``None`` and the caller applies its own default. No step
+is a hard-coded map from a non-Claude model name to a number: adding a model, or
+a provider that reports one, must never require editing code again.
+
+``[1m]`` is a selector suffix, not part of the model name. Every lookup tries the
+name as written first and then the stripped name, so ``k3[1m]`` resolves exactly
+like ``k3`` unless a provider profile deliberately lists the suffixed name as a
+different selector (MiMo's Claude Code endpoint does).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+ONE_M_SELECTOR_SUFFIX = "[1m]"
+
+# A model we know nothing about. Callers apply this themselves; the resolver
+# reports ``None`` so they can tell "unknown" from "known to be 200K".
+DEFAULT_CONTEXT_WINDOW = 200_000
+CLAUDE_STANDARD_CONTEXT_WINDOW = 200_000
+CLAUDE_ONE_M_CONTEXT_WINDOW = 1_000_000
+
+# A number outside this range is a units mistake or a placeholder, not a window.
+MIN_PLAUSIBLE_CONTEXT_WINDOW = 4_096
+MAX_PLAUSIBLE_CONTEXT_WINDOW = 10_000_000
+
+# Fields an OpenAI-compatible or OpenRouter-style listing uses for the window.
+REMOTE_LISTING_CONTEXT_KEYS = (
+    "context_length",
+    "context_window",
+    "context_window_tokens",
+    "max_context_tokens",
+    "max_model_len",
+    "max_input_tokens",
+)
+
+_USER_CAPABILITY_SOURCES = ("manual_override", "model_policy")
+_APPROVED_CAPABILITY_SOURCES = ("approved_facts",)
+_PROFILE_CAPABILITY_SOURCES = ("provider_profile",)
+
+_DATA_FILE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "config", "model-context-windows.json"
+)
+
+_OVERRIDES_CACHE: dict[str, Any] = {"path": None, "mtime": None, "data": None}
+_DATA_FILE_CACHE: dict[str, Any] = {"mtime": None, "data": None}
+
+
+# ── name handling ────────────────────────────────────────────────────────────
+
+def strip_one_m_selector(model_name: Any) -> str:
+    """Drop the ``[1m]`` selector suffix, keeping the rest of the name as written."""
+    normalized = str(model_name or "").strip()
+    if not normalized:
+        return ""
+    return (
+        normalized.replace(ONE_M_SELECTOR_SUFFIX, "")
+        .replace(ONE_M_SELECTOR_SUFFIX.upper(), "")
+        .strip()
+    )
+
+
+def _leaf_name(model_name: Any) -> str:
+    """Lower-case leaf name, selector suffix left as written."""
+    normalized = str(model_name or "").strip().lower()
+    if "/" in normalized:
+        normalized = normalized.rsplit("/", 1)[-1]
+    return normalized
+
+
+def normalize_model_selector(model_name: Any) -> str:
+    """Lower-case leaf name with the ``[1m]`` selector removed.
+
+    The shared key for any table that is keyed by model name — context, Pi
+    hints, vision — so a selector never needs a duplicate entry of its own.
+    """
+    return strip_one_m_selector(_leaf_name(model_name))
+
+
+def has_one_m_selector(model_name: Any) -> bool:
+    return ONE_M_SELECTOR_SUFFIX in str(model_name or "").strip().lower()
+
+
+def coerce_context_window(value: Any) -> int | None:
+    try:
+        window = int(value)
+    except (TypeError, ValueError):
+        return None
+    return window if window > 0 else None
+
+
+def _plausible(value: Any) -> int | None:
+    window = coerce_context_window(value)
+    if window is None:
+        return None
+    if window < MIN_PLAUSIBLE_CONTEXT_WINDOW or window > MAX_PLAUSIBLE_CONTEXT_WINDOW:
+        return None
+    return window
+
+
+def _config_root() -> str:
+    from mms_state_io import resolve_mms_config_dir
+
+    return resolve_mms_config_dir()
+
+
+# ── step 1: the user's own overrides file ────────────────────────────────────
+
+def model_context_overrides_path() -> str:
+    try:
+        config_root = _config_root()
+    except Exception:
+        config_root = os.path.join(os.path.expanduser("~"), ".config", "mms-next")
+    return os.path.join(config_root, "model-context-overrides.json")
+
+
+def load_model_context_overrides() -> dict[str, Any]:
+    """Read ``model-context-overrides.json`` from the selected config root."""
+    overrides_path = model_context_overrides_path()
+    try:
+        mtime = os.path.getmtime(overrides_path)
+    except OSError:
+        _OVERRIDES_CACHE.update(
+            {"path": overrides_path, "mtime": None, "data": {"models": {}, "provider_overrides": {}}}
+        )
+        return _OVERRIDES_CACHE["data"]
+
+    if _OVERRIDES_CACHE.get("path") == overrides_path and _OVERRIDES_CACHE.get("mtime") == mtime:
+        return _OVERRIDES_CACHE["data"]
+
+    models: dict[str, int] = {}
+    provider_overrides: dict[str, int] = {}
+    try:
+        with open(overrides_path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        payload = {}
+
+    if isinstance(payload, dict):
+        raw_models = payload.get("models", payload)
+        if isinstance(raw_models, dict):
+            for key, value in raw_models.items():
+                if key in {"models", "provider_overrides"}:
+                    continue
+                window = coerce_context_window(value)
+                if window:
+                    models[str(key).strip()] = window
+
+        raw_provider_overrides = payload.get("provider_overrides", {})
+        if isinstance(raw_provider_overrides, dict):
+            for key, value in raw_provider_overrides.items():
+                if isinstance(value, dict):
+                    provider_id = str(key or "").strip()
+                    if not provider_id:
+                        continue
+                    for model_id, window_value in value.items():
+                        window = coerce_context_window(window_value)
+                        if window:
+                            provider_overrides[f"{provider_id}:{str(model_id).strip()}"] = window
+                else:
+                    window = coerce_context_window(value)
+                    if window:
+                        provider_overrides[str(key).strip()] = window
+
+    _OVERRIDES_CACHE.update(
+        {
+            "path": overrides_path,
+            "mtime": mtime,
+            "data": {"models": models, "provider_overrides": provider_overrides},
+        }
+    )
+    return _OVERRIDES_CACHE["data"]
+
+
+def _override_window(candidate: str, provider_key: str) -> tuple[int | None, str]:
+    if not candidate:
+        return None, ""
+    overrides = load_model_context_overrides()
+    candidate_lower = candidate.lower()
+
+    if provider_key:
+        provider_overrides = overrides.get("provider_overrides", {})
+        direct = provider_overrides.get(f"{provider_key}:{candidate}")
+        if direct is not None:
+            return coerce_context_window(direct), "provider_override"
+        for key, value in provider_overrides.items():
+            try:
+                override_provider, override_model = key.split(":", 1)
+            except ValueError:
+                continue
+            if override_provider == provider_key and override_model.lower() == candidate_lower:
+                return coerce_context_window(value), "provider_override"
+
+    models = overrides.get("models", {})
+    direct = models.get(candidate)
+    if direct is not None:
+        return coerce_context_window(direct), "user_override"
+    for key, value in models.items():
+        if key.lower() == candidate_lower:
+            return coerce_context_window(value), "user_override"
+    return None, ""
+
+
+# ── steps 2 and 3: capability facts ──────────────────────────────────────────
+
+def _model_capabilities(model_name: str, provider_id: str, base_url: str = "") -> dict[str, Any]:
+    """Capability facts for one model: policy, approved bundle and profile at once.
+
+    Steps 2 to 4 of the chain all live in this one resolution, so the launcher
+    and Pi read the same profile for the same provider instead of two lookups
+    that can drift apart.
+    """
+    if not model_name:
+        return {}
+    from mms_capability_resolver import resolve_model_capabilities
+
+    try:
+        return resolve_model_capabilities(model_name, provider_id=provider_id or "", base_url=base_url or "")
+    except Exception:
+        # A config root without a readable approved bundle still has a policy
+        # file, and a value the user set there must not be lost with it.
+        try:
+            from mms_capability_resolver import load_default_model_policy
+
+            return resolve_model_capabilities(
+                model_name,
+                provider_id=provider_id or "",
+                base_url=base_url or "",
+                approved_facts={},
+                model_policy=load_default_model_policy(),
+            )
+        except Exception:
+            return {}
+
+
+def _capability_window(caps: dict[str, Any], accepted_sources: tuple[str, ...]) -> tuple[int | None, str]:
+    source = caps.get("sources", {}).get("context_window_tokens") if isinstance(caps, dict) else None
+    if source not in accepted_sources:
+        return None, ""
+    return coerce_context_window(caps.get("context_window_tokens")), str(source)
+
+
+# ── step 5: what the provider's own /models listing reported ─────────────────
+
+def _remote_listing_details(provider_id: str) -> dict[str, Any]:
+    if not provider_id:
+        return {}
+    try:
+        path = os.path.join(_config_root(), "cache", f"models_{provider_id}.json")
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    details = payload.get("model_details")
+    return details if isinstance(details, dict) else {}
+
+
+def _remote_listing_window(model_name: str, provider_id: str) -> int | None:
+    details = _remote_listing_details(provider_id)
+    if not details:
+        return None
+    wanted = normalize_model_selector(model_name)
+    if not wanted:
+        return None
+    for key, entry in details.items():
+        if normalize_model_selector(key) != wanted:
+            continue
+        if isinstance(entry, dict):
+            for field in REMOTE_LISTING_CONTEXT_KEYS:
+                window = _plausible(entry.get(field))
+                if window:
+                    return window
+            top_provider = entry.get("top_provider")
+            if isinstance(top_provider, dict):
+                for field in REMOTE_LISTING_CONTEXT_KEYS:
+                    window = _plausible(top_provider.get(field))
+                    if window:
+                        return window
+        else:
+            window = _plausible(entry)
+            if window:
+                return window
+    return None
+
+
+# ── step 6: vendor-documented windows for models no profile covers ───────────
+
+def load_context_window_data() -> dict[str, int]:
+    """Read ``config/model-context-windows.json``.
+
+    A data file, not a code table: every row names the source it came from, and
+    it only answers for a model whose channel profile says nothing about it.
+    Keys stay as written (lower-cased leaf), so a row for a `[1m]` selector can
+    say something different from the plain name where a vendor really means it.
+    """
+    try:
+        mtime = os.path.getmtime(_DATA_FILE_PATH)
+    except OSError:
+        return {}
+    if _DATA_FILE_CACHE.get("mtime") == mtime and isinstance(_DATA_FILE_CACHE.get("data"), dict):
+        return _DATA_FILE_CACHE["data"]
+    try:
+        with open(_DATA_FILE_PATH, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception:
+        payload = {}
+    models = payload.get("models") if isinstance(payload, dict) else None
+    table: dict[str, int] = {}
+    if isinstance(models, dict):
+        for key, row in models.items():
+            value = row.get("context_window_tokens") if isinstance(row, dict) else row
+            window = _plausible(value)
+            if window:
+                table[_leaf_name(key)] = window
+    _DATA_FILE_CACHE.update({"mtime": mtime, "data": table})
+    return table
+
+
+def _data_file_window(model_name: str) -> int | None:
+    table = load_context_window_data()
+    if not table:
+        return None
+    exact = table.get(_leaf_name(model_name))
+    if exact:
+        return exact
+    return table.get(normalize_model_selector(model_name))
+
+
+# ── step 7: the Claude family ────────────────────────────────────────────────
+
+def is_claude_family_model(model_name: Any) -> bool:
+    lower = strip_one_m_selector(model_name).lower()
+    return any(token in lower for token in ("claude", "opus", "sonnet", "haiku"))
+
+
+def claude_family_context_window(model_name: Any) -> int | None:
+    """Anthropic's own models: 1M for Opus/Sonnet, the standard 200K for Haiku.
+
+    A family rule rather than a name list, so a new Claude release needs no
+    entry. Whether 1M is actually *used* stays with the caller: a sensitive
+    provider keeps it disabled through ``enable_claude_1m``.
+    """
+    if not is_claude_family_model(model_name):
+        return None
+    lower = strip_one_m_selector(model_name).lower()
+    if "haiku" in lower:
+        return CLAUDE_STANDARD_CONTEXT_WINDOW
+    return CLAUDE_ONE_M_CONTEXT_WINDOW
+
+
+# ── the chain ────────────────────────────────────────────────────────────────
+
+def _runtime_base_url(runtime: Any) -> str:
+    if not isinstance(runtime, dict):
+        return ""
+    for key in ("openai_base_url", "anthropic_base_url", "base_url"):
+        value = str(runtime.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def user_context_window_override(model_name: Any, *, provider_id: Any = None, runtime: Any = None) -> int | None:
+    """The window the user pinned in ``model-context-overrides.json``, if any.
+
+    The top of the chain, exposed on its own so a harness that resolves its own
+    capability facts can still put the user's file above them instead of
+    silently ignoring it.
+    """
+    raw_model = str(model_name or "").strip()
+    if not raw_model:
+        return None
+    runtime_id = runtime.get("id") if isinstance(runtime, dict) else ""
+    provider_key = str(provider_id or runtime_id or "").strip()
+    clean = strip_one_m_selector(raw_model)
+    for candidate in ([raw_model] if raw_model == clean else [raw_model, clean]):
+        window, _source = _override_window(candidate, provider_key)
+        if window:
+            return window
+    return None
+
+
+def context_window_sources(model_name: Any, *, provider_id: Any = None, runtime: Any = None) -> dict[str, Any]:
+    """Resolve the window and report which step of the chain answered."""
+    raw_model = str(model_name or "").strip()
+    runtime_id = runtime.get("id") if isinstance(runtime, dict) else ""
+    provider_key = str(provider_id or runtime_id or "").strip()
+    result = {
+        "model": raw_model,
+        "provider_id": provider_key,
+        "context_window_tokens": None,
+        "source": "unresolved",
+    }
+    if not raw_model:
+        return result
+
+    base_url = _runtime_base_url(runtime)
+    clean = strip_one_m_selector(raw_model)
+    # The name as written first, then without the selector: an explicit entry for
+    # the suffixed name is a deliberate statement that it is a different
+    # selector, and only then does stripping apply.
+    candidates = [raw_model] if raw_model == clean else [raw_model, clean]
+
+    for candidate in candidates:
+        window, source = _override_window(candidate, provider_key)
+        if window:
+            result.update({"context_window_tokens": window, "source": source})
+            return result
+
+    caps_by_candidate = {
+        candidate: _model_capabilities(candidate, provider_key, base_url) for candidate in candidates
+    }
+    for accepted in (_USER_CAPABILITY_SOURCES, _APPROVED_CAPABILITY_SOURCES, _PROFILE_CAPABILITY_SOURCES):
+        for candidate in candidates:
+            window, source = _capability_window(caps_by_candidate[candidate], accepted)
+            if window:
+                result.update({"context_window_tokens": window, "source": source})
+                return result
+
+    window = _remote_listing_window(raw_model, provider_key)
+    if window:
+        result.update({"context_window_tokens": window, "source": "remote_listing"})
+        return result
+
+    window = _data_file_window(raw_model)
+    if window:
+        result.update({"context_window_tokens": window, "source": "context_window_data"})
+        return result
+
+    window = claude_family_context_window(raw_model)
+    if window:
+        result.update({"context_window_tokens": window, "source": "claude_family"})
+        return result
+
+    return result
+
+
+def resolve_context_window(model_name: Any, *, provider_id: Any = None, runtime: Any = None) -> int | None:
+    """The window for this model on this provider, or ``None`` when unknown."""
+    return context_window_sources(model_name, provider_id=provider_id, runtime=runtime)[
+        "context_window_tokens"
+    ]
+
+
+def clear_context_window_caches() -> None:
+    """Drop the overrides/data-file caches; for tests and config reloads."""
+    _OVERRIDES_CACHE.update({"path": None, "mtime": None, "data": None})
+    _DATA_FILE_CACHE.update({"mtime": None, "data": None})

--- a/mms_core.py
+++ b/mms_core.py
@@ -1197,14 +1197,12 @@ _REASONING_MODEL_HINTS = (
     "minimax-m2", "deepseek-reasoner", "doubao-thinking",
 )
 _TOOL_USE_FAMILIES = {"Claude", "GPT", "Gemini", "Qwen", "Kimi", "GLM", "MiniMax"}
+# Keys are `[1m]`-free: a selector is the same model as its base name, and
+# `_model_supports_vision` normalizes the suffix off before looking here.
 _VISION_CAPABLE_MODEL_NAMES = {
     "mimo-v2.5",
-    # A `[1m]` selector is the same model as its base name, so it must not
-    # disagree about reading images.
-    "mimo-v2.5[1m]",
     "mimo-v2-omni",
     "k3",
-    "k3[1m]",
     "kimi-k3",
     "k2.6",
     "k2.6-code-preview",
@@ -2250,31 +2248,10 @@ def _provider_map(cfg):
 
 
 def _model_context_window(model_name):
-    clean = str(model_name or "").replace("[1m]", "").strip()
-    if not clean:
-        return None
-    try:
-        from mms_capability_resolver import resolve_model_capabilities
+    """The model's context window, from the one resolver every harness uses."""
+    from mms_context_window import resolve_context_window
 
-        caps = resolve_model_capabilities(clean)
-        if caps.get("sources", {}).get("context_window_tokens") in {"approved_facts", "model_policy", "manual_override"}:
-            window = int(caps.get("context_window_tokens"))
-            if window > 0:
-                return window
-    except Exception:
-        pass
-    try:
-        from mms_launchers import _MODEL_CONTEXT_WINDOWS
-    except Exception:
-        return None
-    window = _MODEL_CONTEXT_WINDOWS.get(clean)
-    if window is not None:
-        return window
-    lower = clean.lower()
-    for key, value in _MODEL_CONTEXT_WINDOWS.items():
-        if key.lower() == lower:
-            return value
-    return None
+    return resolve_context_window(model_name)
 
 
 def _native_clis_for_model(model_name):
@@ -2410,10 +2387,11 @@ def _model_capability_tags(model_name):
 
 
 def _model_supports_vision(model_name):
-    normalized = str(model_name or "").strip().lower()
-    if not normalized:
+    from mms_context_window import normalize_model_selector
+
+    model_id = normalize_model_selector(model_name)
+    if not model_id:
         return False
-    model_id = normalized.rsplit("/", 1)[-1]
     if model_id in _VISION_CAPABLE_MODEL_NAMES:
         return True
     return any(hint in model_id for hint in _VISION_CAPABLE_MODEL_HINTS)
@@ -7450,6 +7428,45 @@ def _probe_async_min_interval(cfg=None):
     return _PROBE_ASYNC_MIN_INTERVAL
 
 
+def _listing_model_details(payload):
+    """Per-model facts an upstream /models listing reported, worth keeping.
+
+    Only the context-window fields, so a provider that publishes a window for a
+    model MMS has never heard of still sizes it correctly (issue #230). Nothing
+    here is interpreted; `mms_context_window` decides what to do with it.
+    """
+    from mms_context_window import REMOTE_LISTING_CONTEXT_KEYS
+
+    items = payload.get("data") if isinstance(payload, dict) else None
+    details = {}
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("id") or "").strip()
+        if not model_id:
+            continue
+        row = {}
+        for field in REMOTE_LISTING_CONTEXT_KEYS:
+            try:
+                value = int(item.get(field))
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                row[field] = value
+        top_provider = item.get("top_provider")
+        if isinstance(top_provider, dict):
+            for field in REMOTE_LISTING_CONTEXT_KEYS:
+                try:
+                    value = int(top_provider.get(field))
+                except (TypeError, ValueError):
+                    continue
+                if value > 0:
+                    row.setdefault("top_provider", {})[field] = value
+        if row:
+            details[model_id] = row
+    return details
+
+
 def _probe_file_cache_path(provider_id):
     return os.path.join(_PROBE_FILE_CACHE_DIR, f"models_{provider_id}.json")
 
@@ -7521,17 +7538,18 @@ def _save_probe_file_cache(provider_id, result):
     try:
         os.makedirs(_PROBE_FILE_CACHE_DIR, exist_ok=True)
         path = _probe_file_cache_path(provider_id)
+        payload = {
+            "raw_models": result.get("raw_models") or [],
+            "working_url": result.get("working_url"),
+            "base_source": base_source or "remote",
+            "error": result.get("error"),
+            "error_kind": result.get("error_kind"),
+        }
+        model_details = result.get("model_details")
+        if isinstance(model_details, dict) and model_details:
+            payload["model_details"] = model_details
         with open(path, "w") as f:
-            json.dump(
-                {
-                    "raw_models": result.get("raw_models") or [],
-                    "working_url": result.get("working_url"),
-                    "base_source": base_source or "remote",
-                    "error": result.get("error"),
-                    "error_kind": result.get("error_kind"),
-                },
-                f,
-            )
+            json.dump(payload, f)
     except Exception:
         pass
 
@@ -7811,6 +7829,7 @@ def _probe_models(provider, emit_output=True, force_refresh=False, skip_cache=Fa
                     models.sort()
                     result["raw_models"] = models
                     result["models"] = models
+                    result["model_details"] = _listing_model_details(data)
                     result["working_url"] = try_url
                     attempts.append({"url": f"{try_url}{models_endpoint}", "status": f"ok ({len(models)} models)"})
                     if try_url != base_url and emit_output:

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -126,8 +126,6 @@ from mms_context_window import (
     ONE_M_SELECTOR_SUFFIX as _ONE_M_CONTEXT_SUFFIX,
     DEFAULT_CONTEXT_WINDOW as _DEFAULT_CONTEXT_WINDOW,
     coerce_context_window as _coerce_context_window,
-    context_window_sources,
-    load_model_context_overrides,
     resolve_context_window,
     strip_one_m_selector as _strip_one_m_context_suffix,
 )

--- a/mms_launchers.py
+++ b/mms_launchers.py
@@ -122,7 +122,16 @@ from mms_project_store import (
     read_slot_marker,
     write_slot_marker,
 )
-from mms_provider_profiles import profile_context_window, resolve_provider_profile
+from mms_context_window import (
+    ONE_M_SELECTOR_SUFFIX as _ONE_M_CONTEXT_SUFFIX,
+    DEFAULT_CONTEXT_WINDOW as _DEFAULT_CONTEXT_WINDOW,
+    coerce_context_window as _coerce_context_window,
+    context_window_sources,
+    load_model_context_overrides,
+    resolve_context_window,
+    strip_one_m_selector as _strip_one_m_context_suffix,
+)
+from mms_provider_profiles import resolve_provider_profile
 from mms_reasoning_effort import model_supports_max_reasoning_effort
 import mms_pi_support as _pi_support
 import mms_vision_relay
@@ -343,84 +352,6 @@ def _apply_runtime_locale_profile(env, runtime=None):
     env.update(_runtime_locale_env(runtime))
     return env
 
-# ── 已知模型的 context window（tokens）──
-# 用于设置 CLAUDE_CODE_AUTO_COMPACT_WINDOW，使 Claude Code 按实际模型 context 触发 compact。
-# 来源：各厂商官方 API 文档 / OpenRouter / HuggingFace，2026-03 更新。
-_MODEL_CONTEXT_WINDOWS = {
-    # Claude — 标准 200k，[1m] 变体由 Claude Code 内部处理
-    "claude-opus-4-6": 1_000_000,
-    "claude-sonnet-4-6": 1_000_000,
-    "claude-haiku-4-5-20251001": 200_000,
-    "claude-haiku-4-5": 200_000,
-    # Kimi K3 is a native 1M model. `k3[1m]` remains input compatibility only.
-    "k3": 1_048_576,
-    "k3[1m]": 1_048_576,
-    "kimi-k3": 1_048_576,
-    "moonshotai/kimi-k3": 1_048_576,
-    "kimi-for-coding": 262_144,
-    "kimi-for-coding-highspeed": 262_144,
-    "kimi-k2.7-code": 262_144,
-    "kimi-k2.7-code-highspeed": 262_144,
-    "kimi-k2.5": 262_144,
-    "kimi-k2.6": 262_144,
-    "kimi-k2.6-code-preview": 262_144,
-    "K2.6": 262_144,
-    "K2.6-code-preview": 262_144,
-    # Qwen — hosted plus/coder-plus/3.6-plus 支持 1M；qwen3-max 为 262K
-    "qwen3.5-plus": 1_000_000,
-    "qwen3.6-plus": 1_000_000,
-    "qwen3-coder-plus": 1_000_000,
-    "qwen3-max": 262_144,
-    # GLM — 全系 200K
-    "glm-5": 200_000,
-    "glm-5-turbo": 200_000,
-    "glm-5.1": 200_000,
-    "glm-4.7": 200_000,
-    # MiniMax / MiMo — MiMo [1m] suffix is not universally accepted; keep safe 256K default.
-    "mimo-v2-pro": 262_144,
-    "MiniMax-M2.5": 196_608,
-    "MiniMax-M2.7": 200_000,
-    # GPT-5 系列 — 大部分 1M，nano 256K
-    "gpt-5": 1_000_000,
-    "gpt-5-mini": 1_000_000,
-    "gpt-5-nano": 256_000,
-    "gpt-5-codex": 1_000_000,
-    "gpt-5.1-codex": 1_000_000,
-    "gpt-5.1-codex-max": 1_000_000,
-    "gpt-5.1-codex-mini": 1_000_000,
-    "gpt-5.2": 1_000_000,
-    "gpt-5.2-codex": 1_000_000,
-    "gpt-5.3-codex": 1_000_000,
-    "gpt-5.3-codex-spark": 1_000_000,
-    "gpt-5.4": 1_000_000,
-    "gpt-5.4-pro": 1_000_000,
-}
-_DEFAULT_CONTEXT_WINDOW = 200_000  # 未知模型的安全默认值
-_ONE_M_CONTEXT_SUFFIX = "[1m]"
-_ONE_M_SUFFIX_CONTEXT_WINDOWS = {
-    # MiMo documents [1m] as an opt-in long-context suffix for Claude Code.
-    "mimo-v2.5-pro": 1_000_000,
-    "mimo-v2.5": 1_000_000,
-}
-_ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS = {
-    # MiMo still uses an explicit selector. K3 is resolved by provider profile.
-    "mimo-v2.5-pro": 262_144,
-    "mimo-v2.5": 262_144,
-}
-_MIMO_PLAIN_ONE_M_CONTEXT_WINDOWS = {
-    "mimo-v2.5-pro": 1_048_576,
-    "mimo-v2.5": 1_048_576,
-}
-_MIMO_PLAIN_ONE_M_PROVIDER_HINTS = (
-    "openrouter",
-    "mimo-openai",
-    "mimo-direct-openai",
-    "xiaomi-openai",
-    "openai-mimo",
-)
-
-
-
 def _provider_id_set_from_env(env_name):
     raw = str(os.environ.get(env_name) or "").strip()
     return {
@@ -439,48 +370,6 @@ def _runtime_declares_sensitive_claude(runtime):
         "private",
         "isolated",
     }
-
-
-def _coerce_context_window(value):
-    try:
-        window = int(value)
-    except Exception:
-        return None
-    return window if window > 0 else None
-
-
-def _provider_advertises_plain_mimo_1m(provider_id):
-    provider = str(provider_id or "").strip().lower()
-    return bool(provider and any(token in provider for token in _MIMO_PLAIN_ONE_M_PROVIDER_HINTS))
-
-
-def _capability_context_window(model_name, *, provider_id=None, accepted_sources=None):
-    try:
-        caps = resolve_model_capabilities(str(model_name or "").strip(), provider_id=provider_id or "")
-    except Exception:
-        if accepted_sources is None or "model_policy" not in set(accepted_sources):
-            return None
-        try:
-            from mms_capability_resolver import load_default_model_policy
-
-            caps = resolve_model_capabilities(
-                str(model_name or "").strip(),
-                provider_id=provider_id or "",
-                approved_facts={},
-                model_policy=load_default_model_policy(),
-            )
-        except Exception:
-            return None
-    source = caps.get("sources", {}).get("context_window_tokens")
-    if accepted_sources is not None and source not in set(accepted_sources):
-        return None
-    return _coerce_context_window(caps.get("context_window_tokens"))
-
-
-def _plain_kimi_k3_profile_context_window(model_name, *, provider_id=None):
-    # K3 is natively 1M. Keep this compatibility seam empty so no old safe-base
-    # guard can downgrade the model after a capability refresh.
-    return None
 
 
 def _capability_max_output_tokens(model_name, *, provider_id=None, accepted_sources=None):
@@ -506,181 +395,15 @@ def _capability_max_output_tokens(model_name, *, provider_id=None, accepted_sour
     return _coerce_context_window(caps.get("max_output_tokens"))
 
 
-def _model_context_overrides_path():
-    try:
-        config_root = _resolve_mms_config_dir()
-    except Exception:
-        config_root = _real_user_path(".config", "mms-next")
-    return os.path.join(config_root, "model-context-overrides.json")
-
-
-def _load_model_context_overrides():
-    overrides_path = _model_context_overrides_path()
-    try:
-        mtime = os.path.getmtime(overrides_path)
-    except OSError:
-        _MODEL_CONTEXT_OVERRIDES_CACHE["path"] = overrides_path
-        _MODEL_CONTEXT_OVERRIDES_CACHE["mtime"] = None
-        _MODEL_CONTEXT_OVERRIDES_CACHE["data"] = {"models": {}, "provider_overrides": {}}
-        return _MODEL_CONTEXT_OVERRIDES_CACHE["data"]
-
-    if _MODEL_CONTEXT_OVERRIDES_CACHE.get("path") == overrides_path and _MODEL_CONTEXT_OVERRIDES_CACHE["mtime"] == mtime:
-        return _MODEL_CONTEXT_OVERRIDES_CACHE["data"]
-
-    models = {}
-    provider_overrides = {}
-    try:
-        with open(overrides_path, "r", encoding="utf-8") as f:
-            payload = json.load(f)
-    except Exception:
-        payload = {}
-
-    if isinstance(payload, dict):
-        raw_models = payload.get("models", payload)
-        if isinstance(raw_models, dict):
-            for key, value in raw_models.items():
-                if key in {"models", "provider_overrides"}:
-                    continue
-                window = _coerce_context_window(value)
-                if window:
-                    models[str(key).strip()] = window
-
-        raw_provider_overrides = payload.get("provider_overrides", {})
-        if isinstance(raw_provider_overrides, dict):
-            for key, value in raw_provider_overrides.items():
-                if isinstance(value, dict):
-                    provider_id = str(key or "").strip()
-                    if not provider_id:
-                        continue
-                    for model_id, window_value in value.items():
-                        window = _coerce_context_window(window_value)
-                        if window:
-                            provider_overrides[f"{provider_id}:{str(model_id).strip()}"] = window
-                else:
-                    window = _coerce_context_window(value)
-                    if window:
-                        provider_overrides[str(key).strip()] = window
-
-    _MODEL_CONTEXT_OVERRIDES_CACHE["path"] = overrides_path
-    _MODEL_CONTEXT_OVERRIDES_CACHE["mtime"] = mtime
-    _MODEL_CONTEXT_OVERRIDES_CACHE["data"] = {
-        "models": models,
-        "provider_overrides": provider_overrides,
-    }
-    return _MODEL_CONTEXT_OVERRIDES_CACHE["data"]
-
-
 def _lookup_context_window(model_name, provider_id=None):
-    raw_model = str(model_name or "").strip()
-    if not raw_model:
-        return None
+    """The configured context window for this model, or None when unknown.
 
-    provider_key = str(provider_id or "").strip()
-    raw_lower = raw_model.lower()
-    has_1m_suffix = _ONE_M_CONTEXT_SUFFIX in raw_lower
-    clean = raw_model.replace(_ONE_M_CONTEXT_SUFFIX, "").replace(_ONE_M_CONTEXT_SUFFIX.upper(), "").strip()
-    lower = clean.lower()
-    overrides = _load_model_context_overrides()
+    One resolver answers for every harness (issue #230); this stays as the
+    launcher's seam so the Claude/Codex/OpenCode injection sites keep their own
+    mechanics.
+    """
+    return resolve_context_window(model_name, provider_id=provider_id)
 
-    def _provider_override_lookup(candidate, candidate_lower):
-        if not provider_key:
-            return None
-        provider_overrides = overrides.get("provider_overrides", {})
-        direct = provider_overrides.get(f"{provider_key}:{candidate}")
-        if direct is not None:
-            return direct
-        for key, value in provider_overrides.items():
-            try:
-                override_provider, override_model = key.split(":", 1)
-            except ValueError:
-                continue
-            if override_provider == provider_key and override_model.lower() == candidate_lower:
-                return value
-        return None
-
-    def _model_override_lookup(candidate, candidate_lower):
-        models = overrides.get("models", {})
-        direct = models.get(candidate)
-        if direct is not None:
-            return direct
-        for key, value in models.items():
-            if key.lower() == candidate_lower:
-                return value
-        return None
-
-    # Exact [1m] overrides must win before suffix stripping.
-    provider_exact = _provider_override_lookup(raw_model, raw_lower)
-    if provider_exact is not None:
-        return provider_exact
-    model_exact = _model_override_lookup(raw_model, raw_lower)
-    if model_exact is not None:
-        return model_exact
-
-    if has_1m_suffix:
-        suffixed_window = _ONE_M_SUFFIX_CONTEXT_WINDOWS.get(lower)
-        if suffixed_window is not None:
-            return suffixed_window
-
-    # User policy is the preferred surface for context size. It must win before
-    # the legacy k3/MiMo safe-base guards that otherwise cap plain model names.
-    policy_window = _capability_context_window(
-        clean,
-        provider_id=provider_id,
-        accepted_sources={"model_policy", "manual_override"},
-    )
-    if policy_window is not None:
-        return policy_window
-
-    profile_safe_selector_window = None
-    if not has_1m_suffix:
-        profile_safe_selector_window = _plain_kimi_k3_profile_context_window(
-            clean,
-            provider_id=provider_id,
-        )
-    if profile_safe_selector_window is not None:
-        return profile_safe_selector_window
-
-    if not has_1m_suffix:
-        # Latest-approved capability facts are the WebUI/runtime truth after
-        # preview publish. Keep the MiMo safe-base branch as a fallback only;
-        # K3 is resolved by the provider-aware profile below.
-        approved_window = _capability_context_window(
-            clean,
-            provider_id=provider_id,
-            accepted_sources={"approved_facts", "model_policy", "manual_override"},
-        )
-        if approved_window is not None:
-            return approved_window
-
-        if _provider_advertises_plain_mimo_1m(provider_key):
-            plain_one_m_window = _MIMO_PLAIN_ONE_M_CONTEXT_WINDOWS.get(lower)
-            if plain_one_m_window is not None:
-                return plain_one_m_window
-        else:
-            safe_base_window = _ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS.get(lower)
-            if safe_base_window is not None:
-                return safe_base_window
-
-    if provider_key:
-        provider_clean = _provider_override_lookup(clean, lower)
-        if provider_clean is not None:
-            return provider_clean
-
-    model_clean = _model_override_lookup(clean, lower)
-    if model_clean is not None:
-        return model_clean
-
-    profiled = profile_context_window(clean, provider_id=provider_id or "")
-    if profiled is not None:
-        return profiled
-
-    direct = _MODEL_CONTEXT_WINDOWS.get(clean)
-    if direct is not None:
-        return direct
-    for key, value in _MODEL_CONTEXT_WINDOWS.items():
-        if key.lower() == lower:
-            return value
-    return None
 
 def _runtime_supports_claude_1m(runtime):
     explicit = _normalize_claude_1m_mode((runtime or {}).get("claude_1m_mode", "auto"))
@@ -1070,7 +793,6 @@ def _record_account_guard_finalize(account_id, *, exit_code=None, stale_cleanup=
         atomic_write_json(path, state, mode=0o600)
 
 
-_MODEL_CONTEXT_OVERRIDES_CACHE = {"path": None, "mtime": None, "data": {"models": {}, "provider_overrides": {}}}
 _CLAUDE_NETWORK_GUARD_CACHE: dict = {}
 _CLAUDE_NETWORK_GUARD_TTL_SEC = 20.0
 _SESSION_GUARD_MARKER_NAME = ".mms-session-guard.json"
@@ -3445,11 +3167,6 @@ def _claude_code_effort_env_value(model_name, runtime):
     return ""
 
 
-def _is_kimi_k3_claude_env_model(model_name):
-    model = str(model_name or "").strip().lower().rsplit("/", 1)[-1]
-    return model == "kimi-k3" or model == "k3" or model.startswith("k3[")
-
-
 def _is_non_claude_routed_model(model_name):
     """桥接场景下真实路由到非 Claude 家族模型的判定（剥 [1m]、取末段）。"""
     model = _normalized_model_name(model_name)
@@ -3464,14 +3181,11 @@ def _apply_claude_context_env_overrides(env, *, context_window, model_names=()):
         return env
     env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = str(window)
     env["CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE"] = str(max(window - 3000, 10000))
-    # 非 Claude 桥接模型 + window>=1M 时，Claude Code 的 [1m] 壳名豁免不生效，
-    # 必须显式给 CLAUDE_CODE_MAX_CONTEXT_TOKENS 才能撑开 autocompact 阈值。
-    needs_explicit_context_cap = any(
-        _is_kimi_k3_claude_env_model(model)
-        or (window >= 1_000_000 and _is_non_claude_routed_model(model))
-        for model in model_names
-    )
-    if needs_explicit_context_cap:
+    # Claude Code sizes a routed model by its own [1m] shell-name rule, which
+    # says nothing about someone else's model. Whenever we know the window of a
+    # non-Claude model, state it: without this the client keeps its own cap and
+    # compacts early. No model name and no 1M threshold decides this.
+    if any(_is_non_claude_routed_model(model) for model in model_names):
         env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] = str(window)
     return env
 
@@ -9131,17 +8845,6 @@ def _normalized_model_name(model_name):
     if not isinstance(model_name, str):
         return ""
     return model_name.strip()
-
-
-def _strip_one_m_context_suffix(model_name):
-    normalized = _normalized_model_name(model_name)
-    if not normalized:
-        return ""
-    return (
-        normalized.replace(_ONE_M_CONTEXT_SUFFIX, "")
-        .replace(_ONE_M_CONTEXT_SUFFIX.upper(), "")
-        .strip()
-    )
 
 
 def _is_claude_family_model_name(model_name):

--- a/mms_opencode_config.py
+++ b/mms_opencode_config.py
@@ -918,6 +918,12 @@ def opencode_model_config(
         except (TypeError, ValueError):
             context_window = None
     if not context_window:
+        # The user's own `model-context-overrides.json` is the top of the shared
+        # context chain and must hold here too, not only in the launcher.
+        from mms_context_window import user_context_window_override
+
+        context_window = user_context_window_override(model, runtime=runtime)
+    if not context_window:
         context_window = opencode_capability_int(runtime, model, "context_window_tokens", "max_context_tokens")
     if not context_window and callable(context_window_resolver):
         context_window = context_window_resolver(

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -24,6 +24,7 @@ from mms_provider_profiles import resolve_provider_profile
 from mms_provider_profiles import profile_thinking_capabilities
 from mms_state_io import atomic_write_text
 
+
 def _launchers_module():
     import mms_launchers
     return mms_launchers

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -11,19 +11,18 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 from mms_capability_resolver import resolve_model_capabilities
+from mms_context_window import (
+    ONE_M_SELECTOR_SUFFIX as _ONE_M_CONTEXT_SUFFIX,
+    normalize_model_selector,
+    resolve_context_window,
+    user_context_window_override,
+)
 from mms_core import _model_supports_vision, _probe_models
 from mms_opencode_config import opencode_config_slug as _opencode_config_slug
 from mms_pi_capture import apply_capture_proxy as apply_pi_capture_proxy
 from mms_provider_profiles import resolve_provider_profile
 from mms_provider_profiles import profile_thinking_capabilities
 from mms_state_io import atomic_write_text
-
-_ONE_M_CONTEXT_SUFFIX = "[1m]"
-_ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS = {
-    "mimo-v2.5-pro": 262_144,
-    "mimo-v2.5": 262_144,
-}
-
 
 def _launchers_module():
     import mms_launchers
@@ -404,7 +403,6 @@ _PI_MODEL_MAX_TOKENS_HINTS = {
     "gpt-5.3-codex": 128000,
     "gpt-5.3-codex-spark": 32000,
     "k3": 1048576,
-    "k3[1m]": 1048576,
     "kimi-k3": 1048576,
     "k2.6": 32768,
     "k2.6-code-preview": 32768,
@@ -418,23 +416,10 @@ _PI_MODEL_MAX_TOKENS_HINTS = {
     "mimo-v2-pro": 131072,
     "mimo-v2.5": 131072,
     "mimo-v2.5-pro": 131072,
-    "mimo-v2.5-pro[1m]": 131072,
-    "mimo-v2.5[1m]": 131072,
     "qwen3.5-plus": 65536,
     "qwen3.6-flash": 65536,
     "qwen3.6-plus": 65536,
     "qwen3.7-max": 65536,
-}
-
-_PI_MODEL_CONTEXT_WINDOW_HINTS = {
-    "gpt-5.3-codex": 400000,
-    "gpt-5.3-codex-spark": 128000,
-    # Kimi K3 is natively 1M; the selector is kept only for old config input.
-    "k3": 1048576,
-    "k3[1m]": 1048576,
-    "kimi-k3": 1048576,
-    "qwen3.6-flash": 1000000,
-    "qwen3.7-max": 1000000,
 }
 
 _PI_MODEL_INPUT_HINTS = {
@@ -443,7 +428,6 @@ _PI_MODEL_INPUT_HINTS = {
     "gpt-5.3-codex": ["text", "image"],
     "gpt-5.3-codex-spark": ["text", "image"],
     "k3": ["text", "image"],
-    "k3[1m]": ["text", "image"],
     "kimi-k3": ["text", "image"],
     "kimi-for-coding": ["text", "image"],
     "kimi-for-coding-highspeed": ["text", "image"],
@@ -523,6 +507,17 @@ def _pi_normalize_model_key(value):
     return model_key
 
 
+def _pi_hint_key(value):
+    """Key for the capability hint tables: leaf name, lower case, no `[1m]`.
+
+    A `[1m]` selector is the same model as its base name and must not need a
+    duplicate row of its own (issue #230). Only the hint tables use this;
+    wire-name and replacement lookups keep the exact selector, because there the
+    suffix can be part of a real upstream name.
+    """
+    return normalize_model_selector(value)
+
+
 def _pi_reference_payload():
     global _PI_CAPABILITY_REFERENCE_CACHE
     if _PI_CAPABILITY_REFERENCE_CACHE is not None:
@@ -574,7 +569,7 @@ def _pi_first_positive_int(payload, *keys):
 
 
 def _pi_hint_max_tokens(model_name):
-    normalized = _pi_normalize_model_key(model_name)
+    normalized = _pi_hint_key(model_name)
     direct = _PI_MODEL_MAX_TOKENS_HINTS.get(normalized)
     if direct:
         return direct
@@ -584,15 +579,14 @@ def _pi_hint_max_tokens(model_name):
     return None
 
 
-def _pi_hint_context_window(model_name):
-    normalized = _pi_normalize_model_key(model_name)
-    direct = _PI_MODEL_CONTEXT_WINDOW_HINTS.get(normalized)
-    if direct:
-        return direct
-    for key, value in _PI_MODEL_CONTEXT_WINDOW_HINTS.items():
-        if normalized.startswith(key):
-            return value
-    return None
+def _pi_hint_context_window(model_name, provider_id=""):
+    """Fall back to the shared resolver, never to a Pi-only model-name table.
+
+    Pi used to keep its own map of model to window, which is how the same model
+    could be 1M here and 256K in Claude Code. Everything Pi cannot resolve from
+    the capability facts now asks the one resolver (issue #230).
+    """
+    return resolve_context_window(model_name, provider_id=provider_id)
 
 
 def _pi_reference_supports_vision(model_name):
@@ -707,7 +701,7 @@ def _pi_model_input_types(model_name, caps=None):
     user_vision = _pi_caps_vision_state(caps, _USER_CAPABILITY_SOURCES)
     if user_vision is not None:
         return ["text", "image"] if user_vision else ["text"]
-    normalized = _pi_normalize_model_key(model_name)
+    normalized = _pi_hint_key(model_name)
     hint = _PI_MODEL_INPUT_HINTS.get(normalized)
     if isinstance(hint, list) and hint:
         return list(hint)
@@ -914,10 +908,10 @@ def _pi_model_capabilities(runtime, model_name):
             caps["sources"]["context_window_tokens"] = "pi_reference_fallback"
 
     if caps.get("sources", {}).get("context_window_tokens") == "conservative_fallback":
-        hinted_context = _pi_hint_context_window(model_name)
+        hinted_context = _pi_hint_context_window(model_name, provider_id=provider_id)
         if hinted_context:
             caps["context_window_tokens"] = hinted_context
-            caps["sources"]["context_window_tokens"] = "pi_builtin_hint"
+            caps["sources"]["context_window_tokens"] = "shared_context_resolver"
 
     if caps.get("sources", {}).get("max_output_tokens") == "conservative_fallback":
         reference_max = _pi_first_positive_int(
@@ -934,6 +928,13 @@ def _pi_model_capabilities(runtime, model_name):
         if hinted_max:
             caps["max_output_tokens"] = hinted_max
             caps["sources"]["max_output_tokens"] = "pi_builtin_hint"
+
+    # The user's own `model-context-overrides.json` is the top of the shared
+    # chain, so it has to reach Pi too, not just the launcher.
+    override = user_context_window_override(model_name, provider_id=provider_id)
+    if override:
+        caps["context_window_tokens"] = override
+        caps.setdefault("sources", {})["context_window_tokens"] = "user_override"
     return caps
 
 
@@ -1224,7 +1225,10 @@ def _pi_wire_model_name(runtime, model_name, protocol):
     if original_model.lower().endswith(_ONE_M_CONTEXT_SUFFIX):
         base_model = original_model[: -len(_ONE_M_CONTEXT_SUFFIX)].strip()
         normalized_base = _pi_normalize_model_key(base_model)
-        if normalized_base in _ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS:
+        # MiMo's `[1m]` is an MMS-side selector: the channel exposes the base
+        # name, so that is what goes on the wire. The same judgement the Claude
+        # shell slots use, not a second list.
+        if launchers._is_mimo_one_m_context_selector(original_model):
             available = {}
             for candidate in launchers._pi_runtime_model_names(runtime, selected_model=model_name):
                 normalized_candidate = _pi_normalize_model_key(candidate)

--- a/tests/test_claude_isolation.py
+++ b/tests/test_claude_isolation.py
@@ -895,7 +895,9 @@ def test_model_context_overrides_follow_selected_config_root(monkeypatch, tmp_pa
         json.dumps({"models": {"root-selected-model": 222_000}}),
         encoding="utf-8",
     )
-    mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE.update({"path": None, "mtime": None, "data": {"models": {}, "provider_overrides": {}}})
+    import mms_context_window
+
+    mms_context_window.clear_context_window_caches()
 
     monkeypatch.setenv("MMS_REAL_HOME", str(real_home))
     monkeypatch.setenv("REAL_HOME", str(real_home))
@@ -906,14 +908,14 @@ def test_model_context_overrides_follow_selected_config_root(monkeypatch, tmp_pa
 
     # No explicit root: the default is mms-next.
     assert mms_launchers._lookup_context_window("root-selected-model") == 222_000
-    assert mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
+    assert mms_context_window._OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
 
     # An explicit pin at the retired legacy root is redirected to the shared
     # root (#177): a stale shell export must not resurrect the old config.
     monkeypatch.setenv("MMS_CONFIG_ROOT", str(stable_root))
 
     assert mms_launchers._lookup_context_window("root-selected-model") == 222_000
-    assert mms_launchers._MODEL_CONTEXT_OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
+    assert mms_context_window._OVERRIDES_CACHE["path"] == str(preview_root / "model-context-overrides.json")
 
 
 def test_mmf_wrapper_selects_mms_next_without_stable_fallback(tmp_path):

--- a/tests/test_codex_reasoning_effort_launch.py
+++ b/tests/test_codex_reasoning_effort_launch.py
@@ -27,18 +27,24 @@ def test_claude_kimi_k3_context_env_follows_user_policy(monkeypatch):
     """K3 has no MMS-specific ``[1m]`` selector: user policy wins for every alias."""
     import mms_launchers
 
+    import mms_capability_resolver
+    import mms_context_window
+
     monkeypatch.setattr(
-        mms_launchers,
-        "_load_model_context_overrides",
+        mms_context_window,
+        "load_model_context_overrides",
         lambda: {"models": {}, "provider_overrides": {}},
     )
 
-    def fake_capability_context_window(model_name, *, provider_id=None, accepted_sources=None):
-        if str(model_name).lower() == "k3" and accepted_sources == {"model_policy", "manual_override"}:
-            return 1_000_000
-        return None
+    def fake_capabilities(model_name, *, provider_id="", **_kwargs):
+        if str(model_name).lower() == "k3":
+            return {
+                "context_window_tokens": 1_000_000,
+                "sources": {"context_window_tokens": "model_policy"},
+            }
+        return {"context_window_tokens": 0, "sources": {"context_window_tokens": "conservative_fallback"}}
 
-    monkeypatch.setattr(mms_launchers, "_capability_context_window", fake_capability_context_window)
+    monkeypatch.setattr(mms_capability_resolver, "resolve_model_capabilities", fake_capabilities)
 
     assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 1_000_000
     assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_000_000
@@ -48,12 +54,16 @@ def test_claude_kimi_k3_without_policy_uses_profile_one_million_window(monkeypat
     """Without a policy the provider profile decides, and it records K3 as native 1M."""
     import mms_launchers
 
+    import mms_capability_resolver
+    import mms_context_window
+
     monkeypatch.setattr(
-        mms_launchers,
-        "_load_model_context_overrides",
+        mms_context_window,
+        "load_model_context_overrides",
         lambda: {"models": {}, "provider_overrides": {}},
     )
-    monkeypatch.setattr(mms_launchers, "_capability_context_window", lambda *_a, **_k: None)
+    monkeypatch.setattr(mms_capability_resolver, "_load_default_approved_facts_shared", lambda: {})
+    monkeypatch.setattr(mms_capability_resolver, "load_default_model_policy", lambda: {})
 
     assert mms_launchers._lookup_context_window("k3", provider_id="kimi") == 1_048_576
     assert mms_launchers._lookup_context_window("k3[1m]", provider_id="kimi") == 1_048_576
@@ -96,7 +106,13 @@ def test_claude_glm_1m_context_sets_client_cap_without_selector():
     assert all("[1m]" not in value for value in env.values())
 
 
-def test_claude_glm_below_1m_does_not_override_client_cap():
+def test_claude_glm_below_1m_still_states_its_own_window():
+    """#230: a known window is stated whatever its size, not only at 1M.
+
+    Claude Code's built-in cap describes Anthropic's models, so leaving it in
+    place for a routed GLM meant compacting at the client's number rather than
+    the model's.
+    """
     import mms_launchers
 
     env = {}
@@ -106,7 +122,7 @@ def test_claude_glm_below_1m_does_not_override_client_cap():
         model_names=("glm-5.2",),
     )
 
-    assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in env
+    assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "200000"
 
 
 def test_default_gpt_reasoning_effort_uses_xhigh_for_source_checkout(monkeypatch):

--- a/tests/test_context_window_single_truth.py
+++ b/tests/test_context_window_single_truth.py
@@ -1,0 +1,394 @@
+"""One context window, four harnesses.
+
+Issue #230: the K3 window was changed four times across #194/#204/#209/#213
+because the number lived in several places at once — a model-name table in the
+launcher, a second one in Pi, per-model special cases, and the provider
+profiles. These tests hold the shape that makes that impossible to repeat:
+
+* every model a provider profile declares gets the same number from Claude
+  Code, Codex, Pi and OpenCode, and that number is what the shared resolver
+  says;
+* none of the harness modules carries a model-name-to-window table any more;
+* a `[1m]` selector resolves exactly like its base name unless something
+  deliberately declares the suffixed name;
+* a model nobody has heard of, whose provider listing reports a window, lands
+  correctly in all four harnesses with no code change at all. That last one is
+  the owner's actual requirement: new models are 1M+ now, and adding one must
+  not mean editing code.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import mms_capability_resolver
+import mms_context_window
+import mms_launchers
+import mms_opencode_config
+import mms_pi_support
+import mms_provider_profiles
+
+REPO_ROOT = Path(mms_launchers.__file__).resolve().parent
+PROFILE_PATH = REPO_ROOT / "config" / "provider-profiles.json"
+
+
+@pytest.fixture(autouse=True)
+def isolate_capability_root(monkeypatch):
+    """Answer from the repository's own data, never from this machine's root.
+
+    The approved bundle and the override file belong to whoever is running the
+    tests, so without this the same assertion passes on one laptop and fails on
+    the next.
+    """
+    monkeypatch.setattr(mms_capability_resolver, "_load_default_approved_facts_shared", lambda: {})
+    monkeypatch.setattr(mms_capability_resolver, "load_default_model_policy", lambda: {})
+    monkeypatch.setattr(
+        mms_context_window,
+        "load_model_context_overrides",
+        lambda: {"models": {}, "provider_overrides": {}},
+    )
+    mms_context_window.clear_context_window_caches()
+    mms_provider_profiles.load_provider_profiles.cache_clear()
+
+
+def _runtime(provider_id, models=()):
+    return {
+        "id": provider_id,
+        "name": provider_id,
+        "enabled": True,
+        "auth_mode": "api_key",
+        "api_key": "sk-test",
+        "openai_base_url": "https://relay.example.com/v1",
+        "protocols": ["openai_chat_completions"],
+        "supported_clis": ["claude", "codex", "pi", "opencode"],
+        "_models": list(models),
+    }
+
+
+# ── the four harness paths, driven for real ──────────────────────────────────
+
+def claude_code_window(runtime, model):
+    """What Claude Code is told, through the launcher's own env application."""
+    env = {}
+    window = mms_launchers._effective_context_window(model, provider_id=runtime["id"])
+    mms_launchers._apply_claude_context_env_overrides(env, context_window=window, model_names=(model,))
+    return int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+
+
+def codex_window(runtime, model):
+    """`model_context_window` in the Codex gateway config, or None when omitted."""
+    return mms_launchers._codex_gateway_context_window(runtime, {"model": model})
+
+
+def pi_window(monkeypatch, runtime, model):
+    """`contextWindow` in the models.json entry Pi is launched with."""
+    monkeypatch.setattr(
+        mms_launchers,
+        "_probe_models",
+        lambda _runtime, emit_output=False: {"models": list(runtime.get("_models") or [model])},
+    )
+    return int(mms_pi_support._pi_model_entry(runtime, model)["model"]["contextWindow"])
+
+
+def opencode_window(runtime, model):
+    """`limit.context` in the OpenCode config payload."""
+    return int(mms_launchers._opencode_model_config(runtime, model)["limit"]["context"])
+
+
+def _profile_models():
+    """Every (profile id, provider id, model) a profile declares a window for."""
+    payload = json.loads(PROFILE_PATH.read_text(encoding="utf-8"))
+    for profile_id, profile in (payload.get("profiles") or {}).items():
+        windows = profile.get("context_windows")
+        if not isinstance(windows, dict):
+            continue
+        match = profile.get("match") if isinstance(profile.get("match"), dict) else {}
+        provider_ids = [str(item) for item in match.get("provider_id_contains") or []]
+        provider_id = provider_ids[0] if provider_ids else profile_id
+        for model in windows:
+            yield profile_id, provider_id, str(model)
+
+
+def _profile_cases():
+    cases = []
+    for profile_id, provider_id, model in _profile_models():
+        # Anthropic's own models are the one family with harness-specific rules
+        # left on purpose: Claude Code decides 1M by its shell model name and
+        # OpenCode deliberately asks with 1M off. Everything else must agree.
+        if mms_context_window.is_claude_family_model(model):
+            continue
+        resolved, _profile = mms_provider_profiles.resolve_provider_profile(
+            provider_id=provider_id, model_name=model
+        )
+        if resolved != profile_id:
+            # A provider hint that selects a different profile is not this
+            # test's business; it would be asserting the matcher, not the chain.
+            continue
+        cases.append(pytest.param(provider_id, model, id=f"{profile_id}-{model}"))
+    return cases
+
+
+PROFILE_CASES = _profile_cases()
+
+
+def test_the_profile_corpus_is_not_empty():
+    assert len(PROFILE_CASES) > 30
+
+
+@pytest.mark.parametrize("provider_id,model", PROFILE_CASES)
+def test_every_profile_model_gets_one_window_in_every_harness(monkeypatch, provider_id, model):
+    runtime = _runtime(provider_id, models=[model])
+    expected = mms_context_window.resolve_context_window(model, provider_id=provider_id)
+    assert expected, f"{model} on {provider_id} has a profile entry but no resolved window"
+
+    assert claude_code_window(runtime, model) == expected
+    assert pi_window(monkeypatch, runtime, model) == expected
+    assert opencode_window(runtime, model) == expected
+
+    codex = codex_window(runtime, model)
+    # Codex ships a catalog for OpenAI's own models and its own floor for the
+    # rest; it states a window only where it would otherwise be wrong. When it
+    # states one it must be the same number.
+    if codex is not None:
+        assert codex == expected
+
+
+def test_kimi_k3_is_one_million_everywhere(monkeypatch):
+    """The model whose window was flipped four times. Pin it, once."""
+    runtime = _runtime("kimi-code", models=["k3", "k3[1m]", "kimi-k3"])
+    for model in ("k3", "k3[1m]", "kimi-k3"):
+        assert mms_context_window.resolve_context_window(model, provider_id="kimi-code") == 1_048_576
+        assert claude_code_window(runtime, model) == 1_048_576
+        assert codex_window(runtime, model) == 1_048_576
+        assert pi_window(monkeypatch, runtime, model) == 1_048_576
+        assert opencode_window(runtime, model) == 1_048_576
+
+
+# ── `[1m]` is input normalization ────────────────────────────────────────────
+
+def test_selector_resolves_like_the_base_name():
+    for model in ("k3", "qwen3.6-flash", "glm-5.1", "minimax-m3"):
+        assert mms_context_window.resolve_context_window(
+            f"{model}[1m]"
+        ) == mms_context_window.resolve_context_window(model), model
+
+
+def test_an_explicit_selector_entry_still_wins(monkeypatch):
+    """Where a source really declares the suffixed name, it is not stripped."""
+    monkeypatch.setattr(
+        mms_context_window,
+        "load_context_window_data",
+        lambda: {"vendor-x": 262_144, "vendor-x[1m]": 1_000_000},
+    )
+    assert mms_context_window.resolve_context_window("vendor-x") == 262_144
+    assert mms_context_window.resolve_context_window("vendor-x[1m]") == 1_000_000
+
+
+def test_the_user_file_outranks_everything(monkeypatch):
+    monkeypatch.setattr(
+        mms_context_window,
+        "load_model_context_overrides",
+        lambda: {"models": {"k3": 123_456}, "provider_overrides": {}},
+    )
+    answer = mms_context_window.context_window_sources("k3", provider_id="kimi-code")
+    assert answer["context_window_tokens"] == 123_456
+    assert answer["source"] == "user_override"
+    # And the selector inherits it, because it is the same model.
+    assert mms_context_window.resolve_context_window("k3[1m]", provider_id="kimi-code") == 123_456
+
+
+# ── a model nobody has heard of ──────────────────────────────────────────────
+
+def test_a_new_model_from_a_provider_listing_needs_no_code_change(monkeypatch, tmp_path):
+    """The owner's requirement: a 2M model appears, every harness sizes it right.
+
+    Nothing in this repository knows `nova-9-ultra`. The provider's own /models
+    listing reported its window, MMS cached that, and all four harnesses follow.
+    """
+    monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
+    monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "models_nova-relay.json").write_text(
+        json.dumps(
+            {
+                "raw_models": ["nova-9-ultra"],
+                "base_source": "remote",
+                "model_details": {"nova-9-ultra": {"context_length": 2_000_000}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    runtime = _runtime("nova-relay", models=["nova-9-ultra"])
+    answer = mms_context_window.context_window_sources("nova-9-ultra", provider_id="nova-relay")
+    assert answer == {
+        "model": "nova-9-ultra",
+        "provider_id": "nova-relay",
+        "context_window_tokens": 2_000_000,
+        "source": "remote_listing",
+    }
+
+    assert claude_code_window(runtime, "nova-9-ultra") == 2_000_000
+    assert codex_window(runtime, "nova-9-ultra") == 2_000_000
+    assert pi_window(monkeypatch, runtime, "nova-9-ultra") == 2_000_000
+    assert opencode_window(runtime, "nova-9-ultra") == 2_000_000
+
+
+def test_a_listing_number_that_cannot_be_a_window_is_ignored(monkeypatch, tmp_path):
+    monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
+    monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "models_nova-relay.json").write_text(
+        json.dumps(
+            {
+                "raw_models": ["nova-9-mini"],
+                "model_details": {"nova-9-mini": {"context_length": 12}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert mms_context_window.resolve_context_window("nova-9-mini", provider_id="nova-relay") is None
+
+
+def test_an_unknown_model_stays_unknown():
+    """`None`, not a guess: the caller applies its own default."""
+    assert mms_context_window.resolve_context_window("totally-made-up-model-name") is None
+    assert mms_launchers._effective_context_window("totally-made-up-model-name") == 200_000
+
+
+def test_claude_family_is_a_rule_not_a_list():
+    for model in ("claude-opus-4-6", "claude-sonnet-9-9", "claude-opus-4-6[1m]"):
+        assert mms_context_window.resolve_context_window(model) == 1_000_000, model
+    for model in ("claude-haiku-4-5", "claude-haiku-9-9-20991231"):
+        assert mms_context_window.resolve_context_window(model) == 200_000, model
+
+
+# ── no model-name context tables in code ─────────────────────────────────────
+
+SCANNED_MODULES = (
+    "mms_launchers.py",
+    "mms_pi_support.py",
+    "mms_core.py",
+    "mms_opencode_env.py",
+    "mms_opencode_config.py",
+    "mms_context_window.py",
+)
+
+# Max output tokens, not context. Issue #230 left that mechanism alone; the
+# entry is named here so a context table cannot be smuggled back in under it.
+NON_CONTEXT_TABLES = {"_PI_MODEL_MAX_TOKENS_HINTS"}
+
+# A model name as these tables wrote them: lower case, carries a version digit,
+# separators optional. `k3`, `glm-5.1`, `moonshotai/kimi-k3`, `k3[1m]`.
+_MODEL_NAME = re.compile(r"^[a-z][a-z0-9]*([._/\-][a-z0-9._/\-]*)*(\[1m\])?$")
+_SMALLEST_WINDOW = 4_096
+
+
+def _model_name_key(value):
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip().lower()
+    return bool(_MODEL_NAME.match(candidate)) and any(char.isdigit() for char in candidate)
+
+
+def _looks_like_a_window(value):
+    return isinstance(value, int) and not isinstance(value, bool) and value >= _SMALLEST_WINDOW
+
+
+def _context_tables(source, filename):
+    """Dict literals in this file that map model names to window-sized ints."""
+    found = []
+    for node in ast.walk(ast.parse(source, filename=filename)):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Dict) or len(value.keys) < 2:
+            continue
+        try:
+            keys = [ast.literal_eval(key) for key in value.keys if key is not None]
+            values = [ast.literal_eval(item) for item in value.values]
+        except (ValueError, SyntaxError):
+            continue
+        if len(keys) != len(values):
+            continue
+        if not all(_model_name_key(key) for key in keys):
+            continue
+        if not all(isinstance(item, int) and not isinstance(item, bool) for item in values):
+            continue
+        if not any(_looks_like_a_window(item) for item in values):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [target.id for target in targets if isinstance(target, ast.Name)]
+        found.append((names[0] if names else "<anonymous>", node.lineno))
+    return found
+
+
+def test_no_module_maps_a_model_name_to_a_context_window():
+    """A model's window is data. A dict of them in code is how #230 happened."""
+    offenders = []
+    for filename in SCANNED_MODULES:
+        path = REPO_ROOT / filename
+        if not path.exists():
+            continue
+        for name, lineno in _context_tables(path.read_text(encoding="utf-8"), filename):
+            if name in NON_CONTEXT_TABLES:
+                continue
+            offenders.append(f"{filename}:{lineno} {name}")
+    assert offenders == [], (
+        "model-name context tables are not allowed; put the number in "
+        "config/provider-profiles.json or config/model-context-windows.json: "
+        + ", ".join(offenders)
+    )
+
+
+def test_the_removed_tables_stay_removed():
+    gone = (
+        "_MODEL_CONTEXT_WINDOWS",
+        "_ONE_M_SUFFIX_CONTEXT_WINDOWS",
+        "_ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS",
+        "_MIMO_PLAIN_ONE_M_CONTEXT_WINDOWS",
+        "_MIMO_PLAIN_ONE_M_PROVIDER_HINTS",
+        "_PI_MODEL_CONTEXT_WINDOW_HINTS",
+        "_plain_kimi_k3_profile_context_window",
+        "_is_kimi_k3_claude_env_model",
+    )
+    for filename in SCANNED_MODULES:
+        source = (REPO_ROOT / filename).read_text(encoding="utf-8")
+        for name in gone:
+            assert name not in source, f"{name} is back in {filename}"
+
+
+def test_the_data_file_is_data():
+    """Every row says where its number came from, and the number is plausible."""
+    payload = json.loads((REPO_ROOT / "config" / "model-context-windows.json").read_text(encoding="utf-8"))
+    models = payload["models"]
+    assert models
+    for model, row in models.items():
+        assert row.get("source"), model
+        window = row.get("context_window_tokens")
+        assert isinstance(window, int) and 4_096 <= window <= 10_000_000, model
+        assert model == model.strip().lower(), model
+
+
+def test_a_profile_entry_outranks_the_data_file():
+    """The data file is the last resort, not a second opinion."""
+    table = mms_context_window.load_context_window_data()
+    assert "glm-5.1" in table
+    answer = mms_context_window.context_window_sources("glm-5.1", provider_id="glm")
+    assert answer["source"] == "provider_profile"
+
+
+def test_max_output_never_exceeds_the_context_window():
+    """The invariant that made a stale max-tokens hint visible in the first place."""
+    for provider_id, model in {(case.values[0], case.values[1]) for case in PROFILE_CASES}:
+        window = mms_context_window.resolve_context_window(model, provider_id=provider_id)
+        output = mms_launchers._capability_max_output_tokens(model, provider_id=provider_id)
+        if window and output:
+            assert output <= window, f"{model} on {provider_id}: output {output} > context {window}"

--- a/tests/test_context_window_single_truth.py
+++ b/tests/test_context_window_single_truth.py
@@ -202,6 +202,34 @@ def test_the_user_file_outranks_everything(monkeypatch):
     assert mms_context_window.resolve_context_window("k3[1m]", provider_id="kimi-code") == 123_456
 
 
+def test_a_context_the_user_set_in_pilot_is_final(monkeypatch):
+    """The owner's rule (2026-09-12): a context set on the Pilot model page is
+    the user's confirmed knowledge. Nothing calibrates it, nothing caps it, no
+    `[1m]` is added to the wire name, and every harness carries it as given.
+    """
+    # The profile says 262144 for this variant; the user says otherwise.
+    monkeypatch.setattr(
+        mms_capability_resolver,
+        "load_default_model_policy",
+        lambda: {"models": {"k3-256k": {"capabilities": {"context_window_tokens": 1_048_576}}}},
+    )
+    mms_context_window.clear_context_window_caches()
+    answer = mms_context_window.context_window_sources("k3-256k", provider_id="kimi-code")
+    assert answer["context_window_tokens"] == 1_048_576
+    assert answer["source"] == "model_policy"
+
+    runtime = _runtime("kimi-code", models=["k3-256k"])
+    assert claude_code_window(runtime, "k3-256k") == 1_048_576
+    assert codex_window(runtime, "k3-256k") == 1_048_576
+    assert pi_window(monkeypatch, runtime, "k3-256k") == 1_048_576
+    assert opencode_window(runtime, "k3-256k") == 1_048_576
+
+    # No harness renames the model to carry the window.
+    assert mms_launchers._with_1m_suffix("k3-256k", enable_1m=True, provider_id="kimi-code") == "k3-256k"
+    assert "[1m]" not in json.dumps(mms_pi_support._pi_model_entry(runtime, "k3-256k"))
+    assert "[1m]" not in json.dumps(mms_launchers._opencode_model_config(runtime, "k3-256k"))
+
+
 # ── a model nobody has heard of ──────────────────────────────────────────────
 
 def test_a_new_model_from_a_provider_listing_needs_no_code_change(monkeypatch, tmp_path):

--- a/tests/test_mimo_1m_context.py
+++ b/tests/test_mimo_1m_context.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 import os
 
+import mms_capability_resolver
+import mms_context_window
+
 
 def _empty_context_overrides():
     return {"models": {}, "provider_overrides": {}}
@@ -18,66 +21,66 @@ def _conservative_capabilities(*_args, **_kwargs):
 def test_mimo_pro_1m_suffix_uses_one_m_context(monkeypatch):
     import mms_launchers
 
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
 
     assert (
         mms_launchers._lookup_context_window(
             "mimo-v2.5-pro[1m]",
             provider_id="mimo-direct-anthropic",
         )
-        == 1_000_000
+        == 1_048_576
     )
     assert (
         mms_launchers._effective_context_window(
             "mimo-v2.5-pro[1m]",
             provider_id="mimo-direct-anthropic",
         )
-        == 1_000_000
+        == 1_048_576
     )
 
 
 def test_mimo_non_pro_1m_suffix_uses_one_m_context(monkeypatch):
     import mms_launchers
 
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
 
     assert (
         mms_launchers._lookup_context_window(
             "mimo-v2.5[1m]",
             provider_id="mimo-direct-anthropic",
         )
-        == 1_000_000
+        == 1_048_576
     )
 
 
-def test_mimo_pro_without_1m_suffix_keeps_safe_context(monkeypatch):
+def test_mimo_plain_name_and_selector_agree_on_the_anthropic_route(monkeypatch):
+    """#230: the `[1m]` selector is the same model as the plain name.
+
+    The launcher used to cap the plain name at a "safe" 256K here while Pi and
+    OpenCode read 1M for the same model on the same channel, straight from the
+    provider profile. One truth now: the profile answers both, and both
+    harnesses see the same number.
+    """
     import mms_launchers
 
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
-    monkeypatch.setattr(mms_launchers, "resolve_model_capabilities", _conservative_capabilities)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
 
-    assert (
-        mms_launchers._lookup_context_window(
-            "mimo-v2.5-pro",
-            provider_id="mimo-direct-anthropic",
+    for model in ("mimo-v2.5-pro", "mimo-v2.5"):
+        plain = mms_launchers._lookup_context_window(model, provider_id="mimo-direct-anthropic")
+        selector = mms_launchers._lookup_context_window(
+            f"{model}[1m]", provider_id="mimo-direct-anthropic"
         )
-        == 262_144
-    )
+        assert plain == selector == 1_048_576, model
 
 
-def test_mimo_without_1m_suffix_keeps_safe_context_on_anthropic(monkeypatch):
+def test_mimo_falls_back_to_the_shared_data_file_without_a_profile(monkeypatch):
+    """A channel whose profile says nothing still gets the documented window."""
     import mms_launchers
 
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
-    monkeypatch.setattr(mms_launchers, "resolve_model_capabilities", _conservative_capabilities)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_capability_resolver, "resolve_model_capabilities", _conservative_capabilities)
 
-    assert (
-        mms_launchers._lookup_context_window(
-            "mimo-v2.5",
-            provider_id="mimo-direct-anthropic",
-        )
-        == 262_144
-    )
+    assert mms_launchers._lookup_context_window("mimo-v2-pro", provider_id="some-relay") == 262_144
 
 
 def test_mimo_one_m_policy_shortcut_enables_plain_model_1m(monkeypatch, tmp_path):
@@ -85,7 +88,7 @@ def test_mimo_one_m_policy_shortcut_enables_plain_model_1m(monkeypatch, tmp_path
 
     monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
     monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
     (tmp_path / "model-policy.json").write_text(
         json.dumps(
             {
@@ -115,7 +118,7 @@ def test_mimo_context_policy_enables_plain_model_1m(monkeypatch, tmp_path):
 
     monkeypatch.delenv("MMS_CONFIG_ROOT", raising=False)
     monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
     (tmp_path / "model-policy.json").write_text(
         json.dumps(
             {
@@ -143,7 +146,7 @@ def test_mimo_context_policy_enables_plain_model_1m(monkeypatch, tmp_path):
 def test_mimo_approved_capability_enables_plain_model_1m_before_safe_cap(monkeypatch):
     import mms_launchers
 
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
 
     def fake_resolve_model_capabilities(model_name, *, provider_id="", **_kwargs):
         assert model_name == "mimo-v2.5"
@@ -153,7 +156,7 @@ def test_mimo_approved_capability_enables_plain_model_1m_before_safe_cap(monkeyp
             "sources": {"context_window_tokens": "approved_facts"},
         }
 
-    monkeypatch.setattr(mms_launchers, "resolve_model_capabilities", fake_resolve_model_capabilities)
+    monkeypatch.setattr(mms_capability_resolver, "resolve_model_capabilities", fake_resolve_model_capabilities)
 
     assert (
         mms_launchers._lookup_context_window(
@@ -169,7 +172,7 @@ def test_mimo_plain_model_uses_one_m_on_openrouter_and_openai_routes(monkeypatch
     import mms_provider_profiles
 
     monkeypatch.setenv("MMS_CONFIG_DIR", str(tmp_path))
-    monkeypatch.setattr(mms_launchers, "_load_model_context_overrides", _empty_context_overrides)
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
     mms_provider_profiles.load_provider_profiles.cache_clear()
 
     assert mms_launchers._lookup_context_window("mimo-v2.5", provider_id="openrouter") == 1_048_576
@@ -239,8 +242,8 @@ def test_exact_1m_context_override_wins_before_suffix_stripping(monkeypatch):
     import mms_launchers
 
     monkeypatch.setattr(
-        mms_launchers,
-        "_load_model_context_overrides",
+        mms_context_window,
+        "load_model_context_overrides",
         lambda: {
             "models": {"mimo-v2.5-pro[1m]": 900_000, "mimo-v2.5-pro": 262_144},
             "provider_overrides": {},

--- a/tests/test_mimo_1m_context.py
+++ b/tests/test_mimo_1m_context.py
@@ -11,6 +11,20 @@ def _empty_context_overrides():
     return {"models": {}, "provider_overrides": {}}
 
 
+def _anthropic_mimo_runtime():
+    """The channel MiMo documents for Claude Code: the Anthropic-compatible one."""
+    return {
+        "id": "mimo-direct-anthropic",
+        "name": "MiMo Direct",
+        "enabled": True,
+        "auth_mode": "api_key",
+        "api_key": "sk-test",
+        "anthropic_base_url": "https://api.xiaomimimo.com/anthropic",
+        "protocols": ["anthropic_messages"],
+        "supported_clis": ["claude", "codex", "pi", "opencode"],
+    }
+
+
 def _conservative_capabilities(*_args, **_kwargs):
     return {
         "context_window_tokens": 8_192,
@@ -53,24 +67,129 @@ def test_mimo_non_pro_1m_suffix_uses_one_m_context(monkeypatch):
     )
 
 
-def test_mimo_plain_name_and_selector_agree_on_the_anthropic_route(monkeypatch):
-    """#230: the `[1m]` selector is the same model as the plain name.
+def test_mimo_pro_without_1m_suffix_keeps_safe_context(monkeypatch):
+    """MiMo's Anthropic endpoint runs the plain id in 256K mode.
 
-    The launcher used to cap the plain name at a "safe" 256K here while Pi and
-    OpenCode read 1M for the same model on the same channel, straight from the
-    provider profile. One truth now: the profile answers both, and both
-    harnesses see the same number.
+    The `[1m]` suffix is what asks for the extended context there, so telling
+    Claude Code 1M for the plain name would push requests past what the server
+    honours. The fact is provider-specific, so it is profile data
+    (the `mimo` profile), reached here through the real matcher.
     """
     import mms_launchers
 
     monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
 
-    for model in ("mimo-v2.5-pro", "mimo-v2.5"):
-        plain = mms_launchers._lookup_context_window(model, provider_id="mimo-direct-anthropic")
-        selector = mms_launchers._lookup_context_window(
-            f"{model}[1m]", provider_id="mimo-direct-anthropic"
+    assert (
+        mms_launchers._lookup_context_window(
+            "mimo-v2.5-pro",
+            provider_id="mimo-direct-anthropic",
         )
-        assert plain == selector == 1_048_576, model
+        == 262_144
+    )
+    assert (
+        mms_context_window.resolve_context_window(
+            "mimo-v2.5-pro",
+            runtime=_anthropic_mimo_runtime(),
+        )
+        == 262_144
+    )
+
+
+def test_mimo_without_1m_suffix_keeps_safe_context_on_anthropic(monkeypatch):
+    import mms_launchers
+
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
+
+    assert (
+        mms_launchers._lookup_context_window(
+            "mimo-v2.5",
+            provider_id="mimo-direct-anthropic",
+        )
+        == 262_144
+    )
+    assert (
+        mms_context_window.resolve_context_window(
+            "mimo-v2.5",
+            runtime=_anthropic_mimo_runtime(),
+        )
+        == 262_144
+    )
+
+
+def test_the_anthropic_route_and_the_openai_routes_pick_different_profiles():
+    """The 256K plain mode is provider data, so the matcher has to separate them.
+
+    The `mimo` profile answers for the Anthropic endpoint and for any MiMo
+    channel that does not say which endpoint it is; the OpenAI-style routes have
+    their own profiles, where the plain name really is the 1M model.
+    """
+    import mms_provider_profiles
+
+    for provider_id, base_url in (
+        ("mimo-direct-anthropic", "https://api.xiaomimimo.com/anthropic"),
+        ("mimo-direct-anthropic", ""),
+        ("mimo-anthropic", "https://api.xiaomimimo.com/anthropic"),
+    ):
+        profile_id, _profile = mms_provider_profiles.resolve_provider_profile(
+            provider_id=provider_id, base_url=base_url, model_name="mimo-v2.5"
+        )
+        assert profile_id == "mimo", (provider_id, base_url)
+
+    for provider_id in ("mimo-openai", "mimo-direct-openai", "xiaomi-openai", "openai-mimo"):
+        profile_id, _profile = mms_provider_profiles.resolve_provider_profile(
+            provider_id=provider_id,
+            base_url="https://api.xiaomimimo.com/v1",
+            model_name="mimo-v2.5",
+        )
+        assert profile_id == "mimo-openai", provider_id
+        assert (
+            mms_context_window.resolve_context_window(
+                "mimo-v2.5",
+                provider_id=provider_id,
+                runtime={"id": provider_id, "openai_base_url": "https://api.xiaomimimo.com/v1"},
+            )
+            == 1_048_576
+        ), provider_id
+
+
+def test_every_harness_gets_the_same_mimo_window_on_the_anthropic_route(monkeypatch):
+    """Per (model, provider): 256K for the plain id, 1M for the selector."""
+    import mms_launchers
+    import mms_pi_support
+
+    monkeypatch.setattr(mms_context_window, "load_model_context_overrides", _empty_context_overrides)
+    # Answer from the repository's profiles alone: whether this machine has an
+    # approved bundle must not decide what the assertion sees.
+    monkeypatch.setattr(mms_capability_resolver, "_load_default_approved_facts_shared", lambda: {})
+    monkeypatch.setattr(mms_capability_resolver, "load_default_model_policy", lambda: {})
+    runtime = _anthropic_mimo_runtime()
+    monkeypatch.setattr(
+        mms_launchers,
+        "_probe_models",
+        lambda _runtime, emit_output=False: {
+            "models": ["mimo-v2.5", "mimo-v2.5[1m]", "mimo-v2.5-pro", "mimo-v2.5-pro[1m]"]
+        },
+    )
+
+    for model, expected in (
+        ("mimo-v2.5", 262_144),
+        ("mimo-v2.5-pro", 262_144),
+        ("mimo-v2.5[1m]", 1_048_576),
+        ("mimo-v2.5-pro[1m]", 1_048_576),
+    ):
+        env = {}
+        mms_launchers._apply_claude_context_env_overrides(
+            env,
+            context_window=mms_launchers._effective_context_window(model, provider_id=runtime["id"]),
+            model_names=(model,),
+        )
+        assert int(env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]) == expected, model
+        assert mms_pi_support._pi_model_entry(runtime, model)["model"]["contextWindow"] == expected, model
+        assert mms_launchers._opencode_model_config(runtime, model)["limit"]["context"] == expected, model
+        codex = mms_launchers._codex_gateway_context_window(runtime, {"model": model})
+        # Codex is told only about windows past its own floor; when it is told,
+        # it is the same number.
+        assert codex in (None, expected), model
 
 
 def test_mimo_falls_back_to_the_shared_data_file_without_a_profile(monkeypatch):

--- a/tests/test_non_claude_1m_context.py
+++ b/tests/test_non_claude_1m_context.py
@@ -2,8 +2,9 @@
 
 覆盖两个修复:
 - A: TUI 未展示 1M 开关时返回 None,mms_core 不覆盖 provider 的 claude_1m_mode
-- C: 非 Claude 桥接模型 + window>=1M 时,shell slots 不依赖 enable_claude_1m 开关,
-  且 CLAUDE_CODE_MAX_CONTEXT_TOKENS 泛化写入(不再枚举 glm-5.2)
+- C: 非 Claude 桥接模型 shell slots 不依赖 enable_claude_1m 开关,
+  且 CLAUDE_CODE_MAX_CONTEXT_TOKENS 对任何已知 window 泛化写入
+  (不再枚举模型名,也不再要求 window>=1M —— #230)
 """
 
 import os
@@ -71,10 +72,19 @@ class TestExplicitContextCapGeneralization(unittest.TestCase):
         _apply_claude_context_env_overrides(env, context_window=1_000_000, model_names=["claude-sonnet-4-6[1m]"])
         self.assertNotIn("CLAUDE_CODE_MAX_CONTEXT_TOKENS", env)
 
-    def test_non_claude_model_below_1m_window_no_cap(self):
+    def test_non_claude_model_below_1m_window_still_states_its_window(self):
+        # #230: the cap is no longer gated on >=1M. Claude Code's own default
+        # says nothing about someone else's model, so whenever the window is
+        # known it gets stated, whatever its size.
         env = {}
         _apply_claude_context_env_overrides(env, context_window=200_000, model_names=["glm-5.3"])
+        self.assertEqual(env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS"), "200000")
+
+    def test_unknown_window_sets_nothing(self):
+        env = {}
+        _apply_claude_context_env_overrides(env, context_window=None, model_names=["glm-5.3"])
         self.assertNotIn("CLAUDE_CODE_MAX_CONTEXT_TOKENS", env)
+        self.assertNotIn("CLAUDE_CODE_AUTO_COMPACT_WINDOW", env)
 
 
 class TestTuiNoneDoesNotOverrideProviderMode(unittest.TestCase):

--- a/tests/test_provider_profiles.py
+++ b/tests/test_provider_profiles.py
@@ -386,11 +386,13 @@ def test_openrouter_kimi_k3_profile_aliases_to_moonshot_wire_model(monkeypatch, 
 def test_profile_context_window_and_references(monkeypatch, tmp_path):
     profiles = _profiles(monkeypatch, tmp_path)
 
+    # MiMo documents the `[1m]` suffix as what enables extended context on the
+    # Anthropic endpoint, so the plain id there is the 256K mode.
     assert profiles.profile_context_window(
         "mimo-v2.5-pro",
         provider_id="mimo",
         base_url="https://api.xiaomimimo.com/anthropic",
-    ) == 1_048_576
+    ) == 262_144
     assert profiles.profile_context_window(
         "mimo-v2.5-pro[1m]",
         provider_id="mimo",

--- a/tests/test_single_config_root.py
+++ b/tests/test_single_config_root.py
@@ -58,11 +58,19 @@ def test_core_never_imports_the_legacy_root():
 
 
 def test_config_root_fallbacks_do_not_point_at_the_legacy_root():
-    launchers = (ROOT / "mms_launchers.py").read_text(encoding="utf-8")
-    for name in ("_model_context_overrides_path", "_selected_mms_config_root"):
-        start = launchers.index(f"def {name}(")
-        body = launchers[start: launchers.index("\ndef ", start + 1)]
-        assert '_real_user_path(".config", "mms")' not in body, name
+    # `_model_context_overrides_path` moved to the shared context resolver
+    # (#230); its fallback is still on this contract.
+    sources = {
+        "mms_launchers.py": ("_selected_mms_config_root",),
+        "mms_context_window.py": ("model_context_overrides_path",),
+    }
+    for filename, names in sources.items():
+        text = (ROOT / filename).read_text(encoding="utf-8")
+        for name in names:
+            start = text.index(f"def {name}(")
+            body = text[start: text.index("\ndef ", start + 1)]
+            assert '_real_user_path(".config", "mms")' not in body, name
+            assert '".config", "mms")' not in body, name
     bridge = (ROOT / "mms_bridge.py").read_text(encoding="utf-8")
     start = bridge.index("def _incident_log_path(")
     body = bridge[start: bridge.index("\ndef ", start + 1)]


### PR DESCRIPTION
Closes #230.

k3 的 context 在 #194/#204/#209/#213 之间被改了四次，因为这个数字同时存在于好几个地方。这个 PR 让它只有一条链。

## 一条链

`mms_context_window.resolve_context_window(model, provider_id=..., runtime=...)`，从高到低：

1. `model-context-overrides.json`（用户自己的文件）→ `user_override` / `provider_override`
2. `manual_override` / `model_policy`（Pilot 模型页写的那层）
3. `approved_facts`（已发布的 capability bundle）
4. `provider_profile`（`config/provider-profiles.json` 的 `context_windows`）
5. provider `/models` 上报并缓存的窗口（`cache/models_<provider>.json` 的 `model_details`）→ `remote_listing`
6. `config/model-context-windows.json`（没有 profile 覆盖时的兜底数据，每行带 `source`）
7. Claude 家族规则：opus/sonnet 1M、haiku 200K

查不到返回 `None`，由调用方套自己的默认值。2~4 由同一次 `resolve_model_capabilities` 给出，launcher 和 Pi 不会各自解析出不同的 profile。

`context_window_sources()` 返回同一个答案加上是哪一层赢的，用于排查。

## 删掉的表和数据的去处

| 删掉的 | 在哪里 | 数据去了哪里 |
| --- | --- | --- |
| `_MODEL_CONTEXT_WINDOWS`（43 行） | `mms_launchers` | Claude 行 → 家族规则；其余 → `config/model-context-windows.json`（profile 已覆盖的仍以 profile 为准） |
| `_ONE_M_SUFFIX_CONTEXT_WINDOWS` | `mms_launchers` | MiMo `[1m]` 由 profile 的 `mimo*` `context_windows` 表达 |
| `_ONE_M_SUFFIX_BASE_SAFE_CONTEXT_WINDOWS` ×2 | `mms_launchers` / `mms_pi_support` | 同上；Pi 里剩下的那个用途（`[1m]` 是本地 selector）改用 launcher 已有的 `_is_mimo_one_m_context_selector` |
| `_MIMO_PLAIN_ONE_M_CONTEXT_WINDOWS` + `_MIMO_PLAIN_ONE_M_PROVIDER_HINTS` | `mms_launchers` | profile（三个 mimo profile 都记 1048576） |
| `_plain_kimi_k3_profile_context_window`（空 seam） | `mms_launchers` | 删除 |
| `_is_kimi_k3_claude_env_model` | `mms_launchers` | 删除，见下面第 4 条 |
| `_PI_MODEL_CONTEXT_WINDOW_HINTS` | `mms_pi_support` | `qwen3.6-flash` / `qwen3.7-max` → 数据文件；`k3*` → profile；`gpt-5.3-codex*` 早已被 calibration reference 抢先，无需迁移 |
| `k3[1m]` / `mimo-v2.5[1m]` 重复行 | `_PI_MODEL_MAX_TOKENS_HINTS`、`_PI_MODEL_INPUT_HINTS`、`mms_core._VISION_CAPABLE_MODEL_NAMES`、`mms_config_web._KNOWN_VISION_MODELS` | 查表前统一剥后缀（`normalize_model_selector`），不再需要重复条目 |

`_PI_MODEL_MAX_TOKENS_HINTS` 是 max output，不是 context，按 issue 范围保留；扫描器测试把它显式列为例外，防止有人借它塞回 context。

## 四个 harness

注入机制都没动，只换了数字的来源：Claude Code（`_effective_context_window` → `_apply_claude_context_env_overrides`）、Codex（`_codex_gateway_context_window`，保留 OpenAI 模型豁免和 1M floor）、Pi（`_pi_model_capabilities` → models.json `contextWindow`）、OpenCode（`limit.context`）。用户自己的 overrides 文件现在也能到达 Pi 和 OpenCode。

**Claude Code env**：`CLAUDE_CODE_MAX_CONTEXT_TOKENS` 现在对任何"非 Claude 路由 + 窗口已知"的情况都写，不再判断模型名叫不叫 k3、也不再要求 ≥1M。客户端自带的 cap 描述的是 Anthropic 自己的模型，对别人的模型只会导致过早 compact。`AUTO_COMPACT_WINDOW` 和 `BLOCKING_LIMIT_OVERRIDE` 不变。

`_runtime_supports_claude_1m`、敏感 Claude provider 默认不开 1M、`_with_1m_suffix` / `_apply_claude_shell_context_slots` 的 Claude `[1m]` 语义、model/source 解析顺序、auth、bridge routing 都没有改动。

## MiMo：`[1m]` 在 Anthropic 端点是真 selector（review 后修正）

官方 Claude Code 接入文档写明：在 Anthropic 兼容端点上，支持 1M 的 MiMo 模型要把 `[1m]` 加在 model id 上才启用扩展上下文，平名跑 256K 档（https://mimo.mi.com/docs/en-US/tokenplan/integration/claudecode）。所以这条事实是 provider-specific 的，写成 profile 数据：通用 `mimo` profile（同时服务 Anthropic 端点和"没说端点"的通道）平名 262144、`[1m]` 1048576；`mimo-openai` / `openrouter-xiaomi-mimo` 平名保持 1048576。整条改动就是 profile 里两个数字加一段 note。

我先试过拆出独立的 `mimo-anthropic` profile。六种 shape 都解析正确，但它改变了 MiMo Anthropic 通道上报的 profile id，直接打断 native fallback 配对（`mms_native_fallback` 要求当前 runtime 和候选 provider 的 profile id 相同）以及 TUI 的能力读取——`tests/test_native_fallback.py::test_resolve_native_fallback_routes_uses_anthropic_profile_for_mimo_relays` 和 `tests/test_reasoning_effort_tui.py::test_confirm_profile_capabilities_read_mimo_thinking` 会红。把数字写在本来就服务这个端点的 profile 上，不需要新 profile，也不需要靠 matcher 的 tie-break。

每种 provider shape 实测（只按 id 和带 base URL 各跑一遍，结果一致）：

| shape | profile | 平名 | `[1m]` |
| --- | --- | --- | --- |
| `mimo-direct-anthropic`、`mimo-anthropic`（含 `api.xiaomimimo.com/anthropic`） | `mimo` | 262144 | 1048576 |
| `mimo-openai`（含 `api.xiaomimimo.com/v1`） | `mimo-openai` | 1048576 | 1048576 |
| `mimo-direct-openai` / `xiaomi-openai` / `openai-mimo` | 带 base URL 时 `mimo-openai`；只按 id 时 `openai` → 数据文件 | 1048576 | 1048576 |
| `openrouter` | `openrouter-xiaomi-mimo` | 1048576 | 1048576 |
| `mimo-direct`（只按 id，端点未声明） | `mimo` | 262144 | 1048576 |

`mimo-direct` 按保守档走是有依据的：owner 的这个 provider 没有声明 `openai_chat_completions`，它也是 Anthropic 通道。

四个 harness 在 Anthropic 端点上逐 (model, provider) 一致：平名 262144（Codex 低于自己的 1M floor 所以不注入），`[1m]` 全部 1048576。

## 行为差异（逐格对比 base 与 head，40 个模型 × 12 个 provider = 480 格）

71 格不同，没有任何一格从"有值"变成"无值"或变小，**MiMo 通道（`mimo-direct`、`mimo-direct-anthropic`）的平名不再被放大**：

- `mimo-v2.5[1m]` / `-pro[1m]`：1000000 → 1048576（同一档，profile 的写法）。
- `qwen3.6-flash` / `qwen3.7-max`：无 → 1000000。Pi 原本就有这个数，现在四个 harness 共享。
- `mimo-v2-flash` / `mimo-v2-omni`：无 → 262144，与 `mimo` profile 一致。
- `mimo-v2.5` / `-pro` 平名：262144 → 1048576，**只发生在 id 里没有任何 MiMo/端点线索的通道上**（`newapi-*`、`dashscope`、`glm`、`kimi`、`openai` 这些按 model prefix 落到 `mimo-openai` 的情况）。这类通道是 OpenAI 协议中转，而 MiMo 在 OpenAI 风格路由上平名就是 1M。要压回去有两个现成入口：Pilot 模型页（`model_policy`）或 `model-context-overrides.json`，两者都在链的最上面。这是本 PR 里唯一一处放大，且 owner 的 `newapi-tencent` 实际取值来自 approved facts（见下），base 和 head 都是 1048576，没有变化。

## 不变量测试

`tests/test_context_window_single_truth.py`（90 项）：

- 对 profile 里每个模型，真实跑四条注入路径（Claude env dict、Codex `model_context_window`、Pi models.json entry、OpenCode payload），要求彼此相等且等于 resolver。Claude 家族排除在外——Claude Code 用壳名决定 1M、OpenCode 故意 `enable_claude_1m=False`，那是有意保留的 harness 规则。
- ast 扫描 `mms_launchers` / `mms_pi_support` / `mms_core` / `mms_opencode_env` / `mms_opencode_config` / `mms_context_window`，任何把模型名映射到窗口大小整数的 dict 都算失败（已反向验证：塞回一个假表会红）。另一条断言被删掉的符号不会回来。
- `k3[1m]` 与 `k3` 解析一致；显式带后缀的条目仍然优先。
- 一个仓库里完全不认识的模型 `nova-9-ultra`，只靠 provider 缓存里的 `context_length: 2000000`，四个 harness 都得到 2000000——这就是"以后新模型不用改代码"。
- 保留 `tests/test_provider_profiles.py` 的 k3 alias 锁和 max-output ≤ context 不变量。

编码了被删表的测试是改写到新机制，不是删断言：MiMo 套件改为 patch 共享的 overrides loader / capability resolver，并断言平名与 `[1m]` 在 profile 上取同一个值；两条 "below 1M 不写 cap" 改成 "已知窗口一律写"，这正是本次修复。

## 验证

- `python3 -m py_compile`：所有改动的 Python 文件通过。
- 定向：`tests/test_context_window_single_truth.py`（90 passed）以及 provider_profiles / pi_launcher / opencode_launcher / codex_reasoning_effort_launch / pi_vision_relay / vision_relay_harnesses / single_config_root / mimo_1m_context / non_claude_1m_context / capability_resolver / claude_isolation / claude_hardening_regressions 一起 623 passed，39 failed —— 与 base 在这台机器上的 39 个失败逐条相同（Pilot bundle / 已安装 pi 之类的机器状态），没有新增。
- `python3 scripts/ci_pytest_regression.py --base origin/dev`：`base: 68 failing of 2262` / `head: 68 failing of 2348` → **No test that passes on the base commit fails here.**（没有 Repaired 列表。中途 `mimo-anthropic` 拆分方案被这道 gate 抓到 2 个新红，已按上面的说明改掉。）
- fresh-user gate：`653 passed in 144.14s` / `[gate] fresh-user regression: PASS`，0 failed，与 dev 基线一致。（第一次跑时 `test_installer_does_not_reuse_another_homes_web_instance` 因为本机 18931/18932 端口被占而红，单独重跑与整轮重跑都是绿的。）
- 对真实 config root（`~/.config/mms-next`，只读）的实测：见下。

```
config root: /Users/xin/.config/mms-next

model                        provider                   window  source
k3                           kimi-code                 1048576  model_policy
k3                           newapi-personal-tokyo     1048576  model_policy
kimi-k3                      kimi-code                 1048576  provider_profile
k3[1m]                       kimi-code                 1048576  model_policy
k3-256k                      kimi-code                  262144  provider_profile
mimo-v2.5                    mimo-direct-anthropic     1048576  approved_facts
claude-opus-4-6              newapi-personal-tokyo     1000000  provider_profile
gpt-5.4                      newapi-personal-tokyo      400000  approved_facts
qwen3.7-plus                 newapi-personal-tokyo     1000000  model_policy
gemini-3.8-flash-high        newapi-personal-tokyo     1048576  provider_profile

four harnesses for k3 on provider 'kimi-code':
  Claude Code CLAUDE_CODE_AUTO_COMPACT_WINDOW : 1048576
  Claude Code CLAUDE_CODE_MAX_CONTEXT_TOKENS  : 1048576
  Codex       model_context_window            : 1048576
  Pi          models.json contextWindow       : 1048576
  OpenCode    limit.context                   : 1048576
```


`k3` 在这台机器上走的是用户自己在 Pilot 里设的 `model_policy`，这正是链的第 2 层；`kimi-k3` 没有 policy 条目，落到 profile，两者同值。真实缓存里目前还没有 `model_details`（要等下一次 `/models` 探测才会写），所以 `remote_listing` 这一层由测试覆盖，而不是这次实测命中。

MiMo 在这台机器上的实测需要单独说明。真实 config root 里 **approved facts 对平名 `mimo-v2.5` / `mimo-v2.5-pro` 写的是 1048576**，而 approved facts 在链上高于 provider profile，所以实测打印的是 1048576：

```
mimo-v2.5                mimo-direct-anthropic       1048576  approved_facts
mimo-v2.5[1m]            mimo-direct-anthropic       1048576  approved_facts
mimo-v2.5                newapi-tencent              1048576  approved_facts
```

这不是本 PR 引入的：`origin/dev` 在同一个 config root 上对 `mimo-v2.5@mimo-direct-anthropic` 同样返回 1048576（旧代码里 approved facts 也排在 MiMo safe-base 表前面，`test_mimo_approved_capability_enables_plain_model_1m_before_safe_cap` 就是锁这条的）。也就是说 owner 这台机器上的取值 base 与 head 相同，本 PR 把**仓库默认值**修正回了 256K。要让 owner 那台也降下来，需要 Pilot 发布的 capability bundle 不再对平名声称 1M，或者用户显式 pin——这属于数据问题，不应该靠调换链的顺序解决（profile 盖过用户设置会破坏「Pilot 设置生效」这条契约）。

把本机 bundle/policy 放到一边、只用仓库数据时，链的结果就是文档里的那条事实：

```
mimo-v2.5                mimo-direct-anthropic        262144  provider_profile
mimo-v2.5[1m]            mimo-direct-anthropic       1048576  provider_profile
mimo-v2.5-pro            mimo-direct-anthropic        262144  provider_profile
mimo-v2.5-pro[1m]        mimo-direct-anthropic       1048576  provider_profile
mimo-v2.5                mimo-direct                  262144  provider_profile
mimo-v2.5                mimo-direct-openai          1048576  context_window_data
mimo-v2.5                openrouter                  1048576  provider_profile
k3                       kimi-code                   1048576  provider_profile

four harnesses, MiMo on the Anthropic endpoint:
  mimo-v2.5        claude=  262144  codex=    None  pi=  262144  opencode=  262144
  mimo-v2.5[1m]    claude= 1048576  codex= 1048576  pi= 1048576  opencode= 1048576
```

## 不在本 PR 范围内

Pi 的 `_pi_wire_model_name` 对 MiMo 的 `[1m]` selector 会把**基础名**发到 wire 上，而 MiMo 文档说的是后缀本身才启用 1M 模式。这是本 PR 之前就有的行为，这次没有改动它（只把判定来源从被删掉的表换成了 launcher 里已有的同一个谓词）。值得单开一个 issue。

https://claude.ai/code/session_01Q7g7jpHK2ikM4mWcpLuWKX
