### PR TITLE
chore: release v4.19.4

### DIFF
--- a/.ai/regression-reports/2026-09-12-context-window-single-truth.md
+++ b/.ai/regression-reports/2026-09-12-context-window-single-truth.md
@@ -1,0 +1,18 @@
+# 回归报告：统一 context window 来源
+
+- 时间：2026-09-12（Asia/Singapore）
+- 范围：合入 PR #233 后，四个 harness 共用 context-window resolver；发布 v4.19.4。
+- 修改：版本元数据、Pilot bundle、release note、回归记录。
+
+## 验证
+
+- PR #233 CI：pytest、digger、redline 全部 SUCCESS。
+- PR #233 fresh-user gate：653 passed / 0 failed。
+- PR #233 对比回归：没有 base 通过而 head 失败的测试。
+- `python3 scripts/build_mms_web_release.py --skip-install`：通过，bundle v4.19.4。
+- `git diff --check`：通过。
+
+## 边界
+
+- 当前真实本机 Pilot 未停止或重启；本报告没有修改 `~/.config/mms-next`。
+- MiMo Anthropic endpoint 的平名与 `[1m]` selector 仍按 provider profile 区分。

--- a/README.en.md
+++ b/README.en.md
@@ -51,7 +51,7 @@ Limits: it listens on the loopback address only, there is no remote multi-user a
 
 ## Current Version
 
-Current release: `v4.19.3` on the `dev` track. Stable and canary tracks keep
+Current release: `v4.19.4` on the `dev` track. Stable and canary tracks keep
 their branch-specific versions; see [Release channels](docs/RELEASE_CHANNELS.md)
 for the channel contract.
 
@@ -131,7 +131,7 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 Exact pin when needed:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref v4.19.3
+curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref v4.19.4
 curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref main
 ```
 

--- a/apps/mms-web/package-lock.json
+++ b/apps/mms-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mms/web",
-  "version": "4.19.3",
+  "version": "4.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mms/web",
-      "version": "4.19.3",
+      "version": "4.19.4",
       "dependencies": {
         "lucide-react": "0.468.0",
         "qrcode-generator": "2.0.4",

--- a/apps/mms-web/package.json
+++ b/apps/mms-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mms/web",
-  "version": "4.19.3",
+  "version": "4.19.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/mms-web/RELEASE-v4.19.4.md
+++ b/docs/mms-web/RELEASE-v4.19.4.md
@@ -1,0 +1,14 @@
+# v4.19.4 · 四个 harness 统一 context window
+
+- 所有 harness 通过同一个 context-window resolver 读取模型上下文窗口。
+- 用户在 Pilot 设置的 context window 优先级最高，并在 Claude Code、Codex、Pi、OpenCode 之间保持一致。
+- `k3`、MiMo `[1m]`、provider profile、远端 `/models` listing 和本地覆盖文件的来源顺序固定并可排查。
+- 普通稳定版安装入口仍只提供公开的 `mms` 命令。
+
+## 升级须知
+
+普通用户照常执行公开安装命令即可。升级不会删除会话数据；正在执行的任务按 Pilot 的安全更新规则处理。
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash
+```

--- a/mms_version.py
+++ b/mms_version.py
@@ -1,2 +1,2 @@
 """Version of the packaged MMS source and Web client."""
-VERSION = "4.19.3"
+VERSION = "4.19.4"

--- a/mms_web_static/build.json
+++ b/mms_web_static/build.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.19.3",
-  "sourceSha256": "97009ceccb3c62e40320bad71fb1f2df5ca075d6bafa4e5639f0028623757655",
+  "version": "4.19.4",
+  "sourceSha256": "57379b6467f170bff56245e901b7ebdbed99b930174fd30c068bc7eb094d7b57",
   "files": {
     "assets/index-DnGpPfnh.css": "3a74f7de2c48ae0e57d010baa908e7fedc6942cbdb0ea01886afd0c999754114",
     "assets/index-DsA4Hd6J.js": "ebd32d1c8572d9e8458d698285e29c1dd22fdd2e71e5274309acd0f0991ba543",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-model-switch",
-  "version": "4.19.3",
+  "version": "4.19.4",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## 变更

发布 PR #233 合入后的 v4.19.4：四个 harness 共用 context-window resolver，并更新 Pilot bundle 与版本元数据。

## 验证

- PR #233 CI：pytest、digger、redline 全部 SUCCESS
- PR #233 fresh-user gate：653 passed / 0 failed
- `python3 scripts/build_mms_web_release.py --skip-install`：通过
- `git diff --check`：通过

## 说明

不修改真实 `~/.config/mms-next`，不停止当前 Pilot。
