### PR TITLE
feat(pilot): 设置页运行环境标签、帮助内版本更新、设置边距

### DIFF
--- a/apps/mms-web/src/App.tsx
+++ b/apps/mms-web/src/App.tsx
@@ -1692,7 +1692,6 @@ export function App() {
               className={"home-content" + (homeSplit ? " home-split" : "")}
               ref={setHomeNode}
             >
-              <WhatsNew ready={!loading && connected} />
               <div className="home-intro">
                 <WorkspacePicker
                   workspaces={data.workspaces}
@@ -1929,7 +1928,7 @@ export function App() {
             refresh={() => void load()}
           />
         )}
-        {page === "bots" && !settingsOpen && <BotStudio data={data} onOpenSession={openSession} onExit={() => navigate("new")} />}
+        {page === "bots" && !settingsOpen && <BotStudio data={data} enterToSend={enterToSend} onOpenSession={openSession} onExit={() => navigate("new")} />}
         {page === "session" && (
           <div className={"session-layout " + (panel ? "with-panel" : "")}>
             <div className="conversation">

--- a/apps/mms-web/src/HelpGuide.tsx
+++ b/apps/mms-web/src/HelpGuide.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useRef, useState } from "react";
-import { ArrowRight, Search, X } from "lucide-react";
+import { ArrowRight, Search, X, ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { guideTopics, matchingTopics } from "./guide-content";
 import type { GuideAction } from "./guide-content";
 import "./guide.css";
-import { request } from "./api";
+import "./updates.css";
+import { isPreview, request } from "./api";
+import { previewUpdateHistory } from "./preview";
+import type { UpdateHistoryItem } from "./types";
+import { parseSemver, compareSemverDesc } from "./semver-sort";
 
 const seenKey = "mms-web-tour-seen-v1";
 function markSeen(persist: boolean) {
@@ -17,10 +23,46 @@ export function HelpGuide({ ready, modelReady, open, setOpen, hasSession, naviga
 }) {
   const [section, setSection] = useState("start");
   const [query, setQuery] = useState("");
+  const [updateHistory, setUpdateHistory] = useState<UpdateHistoryItem[]>([]);
+  const [loadingUpdates, setLoadingUpdates] = useState(false);
+  const [expandedVersions, setExpandedVersions] = useState<Set<string>>(() => new Set());
   const dialog = useRef<HTMLDialogElement>(null);
   const content = useRef<HTMLElement>(null);
   const attempted = useRef(false);
   const returnFocus = useRef<HTMLElement | null>(null);
+
+  const toggleVersion = (v: string) => {
+    setExpandedVersions((prev) => {
+      const next = new Set(prev);
+      if (next.has(v)) {
+        next.delete(v);
+      } else {
+        next.add(v);
+      }
+      return next;
+    });
+  };
+
+  const fetchUpdateHistory = async () => {
+    if (isPreview) {
+      const sorted = [...previewUpdateHistory].sort((a, b) => compareSemverDesc(a.version, b.version));
+      setUpdateHistory(sorted);
+      return;
+    }
+    setLoadingUpdates(true);
+    try {
+      const res = await request<{ releases?: UpdateHistoryItem[] } | UpdateHistoryItem[]>("/update/history");
+      const list = Array.isArray(res) ? res : (Array.isArray(res?.releases) ? res.releases : []);
+      const sorted = [...list].sort((a, b) => compareSemverDesc(a.version, b.version));
+      setUpdateHistory(sorted);
+    } catch {
+      // A live install shows only what the server actually has; the preview
+      // list is demo data and must not stand in for real release notes.
+      setUpdateHistory([]);
+    } finally {
+      setLoadingUpdates(false);
+    }
+  };
   useEffect(() => {
     if (!ready || attempted.current) return;
     attempted.current = true;
@@ -51,8 +93,25 @@ export function HelpGuide({ ready, modelReady, open, setOpen, hasSession, naviga
     };
   }, [open]);
   useEffect(() => { content.current?.scrollTo(0, 0); }, [section]);
+  useEffect(() => {
+    if (open && section === "updates" && updateHistory.length === 0) {
+      void fetchUpdateHistory();
+    }
+  }, [open, section]);
   const close = () => setOpen(false);
   const go = (action: GuideAction) => { close(); navigate(action); };
+  const queryTrimmed = query.trim().toLowerCase();
+  const updateMatchesQuery = (item: UpdateHistoryItem) => {
+    if (!queryTrimmed) return false;
+    return (
+      item.version.toLowerCase().includes(queryTrimmed) ||
+      item.notes.toLowerCase().includes(queryTrimmed) ||
+      (item.upgradeNotice ? item.upgradeNotice.toLowerCase().includes(queryTrimmed) : false)
+    );
+  };
+  const activeHistory = updateHistory.length > 0 ? updateHistory : isPreview ? previewUpdateHistory : [];
+  const hasUpdateMatches = queryTrimmed ? activeHistory.some(updateMatchesQuery) : false;
+  const matchesUpdates = !queryTrimmed || /更新|版本|update|version|changelog|history|升级/i.test(queryTrimmed) || hasUpdateMatches;
   const topics = matchingTopics(query);
   const topic = guideTopics.find(t => t.id === section);
   return <>
@@ -67,10 +126,89 @@ export function HelpGuide({ ready, modelReady, open, setOpen, hasSession, naviga
           <label className="guide-search"><Search size={16} /><input type="search" aria-label="搜索功能说明" placeholder="搜索功能，如 effort" value={query} onChange={event => setQuery(event.target.value)} /></label>
           {!query.trim() && <button type="button" aria-current={section === "start" ? "page" : undefined} onClick={() => setSection("start")}>第一次使用<span>连接、选择、开始对话</span></button>}
           {topics.map(item => <button type="button" key={item.id} aria-current={section === item.id ? "page" : undefined} onClick={() => setSection(item.id)}>{item.title}</button>)}
-          {!topics.length && <p className="guide-empty" role="status">没有匹配的功能。试试“模型”“路径”或“成果”。</p>}
+          {matchesUpdates && (
+            <button
+              type="button"
+              className="guide-index-entry"
+              aria-current={section === "updates" ? "page" : undefined}
+              onClick={() => {
+                setSection("updates");
+                if (updateHistory.length === 0) void fetchUpdateHistory();
+              }}
+            >
+              版本更新
+              <span>更新历史与变更记录</span>
+            </button>
+          )}
+          {!topics.length && !matchesUpdates && <p className="guide-empty" role="status">没有匹配的功能。试试“模型”“路径”或“成果”。</p>}
         </nav>
         <section className="guide-content" ref={content} aria-label="功能说明">
-          {section === "start" ? <>
+          {section === "updates" ? (
+            <div className="guide-updates" aria-label="版本更新历史">
+              <h3>版本更新</h3>
+              <p className="guide-lead">
+                查阅 MMS 各版本更新说明与改进记录。点击版本卡片可展开或收起详细说明。
+              </p>
+              {loadingUpdates && updateHistory.length === 0 ? (
+                <p className="guide-empty" role="status">正在加载版本更新记录…</p>
+              ) : updateHistory.length === 0 ? (
+                <div className="guide-empty-updates">
+                  <p className="guide-empty">暂无更新历史记录。</p>
+                  <button type="button" className="button" onClick={() => void fetchUpdateHistory()}>
+                    <RefreshCw size={14} /> 重新获取
+                  </button>
+                </div>
+              ) : (
+                <div className="update-history-list" role="list">
+                  {updateHistory.map((item) => {
+                    const isExpanded = expandedVersions.has(item.version) || (queryTrimmed ? updateMatchesQuery(item) : false);
+                    const tag = item.version.startsWith("v") ? item.version : `v${item.version}`;
+                    return (
+                      <article className="update-history-item" key={item.version} role="listitem">
+                        <button
+                          type="button"
+                          className="update-history-toggle"
+                          onClick={() => toggleVersion(item.version)}
+                          aria-expanded={isExpanded}
+                        >
+                          <div className="update-history-meta">
+                            <strong className="update-history-tag">{tag}</strong>
+                            {item.publishedAt && (
+                              <span className="update-history-date">
+                                {item.publishedAt.slice(0, 10)}
+                              </span>
+                            )}
+                          </div>
+                          <span className="update-history-chevron" aria-hidden="true">
+                            {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                          </span>
+                        </button>
+                        {isExpanded && (
+                          <div className="update-history-content">
+                            {item.upgradeNotice && (
+                              <div className="update-warning">
+                                <h4>升级须知</h4>
+                                <div className="update-notes-body">
+                                  <Markdown remarkPlugins={[remarkGfm]} skipHtml>
+                                    {item.upgradeNotice}
+                                  </Markdown>
+                                </div>
+                              </div>
+                            )}
+                            <div className="update-notes-body">
+                              <Markdown remarkPlugins={[remarkGfm]} skipHtml>
+                                {item.notes}
+                              </Markdown>
+                            </div>
+                          </div>
+                        )}
+                      </article>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : section === "start" ? <>
             <h3>让我们一起开始第一条对话</h3>
             <p className="guide-lead">不用先读完说明书。悬浮引导会圈亮真实按钮和输入框，一步步带你选择文件夹、模型与思考强度，再写下并发送第一条消息。</p>
             <button type="button" className="button primary" onClick={() => { close(); startTour(); }}>{modelReady ? "带我一步步操作" : "先配置模型服务"} <ArrowRight size={15} /></button>

--- a/apps/mms-web/src/HelpGuide.tsx
+++ b/apps/mms-web/src/HelpGuide.tsx
@@ -7,6 +7,7 @@ import type { GuideAction } from "./guide-content";
 import "./guide.css";
 import "./updates.css";
 import { isPreview, request } from "./api";
+import { withoutUpgradeSection } from "./release-notes";
 import { previewUpdateHistory } from "./preview";
 import type { UpdateHistoryItem } from "./types";
 import { parseSemver, compareSemverDesc } from "./semver-sort";
@@ -197,7 +198,7 @@ export function HelpGuide({ ready, modelReady, open, setOpen, hasSession, naviga
                             )}
                             <div className="update-notes-body">
                               <Markdown remarkPlugins={[remarkGfm]} skipHtml>
-                                {item.notes}
+                                {item.upgradeNotice ? withoutUpgradeSection(item.notes) : item.notes}
                               </Markdown>
                             </div>
                           </div>

--- a/apps/mms-web/src/ModelExplorer.tsx
+++ b/apps/mms-web/src/ModelExplorer.tsx
@@ -9,6 +9,7 @@ import {
   Brain,
   Image,
   Layers,
+  RotateCcw,
 } from "lucide-react";
 import type { Model, Preset } from "./types";
 import { request } from "./api";
@@ -171,8 +172,9 @@ export function ModelExplorer({
   const [query, setQuery] = useState("");
   const [onlyFavorite, setOnlyFavorite] = useState(false);
   const [revision, setRevision] = useState(0);
+  const [retry, setRetry] = useState(0);
   const selected = presets.find((p) => p.id === value);
-  const { facts, error } = useLaunchFacts(value, workspaceId);
+  const { facts, error } = useLaunchFacts(value, workspaceId, retry);
   const prefs = readRoutePreferences();
   const groups = useMemo(() => {
     const map = new Map<string, Preset[]>();
@@ -364,9 +366,17 @@ export function ModelExplorer({
                   ))}
                 </div>
                 {error && (
-                  <p className="inline-alert" role="alert">
-                    {error}
-                  </p>
+                  <div className="inline-alert inline-alert-retryable" role="alert">
+                    <span>{error}</span>
+                    <button
+                      type="button"
+                      className="inline-retry-button"
+                      onClick={() => setRetry((r) => r + 1)}
+                    >
+                      <RotateCcw size={13} />
+                      重试
+                    </button>
+                  </div>
                 )}
                 <details className="quick-config">
                   <summary>

--- a/apps/mms-web/src/SettingsPage.tsx
+++ b/apps/mms-web/src/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from "react";
-import { Sun, Moon, Monitor, Minus, Plus, SlidersHorizontal, Palette, Settings2 } from "lucide-react";
+import { Sun, Moon, Monitor, Minus, Plus, SlidersHorizontal, Palette, Settings2, Cpu } from "lucide-react";
 import type { Bootstrap } from "./types";
 import { RemoteAccessSection } from "./RemoteAccess";
 import { Models } from "./Models";
@@ -104,22 +104,15 @@ export function SettingsPage({
           <Settings2 size={16} />
           使用
         </button>
+        <button
+          className={tab === "runtime" ? "active" : ""}
+          onClick={() => requestNavigation(() => setTab("runtime"))}
+        >
+          <Cpu size={16} />
+          运行环境
+        </button>
         <AppVersion version={data.appVersion} onClick={openUpdates} updateAvailable={updateAvailable} />
       </nav>
-      <section className="platform-capability" aria-label="运行环境能力">
-        <div>
-          <strong>{data.platform?.os === "win32" ? "Windows Native Preview" : "当前运行环境"}</strong>
-          <span>{data.platform?.pathStyle || "unknown"} · {data.platform?.processControl || "能力未知"}</span>
-        </div>
-        <div className="platform-browser-capabilities">
-          {(data.browser || []).map((capability) => (
-            <span className={capability.supported ? "capability-chip" : "capability-chip unavailable"} key={capability.backend}>
-              {capability.backend}: {capability.loggedIn === "unknown" ? "登录态未知" : capability.loggedIn ? "已登录" : "独立环境"}
-              {capability.reason ? ` · ${capability.reason}` : ""}
-            </span>
-          ))}
-        </div>
-      </section>
       {tab === "models" ? (
         <Models
           connectionCompleted={connectionCompleted}
@@ -133,8 +126,7 @@ export function SettingsPage({
           effortChanged={effortChanged}
           editStateChanged={editStateChanged}
         />
-      ) : (
-        tab === "appearance" ? (
+      ) : tab === "appearance" ? (
         <section className="general-settings">
           <div className="preference-row">
             <div>
@@ -285,7 +277,7 @@ export function SettingsPage({
             />
           </label>
         </section>
-        ) : (
+      ) : tab === "usage" ? (
         <section className="general-settings">
           <label className="preference-row">
             <div>
@@ -336,7 +328,115 @@ export function SettingsPage({
               : "当前读取已有 MMF 配置。收藏、通道备注与 Web 默认值保存于此浏览器。"}
           </p>
         </section>
-        )
+      ) : (
+        <section className="general-settings runtime-settings" aria-label="运行环境设置">
+          <div className="platform-capability" aria-label="运行环境能力">
+            <div className="platform-capability-header">
+              <div>
+                <strong>
+                  {data.platform?.os === "win32"
+                    ? "Windows Native Preview"
+                    : data.platform?.os === "darwin"
+                    ? "macOS 运行环境"
+                    : data.platform?.os === "linux"
+                    ? "Linux 运行环境"
+                    : "当前运行环境"}
+                </strong>
+                <span>
+                  {data.platform?.pathStyle || "unknown"} · {data.platform?.processControl || "能力未知"}
+                </span>
+              </div>
+              {data.platform?.shell && (
+                <div className="platform-meta">
+                  <span>Shell: <code>{data.platform.shell}</code></span>
+                </div>
+              )}
+            </div>
+            {data.browser && data.browser.length > 0 ? (
+              <div className="platform-browser-capabilities">
+                {data.browser.map((capability) => (
+                  <span
+                    className={capability.supported ? "capability-chip" : "capability-chip unavailable"}
+                    key={capability.backend}
+                    title={capability.reason || undefined}
+                  >
+                    <span className="chip-indicator" />
+                    <strong>{capability.backend}</strong>:{" "}
+                    {capability.loggedIn === "unknown"
+                      ? "登录态未知"
+                      : capability.loggedIn
+                      ? "已登录"
+                      : "独立环境"}
+                    {capability.reason ? ` · ${capability.reason}` : ""}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <div className="platform-browser-capabilities">
+                <span className="capability-chip unavailable">
+                  <span className="chip-indicator" />
+                  浏览器能力: 独立环境
+                </span>
+              </div>
+            )}
+          </div>
+          <div className="preference-row">
+            <div>
+              <h2>会话启动链路</h2>
+              <p>{data.capabilities.launch ? "本地执行链路正常，可正常创建与执行会话。" : "会话启动受限或不可用。"}</p>
+            </div>
+            <span className={`status-pill ${data.capabilities.launch ? "active" : "muted"}`}>
+              {data.capabilities.launch ? "就绪" : "受限"}
+            </span>
+          </div>
+          <div className="preference-row">
+            <div>
+              <h2>配置模式</h2>
+              <p>
+                {data.capabilities.configure
+                  ? "当前使用 Web 独立配置，可在模型与通道中直接管理服务。"
+                  : "当前读取外部只读配置，配置修改受保护。"}
+              </p>
+            </div>
+            <span className={`status-pill ${data.capabilities.configure ? "active" : "muted"}`}>
+              {data.capabilities.configure ? "独立可写" : "只读"}
+            </span>
+          </div>
+          <div className="preference-row">
+            <div>
+              <h2>模型自动发现</h2>
+              <p>
+                {data.capabilities.discoverModels
+                  ? "支持通过连接服务自动拉取与探活模型列表。"
+                  : "使用静态预设模型列表。"}
+              </p>
+            </div>
+            <span className={`status-pill ${data.capabilities.discoverModels ? "active" : "muted"}`}>
+              {data.capabilities.discoverModels ? "支持" : "静态"}
+            </span>
+          </div>
+          {data.platform?.configRoot && (
+            <div className="preference-row">
+              <div>
+                <h2>配置目录</h2>
+                <p><code>{data.platform.configRoot}</code></p>
+              </div>
+            </div>
+          )}
+          {data.platform?.stateRoot && (
+            <div className="preference-row">
+              <div>
+                <h2>状态目录</h2>
+                <p><code>{data.platform.stateRoot}</code></p>
+              </div>
+            </div>
+          )}
+          <p className="settings-footnote">
+            {data.capabilities.configure
+              ? "当前使用 Web 独立配置，可在模型与通道中连接服务。"
+              : "当前读取已有 MMF 配置。收藏、通道备注与 Web 默认值保存于此浏览器。"}
+          </p>
+        </section>
       )}
     </div>
     {tour}

--- a/apps/mms-web/src/channel-models.css
+++ b/apps/mms-web/src/channel-models.css
@@ -1,6 +1,8 @@
 .channel-models {
-  max-width: 960px;
-  padding: 8px 14px 32px 0;
+  width: 100%;
+  max-width: none;
+  padding: 0 0 32px 0;
+  box-sizing: border-box;
 }
 .channel-models h2 {
   margin: 26px 0 6px;
@@ -318,12 +320,19 @@
 }
 .channel-save {
   position: sticky;
-  top: 0;
-  z-index: 2;
-  padding: 10px 0;
-  margin: 0 0 16px;
-  border-bottom: 1px solid var(--line);
+  bottom: 0;
+  z-index: 10;
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 0;
+  margin-top: 18px;
+  border-top: 1px solid var(--line);
   background: var(--surface);
+  box-shadow: 0 -4px 16px color-mix(in srgb, var(--ink) 4%, transparent);
   font-size: max(11px, 0.9286rem);
   color: var(--muted);
 }

--- a/apps/mms-web/src/guide.css
+++ b/apps/mms-web/src/guide.css
@@ -86,3 +86,84 @@
 .context-source-state { color: var(--accent); font-size: .9286rem; }
 
 .context-catalog { max-height: 420px; overflow-y: auto; }
+
+/* Version update history in Help Guide */
+.guide-updates {
+  display: flex;
+  flex-direction: column;
+}
+.guide-empty-updates {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 18px 0;
+}
+.update-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 8px;
+}
+.update-history-item {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface);
+  overflow: hidden;
+  transition: border-color 0.15s ease;
+}
+.update-history-item:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--line));
+}
+.update-history-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 13px 16px;
+  border: 0;
+  background: var(--surface);
+  color: var(--ink);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+.update-history-toggle:hover {
+  background: var(--soft);
+}
+.update-history-toggle[aria-expanded="true"] {
+  border-bottom: 1px solid var(--line);
+  background: var(--soft);
+}
+.update-history-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.update-history-tag {
+  font-size: max(11px, 0.9643rem);
+  font-weight: 650;
+  color: var(--ink);
+}
+.update-history-date {
+  font-size: max(11px, 0.7857rem);
+  color: var(--muted);
+}
+.update-history-chevron {
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.update-history-content {
+  padding: 16px 18px;
+  background: var(--surface);
+}
+.update-history-content .update-notes-body {
+  font-size: max(11px, 0.8571rem);
+  line-height: 1.75;
+  color: var(--ink);
+}

--- a/apps/mms-web/src/preview.ts
+++ b/apps/mms-web/src/preview.ts
@@ -1,4 +1,4 @@
-import type { Bootstrap, SessionDetail, SessionEvent } from "./types";
+import type { Bootstrap, SessionDetail, SessionEvent, UpdateHistoryItem } from "./types";
 
 const time = "2026-09-08T09:00:00Z";
 // Preview turns carry plausible clocks so the timestamp and reply duration
@@ -141,7 +141,23 @@ export const previewBootstrap: Bootstrap = {
   version: "1",
   mode: "preview",
   csrfToken: "",
-  capabilities: { catalogRead: true, configure: false, launch: true },
+  platform: {
+    os: "darwin",
+    shell: "/bin/zsh",
+    home: "/Users/preview",
+    configRoot: "/Users/preview/.config/mms-next",
+    stateRoot: "/Users/preview/.local/share/mms",
+    tempRoot: "/tmp",
+    pathStyle: "posix",
+    processControl: "macOS launchd / loopback process",
+    filePicker: "native",
+  },
+  browser: [
+    { backend: "chrome", supported: true, loggedIn: true },
+    { backend: "edge", supported: true, loggedIn: false, reason: "未检测到已登录的 Edge 账号" },
+    { backend: "chromium", supported: false, loggedIn: "unknown", reason: "未安装 Chromium 独立运行时" },
+  ],
+  capabilities: { catalogRead: true, configure: false, launch: true, discoverModels: true, modelSettings: true },
   workspaces: [
     { id: "product", name: "产品工作室", path: "~/Projects/product-studio" },
     { id: "website", name: "官网", path: "~/Projects/website" },
@@ -225,3 +241,22 @@ export const previewBootstrap: Bootstrap = {
   sessions: Object.values(previewDetails).map((detail) => detail.session),
   diagnostics: [],
 };
+
+export const previewUpdateHistory: UpdateHistoryItem[] = [
+  {
+    version: "4.16.0",
+    notes: "# v4.16.0 · 运行环境诊断与外观微调\n\n- 设置面板新增「运行环境」Tab，整合系统与浏览器能力探测。\n- 优化深色模式对比度，提供更清晰的状态指示。\n- 统一全站设置与通道配置边距，优化滚动交互体验。",
+    upgradeNotice: "升级后如果遇到浏览器扩展连接异常，请在「运行环境」Tab 重新检查调试端口状态。",
+    publishedAt: "2026-09-12T12:00:00Z",
+  },
+  {
+    version: "4.15.2",
+    notes: "# v4.15.2 · 稳定性修复\n\n- 优化 Pi 会话长轮次恢复逻辑。\n- 完善本地文件拖拽定位准确率。",
+    publishedAt: "2026-09-10T08:30:00Z",
+  },
+  {
+    version: "4.15.0",
+    notes: "# v4.15.0 · 多通道管理与 Effort 档位支持\n\n- 通道模型支持自定义 Effort 预设。\n- 增强安全更新事务回滚保障机制。",
+    publishedAt: "2026-09-05T14:00:00Z",
+  },
+];

--- a/apps/mms-web/src/release-notes.ts
+++ b/apps/mms-web/src/release-notes.ts
@@ -1,0 +1,25 @@
+/** Release-note helpers shared by the help guide's update history. */
+
+/**
+ * The body without its `## 升级须知` section. The guide shows that section as
+ * its own callout above the body, so leaving it in the body prints the same
+ * paragraphs twice.
+ */
+export function withoutUpgradeSection(notes: string): string {
+  const lines = notes.split("\n");
+  const kept: string[] = [];
+  let skippingLevel = 0;
+  for (const line of lines) {
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      const level = heading[1].length;
+      if (skippingLevel && level <= skippingLevel) skippingLevel = 0;
+      if (!skippingLevel && heading[2].trim() === "升级须知") {
+        skippingLevel = level;
+        continue;
+      }
+    }
+    if (!skippingLevel) kept.push(line);
+  }
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/apps/mms-web/src/semver-sort.ts
+++ b/apps/mms-web/src/semver-sort.ts
@@ -1,0 +1,16 @@
+export function parseSemver(v: string): [number, number, number] | null {
+  const m = String(v).trim().replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+export function compareSemverDesc(a: string, b: string): number {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa && !pb) return b.localeCompare(a);
+  if (!pa) return 1;
+  if (!pb) return -1;
+  if (pa[0] !== pb[0]) return pb[0] - pa[0];
+  if (pa[1] !== pb[1]) return pb[1] - pa[1];
+  return pb[2] - pa[2];
+}

--- a/apps/mms-web/src/studio.css
+++ b/apps/mms-web/src/studio.css
@@ -38,6 +38,20 @@
 :root[data-theme="dark"][data-accent="pink"] { --accent: #ff6482; --accent-hover: #ff90a5; }
 :root[data-theme="dark"][data-accent="orange"] { --accent: #ff9f0a; --accent-hover: #ffbb52; }
 :root[data-theme="dark"][data-accent="green"] { --accent: #30d158; --accent-hover: #6ade8b; }
+html[data-theme],
+body,
+.app-shell,
+.bot-workspace {
+  transition: background-color 160ms ease, color 160ms ease, border-color 160ms ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  html[data-theme],
+  body,
+  .app-shell,
+  .bot-workspace {
+    transition: none;
+  }
+}
 .sidebar {
   width: 264px;
   border-right: 1px solid var(--line);
@@ -1011,12 +1025,24 @@
   color: var(--ink);
   border-bottom-color: var(--accent);
 }
-.settings-shell .settings-page {
-  padding: 16px 0 0;
-  max-width: none;
+.settings-shell .settings-page,
+.settings-shell .general-settings {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px 0 24px;
   width: 100%;
-  margin: auto;
-  overflow: visible;
+  max-width: none;
+  margin: 0;
+  box-sizing: border-box;
+  scroll-padding-bottom: 72px;
+}
+.settings-shell .channel-models {
+  width: 100%;
+  max-width: none;
+  padding: 0 0 28px 0;
+  box-sizing: border-box;
 }
 .settings-shell .page-heading {
   margin-bottom: 10px;
@@ -1064,11 +1090,95 @@
 .model-group.selected {
   box-shadow: none;
 }
-/* The pane used to be centred inside a full page; inside the sheet it must
-   share the same edges as the tab row and the models pane. */
-.general-settings {
-  max-width: none;
+/* Runtime environment capability card and chips (high-contrast dark and light themes) */
+.runtime-settings {
+  display: flex;
+  flex-direction: column;
+}
+.platform-capability-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.platform-capability strong {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 3px;
+}
+.platform-meta {
+  font-size: 11px;
+  color: var(--muted);
+}
+.platform-meta code {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--soft);
+  color: var(--ink);
+  border: 1px solid var(--line);
+}
+.platform-browser-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.capability-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--soft);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.capability-chip strong {
+  display: inline;
+  font-weight: 600;
   margin: 0;
+  color: var(--ink);
+}
+.capability-chip .chip-indicator {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+.capability-chip.unavailable {
+  color: var(--muted);
+  background: color-mix(in srgb, var(--surface) 60%, transparent);
+  border: 1px dashed var(--line);
+  opacity: 0.85;
+}
+.capability-chip.unavailable .chip-indicator {
+  background: var(--muted);
+}
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--line);
+  background: var(--soft);
+  color: var(--ink);
+}
+.status-pill.active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+.status-pill.muted {
+  color: var(--muted);
+  background: var(--soft);
 }
 .preference-row {
   display: flex;
@@ -1475,10 +1585,6 @@
   color: var(--muted, #6b6b6b);
   font-size: 12px;
 }
-.platform-capability strong { display: block; color: var(--ink, #242424); font-size: 13px; }
-.platform-browser-capabilities { display: flex; flex-wrap: wrap; gap: 6px; }
-.capability-chip { padding: 3px 7px; border-radius: 999px; background: var(--surface-2, #f2f2f2); }
-.capability-chip.unavailable { color: var(--muted, #6b6b6b); opacity: .8; }
 /* The version doubles as the entry to version and updates. */
 button.app-version { border: 0; background: transparent; padding: 4px 7px; border-radius: 6px; cursor: pointer; font: inherit; color: var(--muted); }
 button.app-version:hover { background: var(--soft); color: var(--ink); }

--- a/apps/mms-web/src/styles.css
+++ b/apps/mms-web/src/styles.css
@@ -1640,6 +1640,31 @@ dialog:has(.dialog-body.sheet) .dialog-body.sheet > header {
   color: var(--amber);
   margin-bottom: 18px;
 }
+.inline-alert-retryable {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.inline-retry-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border: 1px solid color-mix(in srgb, var(--amber) 40%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--amber) 15%, var(--surface));
+  color: var(--amber);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: all 150ms ease-out;
+}
+.inline-retry-button:hover {
+  background: color-mix(in srgb, var(--amber) 25%, var(--surface));
+  border-color: var(--amber);
+}
 .form-error {
   color: var(--danger);
   margin-top: 15px;

--- a/apps/mms-web/src/types.ts
+++ b/apps/mms-web/src/types.ts
@@ -280,6 +280,12 @@ export interface ConfigPreview {
   changes: { label: string; before: string; after: string }[];
   warnings: string[];
 }
+export interface UpdateHistoryItem {
+  version: string;
+  notes: string;
+  upgradeNotice?: string;
+  publishedAt?: string;
+}
 export type Page = "new" | "models" | "bots" | "session";
 
 // Bot 结果送达（T3）：页面通知与 webhook 共用同一事件形状。

--- a/apps/mms-web/tests/release-notes.test.mjs
+++ b/apps/mms-web/tests/release-notes.test.mjs
@@ -1,0 +1,16 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { withoutUpgradeSection } from "../src/release-notes.ts";
+
+test("the upgrade section is removed from the body and later sections survive", () => {
+  const body = "# v4.20.0 · X\n\n## 升级须知\n\n先运行安装器。\n\n更多。\n\n## 其他\n\n- 一条\n";
+  assert.equal(withoutUpgradeSection(body), "# v4.20.0 · X\n\n## 其他\n\n- 一条");
+});
+
+test("a body without the section is returned unchanged apart from trimming", () => {
+  assert.equal(withoutUpgradeSection("# v1\n\n- a\n"), "# v1\n\n- a");
+});
+
+test("a deeper heading inside the section is skipped too", () => {
+  assert.equal(withoutUpgradeSection("## 升级须知\n\n### 细节\n\nx\n\n## 后面\n\ny"), "## 后面\n\ny");
+});

--- a/apps/mms-web/tests/settings-runtime-updates.test.mjs
+++ b/apps/mms-web/tests/settings-runtime-updates.test.mjs
@@ -1,0 +1,189 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compareSemverDesc, parseSemver } from "../src/semver-sort.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = path.resolve(__dirname, "../src");
+
+test("compareSemverDesc sorts versions strictly descending by semver numbers", () => {
+  const versions = [
+    "4.2.0",
+    "v4.10.0",
+    "4.9.0",
+    "4.16.0",
+    "4.10.1",
+    "v4.15.2",
+    "10.0.0",
+  ];
+  const sorted = [...versions].sort(compareSemverDesc);
+  assert.deepEqual(sorted, [
+    "10.0.0",
+    "4.16.0",
+    "v4.15.2",
+    "4.10.1",
+    "v4.10.0",
+    "4.9.0",
+    "4.2.0",
+  ]);
+
+  assert.deepEqual(parseSemver("v4.16.0"), [4, 16, 0]);
+  assert.deepEqual(parseSemver("4.1.2"), [4, 1, 2]);
+  assert.equal(parseSemver("invalid"), null);
+});
+
+test("SettingsPage includes 4th tab '运行环境' with Cpu icon and isolated runtime section", () => {
+  const content = fs.readFileSync(path.join(srcDir, "SettingsPage.tsx"), "utf-8");
+
+  // 4 tabs must be present in settings-tabs
+  assert.match(content, /tab === "models"/);
+  assert.match(content, /tab === "appearance"/);
+  assert.match(content, /tab === "usage"/);
+  assert.match(content, /tab === "runtime"/);
+  assert.match(content, /<Cpu size=\{16\} \/>\s*运行环境/);
+
+  // Platform capability is located in runtime tab
+  assert.match(content, /runtime-settings/);
+  assert.match(content, /className="platform-capability"/);
+});
+
+test("Platform capability is moved out of models page and only present in runtime tab", () => {
+  const modelsContent = fs.readFileSync(path.join(srcDir, "Models.tsx"), "utf-8");
+  const channelContent = fs.readFileSync(path.join(srcDir, "ChannelModels.tsx"), "utf-8");
+  const settingsContent = fs.readFileSync(path.join(srcDir, "SettingsPage.tsx"), "utf-8");
+
+  // Neither Models.tsx nor ChannelModels.tsx contains platform capability
+  assert.doesNotMatch(modelsContent, /platform-capability/);
+  assert.doesNotMatch(channelContent, /platform-capability/);
+
+  // In SettingsPage, platform-capability is inside the runtime branch
+  const runtimeBranchIndex = settingsContent.indexOf('runtime-settings');
+  const capabilityIndex = settingsContent.indexOf('className="platform-capability"');
+  assert.ok(runtimeBranchIndex > 0);
+  assert.ok(capabilityIndex > runtimeBranchIndex);
+});
+
+test("Dark theme contrast: capability chip uses semantic tokens and avoids hardcoded light backgrounds", () => {
+  const studioCss = fs.readFileSync(path.join(srcDir, "studio.css"), "utf-8");
+
+  // Must not use absent --surface-2 or light-on-light defaults
+  assert.doesNotMatch(studioCss, /--surface-2/);
+  assert.doesNotMatch(studioCss, /background:\s*#f2f2f2/);
+
+  // Must use Pilot semantic tokens
+  assert.match(studioCss, /\.capability-chip\s*\{[^}]*background:\s*var\(--soft\)/);
+  assert.match(studioCss, /\.capability-chip\s*\{[^}]*color:\s*var\(--ink\)/);
+  assert.match(studioCss, /\.capability-chip\s*\{[^}]*border:\s*1px solid var\(--line\)/);
+});
+
+test("Settings tabs, models, appearance, usage and channel-models share unified horizontal insets", () => {
+  const studioCss = fs.readFileSync(path.join(srcDir, "studio.css"), "utf-8");
+  const channelCss = fs.readFileSync(path.join(srcDir, "channel-models.css"), "utf-8");
+
+  // settings-page and general-settings unified width & margin
+  assert.match(studioCss, /\.settings-shell \.settings-page,\s*\.settings-shell \.general-settings\s*\{[^}]*width:\s*100%/);
+  assert.match(studioCss, /\.settings-shell \.settings-page,\s*\.settings-shell \.general-settings\s*\{[^}]*max-width:\s*none/);
+
+  // channel-models container width & margin flush with settings
+  assert.match(channelCss, /\.channel-models\s*\{[^}]*width:\s*100%/);
+  assert.match(channelCss, /\.channel-models\s*\{[^}]*max-width:\s*none/);
+});
+
+test("Channel save footer is sticky with full width, border and scroll occlusion prevention", () => {
+  const channelCss = fs.readFileSync(path.join(srcDir, "channel-models.css"), "utf-8");
+  const studioCss = fs.readFileSync(path.join(srcDir, "studio.css"), "utf-8");
+
+  // channel-save sticky properties
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*position:\s*sticky/);
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*bottom:\s*0/);
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*z-index:\s*10/);
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*width:\s*100%/);
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*background:\s*var\(--surface\)/);
+  assert.match(channelCss, /\.channel-save\s*\{[^}]*border-top:\s*1px solid var\(--line\)/);
+
+  // scroll padding to prevent occluding the bottom content
+  assert.match(studioCss, /scroll-padding-bottom:\s*72px/);
+});
+
+test("Home page does not automatically display WhatsNew card", () => {
+  const appContent = fs.readFileSync(path.join(srcDir, "App.tsx"), "utf-8");
+
+  // Home scroll/content must not contain automatic WhatsNew card
+  assert.doesNotMatch(appContent, /<WhatsNew/);
+});
+
+test("HelpGuide contains '版本更新' directory entry, calls /update/history, and is default-collapsed", () => {
+  const guideContent = fs.readFileSync(path.join(srcDir, "HelpGuide.tsx"), "utf-8");
+
+  // Nav directory entry
+  assert.match(guideContent, /版本更新/);
+  assert.match(guideContent, /更新历史与变更记录/);
+
+  // Endpoint call
+  assert.match(guideContent, /\/update\/history/);
+
+  // Default collapsed state
+  assert.match(guideContent, /useState<Set<string>>\(\(\)\s*=>\s*new Set\(\)\)/);
+  assert.match(guideContent, /isExpanded \? <ChevronUp/);
+
+  // Markdown rendering
+  assert.match(guideContent, /<Markdown remarkPlugins=\{\[remarkGfm\]\} skipHtml>/);
+});
+
+test("BotEditor renders PixelAvatar previews and PixelAvatar is exported", () => {
+  const botContent = fs.readFileSync(path.join(srcDir, "Bot.tsx"), "utf-8");
+  const botStudioContent = fs.readFileSync(path.join(srcDir, "BotStudio.tsx"), "utf-8");
+  const botCss = fs.readFileSync(path.join(srcDir, "bot.css"), "utf-8");
+
+  // PixelAvatar is exported
+  assert.match(botContent, /export function PixelAvatar/);
+
+  // BotStudio uses PixelAvatar in avatar options
+  assert.match(botStudioContent, /<PixelAvatar\s+avatarId=\{avatar\.id\}/);
+
+  // Avatar option has size definition in css
+  assert.match(botCss, /\.bot-avatar-option \.pixel-avatar,\s*\.bot-avatar-picker-preview\s*\{[^}]*width:\s*32px/);
+});
+
+test("Bot wake checkbox is aligned inline and not stretched by 100% width", () => {
+  const botCss = fs.readFileSync(path.join(srcDir, "bot.css"), "utf-8");
+
+  // Inputs in dialog exclude checkbox from full width
+  assert.match(botCss, /\.bot-create-dialog input:not\(\[type="checkbox"\]\)/);
+
+  // Bot-check is inline-flex with fixed 16px input
+  assert.match(botCss, /\.bot-check\s*\{[^}]*display:\s*inline-flex/);
+  assert.match(botCss, /\.bot-check input\[type="checkbox"\],\s*\.bot-check input\s*\{[^}]*width:\s*16px/);
+});
+
+test("BotChat respects enterToSend setting and BotArtifactPreview provides copy action", () => {
+  const botContent = fs.readFileSync(path.join(srcDir, "Bot.tsx"), "utf-8");
+  const botStudioContent = fs.readFileSync(path.join(srcDir, "BotStudio.tsx"), "utf-8");
+  const previewContent = fs.readFileSync(path.join(srcDir, "BotArtifactPreview.tsx"), "utf-8");
+  const botCss = fs.readFileSync(path.join(srcDir, "bot.css"), "utf-8");
+
+  // enterToSend prop in BotChat and BotStudio
+  assert.match(botContent, /enterToSend\s*=\s*true/);
+  assert.match(botContent, /sendCombo = enterToSend/);
+  assert.match(botStudioContent, /enterToSend\?: boolean/);
+  assert.match(botStudioContent, /enterToSend=\{enterToSend\}/);
+
+  // Artifact copy button
+  assert.match(previewContent, /navigator\.clipboard\.writeText/);
+  assert.match(previewContent, /className=\{`bot-preview-copy/);
+  assert.match(botCss, /\.bot-preview-copy\s*\{/);
+});
+
+test("ModelExplorer has inline retry button on launch options error", () => {
+  const explorerContent = fs.readFileSync(path.join(srcDir, "ModelExplorer.tsx"), "utf-8");
+  const stylesCss = fs.readFileSync(path.join(srcDir, "styles.css"), "utf-8");
+
+  assert.match(explorerContent, /setRetry\(\(r\)\s*=>\s*r \+ 1\)/);
+  assert.match(explorerContent, /className="inline-retry-button"/);
+  assert.match(stylesCss, /\.inline-alert-retryable/);
+  assert.match(stylesCss, /\.inline-retry-button/);
+});
+

--- a/mms_web/server.py
+++ b/mms_web/server.py
@@ -306,6 +306,9 @@ class WebApplication:
         if parts == ["update", "identity"]:
             from .update_handoff import path_identity, session_inventory
             return {"version": VERSION, "processId": os.getpid(), "instance": self.instance, "identity": path_identity(Path(__file__).resolve().parent.parent, self.state_root, self.config_root, Path.cwd()), "sessions": session_inventory(self.sessions)}
+        if parts == ["update", "history"]:
+            from .updates import release_history
+            return {"releases": release_history()}
         if parts == ["update"]:
             return self.updates.status()
         if parts == ["remote-access"]:

--- a/mms_web/updates.py
+++ b/mms_web/updates.py
@@ -86,6 +86,33 @@ def release_notes(version):
         return ''
 
 
+def release_history(root=None, limit=30):
+    """Every release note shipped with this install, newest first.
+
+    Same local source as release_notes(): the docs folder next to the code,
+    so the list is exactly what this install can say about itself and never
+    a network guess. Missing folder means an empty list, not an error.
+    """
+    base = Path(root) if root else Path(__file__).resolve().parent.parent / 'docs' / 'mms-web'
+    items = []
+    try:
+        paths = list(base.glob('RELEASE-v*.md'))
+    except OSError:
+        return []
+    for path in paths:
+        tag = path.name[len('RELEASE-v'):-len('.md')]
+        parsed = version_tuple(tag)
+        if parsed is None:
+            continue
+        try:
+            body = path.read_text(encoding='utf-8')[:16000]
+        except OSError:
+            continue
+        items.append((parsed, {'version': tag, 'notes': body, 'upgradeNotice': upgrade_notice(body)}))
+    items.sort(key=lambda item: item[0], reverse=True)
+    return [item[1] for item in items[:limit]]
+
+
 def fetch_release():
     request = urllib.request.Request(RELEASE_API, headers={'User-Agent': 'MMS-Pilot', 'Accept': 'application/vnd.github+json'})
     with urllib.request.build_opener(NoRedirect()).open(request, timeout=10) as response:

--- a/tests/test_mms_web_updates.py
+++ b/tests/test_mms_web_updates.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from mms_web.runtime import private_json
-from mms_web.updates import CHECK_INTERVAL, UpdateService, version_tuple
+from mms_web.updates import CHECK_INTERVAL, UpdateService, release_history, version_tuple
 from mms_web.update_guidance import upgrade_guidance, release_policy, INSTALL_COMMAND
 from mms_web.server import WebApplication
 
@@ -167,3 +167,20 @@ def test_ui_preferences_remember_which_notes_were_read(tmp_path):
 
     prefs.update({'whatsNewSeenVersion': 'x' * 200})
     assert len(UiPreferences(tmp_path).read()['whatsNewSeenVersion']) == 64
+
+
+def test_release_history_lists_shipped_notes_newest_first(tmp_path):
+    (tmp_path / 'RELEASE-v4.9.0.md').write_text('# v4.9.0\n\n- old', encoding='utf-8')
+    (tmp_path / 'RELEASE-v4.10.0.md').write_text('# v4.10.0\n\n## 升级须知\n\n先运行安装器。\n\n## 其他\n', encoding='utf-8')
+    (tmp_path / 'RELEASE-vnext.md').write_text('not a version', encoding='utf-8')
+    history = release_history(tmp_path)
+    assert [item['version'] for item in history] == ['4.10.0', '4.9.0']
+    assert history[0]['upgradeNotice'].strip() == '先运行安装器。'
+    assert history[1]['upgradeNotice'] == ''
+    assert release_history(tmp_path / 'missing') == []
+
+
+def test_update_history_route_reads_local_release_notes(tmp_path):
+    app = WebApplication.__new__(WebApplication)
+    with patch('mms_web.updates.release_history', return_value=[{'version': '4.20.0', 'notes': 'x', 'upgradeNotice': ''}]):
+        assert WebApplication.get(app, ["update", "history"], {}) == {'releases': [{'version': '4.20.0', 'notes': 'x', 'upgradeNotice': ''}]}


### PR DESCRIPTION
用户直接交给 gemini3.6 做的 Pilot 视觉改动，原本混在 Bot T1 分支里，Claude 拆出来单独评审。

## 内容
- 设置弹窗新增第四个"运行环境"标签，平台与浏览器能力 chip 从模型页移到这里，深色模式用 token 保证对比度。
- 统一设置各标签与通道模型页的左右边距，修复"检查并保存"吸底栏的宽度、边框和遮挡。
- 帮助引导新增"版本更新"目录：按 semver 倒序的版本卡片，可展开 Markdown，搜索能命中更新说明。
- 首页不再自动弹 What's New。
- 文本类成果预览加"复制全文"，通道启动选项失败时有内联重试。

## Claude 复核后修的
- 帮助里的版本列表原来请求的 `/api/v1/update/history` 后端并不存在，失败后回退到一份手写的三条假记录（含把 gemini 自己的改动写成 v4.16.0 发布说明）。已补后端接口，读取随安装附带的 `RELEASE-v*.md`，与 What's New 同源；前端在真实模式下不再用预览数据顶替。当前树列出 27 个版本。

## 验证
- `tests/test_mms_web_updates.py` 15 passed（新增 2 条）；9 个前端测试文件全过；build 通过。
- 61500 独立实例上用 ego-browser 看过：运行环境标签浅色/深色、模型页、帮助版本更新（真实数据，v4.20.0 可展开）。

基于任务分支，随 #242 一起进 dev。Refs #238。

https://claude.ai/code/session_017SDWGU4VKoxgBtTjqjUxpT