### PR TITLE
fix(windows): resolve Pi launcher and package tzdata

### DIFF
--- a/.github/workflows/windows-acceptance.yml
+++ b/.github/workflows/windows-acceptance.yml
@@ -30,6 +30,7 @@ on:
       - "tests/test_mms_web_install_lock.py"
       - "tests/test_mms_web_local_files.py"
       - "tests/test_mms_web_service.py"
+      - "tests/test_mms_web_windows_imports.py"
       - "tests/test_mms_web_status.py"
       - "tests/test_mms_web_sessions_pi_driver.py"
       - "tests/test_npx_installer_package.py"
@@ -166,6 +167,7 @@ jobs:
             tests/test_mms_web_install_lock.py `
             tests/test_mms_web_local_files.py `
             tests/test_mms_web_service.py `
+            tests/test_mms_web_windows_imports.py `
             tests/test_mms_web_status.py `
             tests/test_mms_web_sessions_pi_driver.py `
             tests/test_npx_installer_package.py `

--- a/.github/workflows/windows-acceptance.yml
+++ b/.github/workflows/windows-acceptance.yml
@@ -17,10 +17,14 @@ on:
       - ".github/workflows/windows-acceptance.yml"
       - "scripts/ci/windows_acceptance.ps1"
       - "mms_platform.py"
+      - "mms_runtime.py"
+      - "mms_pi_support.py"
       - "mms_web/**"
       - "packages/mms-install/**"
       - "apps/mms-web/src/local-file-paths.ts"
       - "tests/test_mms_platform.py"
+      - "tests/test_mms_runtime.py"
+      - "tests/test_pi_windows_resolution.py"
       - "tests/test_mms_web_browser_capability.py"
       - "tests/test_mms_web_file_lock.py"
       - "tests/test_mms_web_install_lock.py"
@@ -103,7 +107,8 @@ jobs:
 
       - name: Install Python test tools
         shell: pwsh
-        run: python -m pip install pytest httpx rich tomli-w
+        # tzdata: Windows CPython has no IANA database; zoneinfo needs it.
+        run: python -m pip install pytest httpx rich tomli-w tzdata
 
       - name: Install Pi (positive discoverability cell)
         if: matrix.pi_present
@@ -134,6 +139,8 @@ jobs:
         env:
           MMS_CONFIG_ROOT: ${{ runner.temp }}\mms-ci-config
           MMS_STATE_ROOT: ${{ runner.temp }}\mms-ci-state
+          # Optional one-real-model-reply smoke (phase 7c); unset secret = skipped.
+          MMS_SMOKE_OPENAI_KEY: ${{ secrets.MMS_WINDOWS_SMOKE_OPENAI_KEY }}
         run: |
           $piPresent = [bool]::Parse('${{ matrix.pi_present }}')
           & .\scripts\ci\windows_acceptance.ps1 `
@@ -152,6 +159,8 @@ jobs:
           $env:PYTHONPATH = $PWD.Path
           python -m pytest -q `
             tests/test_mms_platform.py `
+            tests/test_mms_runtime.py `
+            tests/test_pi_windows_resolution.py `
             tests/test_mms_web_browser_capability.py `
             tests/test_mms_web_file_lock.py `
             tests/test_mms_web_install_lock.py `

--- a/mms_pi_support.py
+++ b/mms_pi_support.py
@@ -236,7 +236,24 @@ def _pi_global_executable():
     A session started from Finder or by the installer does not inherit the
     shell PATH that nvm/fnm/npm-global rely on, so `which` alone reported no
     Pi on machines that run it fine from a terminal.
+
+    Windows npm-global puts the shims directly in the prefix (no ``bin/``),
+    and the extensionless ``pi`` there is a POSIX shell script that
+    CreateProcess cannot start; only the ``.cmd``/``.exe`` sibling is a valid
+    subprocess.Popen target.
     """
+    if os.name == "nt":
+        from mms_runtime import windows_executable_candidate
+
+        candidate = windows_executable_candidate(shutil.which("pi"))
+        if candidate and os.path.isfile(candidate):
+            return candidate
+        prefix = _npm_global_prefix()
+        if prefix:
+            candidate = windows_executable_candidate(os.path.join(prefix, "pi"))
+            if candidate and os.path.isfile(candidate):
+                return candidate
+        return ""
     candidate = shutil.which("pi")
     if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
         return candidate

--- a/mms_runtime.py
+++ b/mms_runtime.py
@@ -92,6 +92,37 @@ def cli_search_dirs(env=None, real_home=None):
     return _dedupe([*path_dirs, *nvm_dirs, *preferred, "/usr/bin", "/bin"])
 
 
+# Extensions CreateProcess can start directly. npm also installs an
+# extensionless shell shim (Git Bash/WSL) and a .ps1 next to the real
+# ``pi.cmd``; neither is a valid subprocess.Popen target on Windows.
+_WINDOWS_EXECUTABLE_EXTS = (".exe", ".cmd", ".bat", ".com")
+
+
+def windows_executable_candidate(candidate):
+    """Return a Popen-startable Windows executable for ``candidate`` or "".
+
+    ``where.exe pi`` lists the extensionless npm shim before ``pi.cmd``, and a
+    misconfigured PATHEXT can make even ``shutil.which`` return it. The bare
+    shim is a POSIX shell script: handing it to CreateProcess fails or, worse,
+    starts something that never speaks the expected protocol. An extensionless
+    candidate is replaced by its sibling ``.exe``/``.cmd`` when one exists;
+    anything else without an executable extension is rejected outright.
+    """
+    if not candidate:
+        return ""
+    text = str(candidate)
+    if text.lower().endswith(_WINDOWS_EXECUTABLE_EXTS):
+        return text
+    _, ext = os.path.splitext(text)
+    if ext:
+        return ""
+    for suffix in _WINDOWS_EXECUTABLE_EXTS:
+        sibling = text + suffix
+        if os.path.isfile(sibling):
+            return sibling
+    return ""
+
+
 def resolve_cli_binary(command_name, env=None, real_home=None):
     name = str(command_name or "").strip()
     if not name:
@@ -110,11 +141,13 @@ def resolve_cli_binary(command_name, env=None, real_home=None):
         if not candidate:
             continue
         path_value = candidate if os.path.isabs(candidate) else shutil.which(candidate, path=search_path)
-        # The repository Pi wrapper is a POSIX shell script. Windows can
-        # discover a real ``pi.cmd`` on PATH, but CreateProcess cannot execute
-        # the ``.sh`` wrapper directly.
-        if os.name == "nt" and str(path_value or "").lower().endswith(".sh"):
-            continue
+        if os.name == "nt":
+            # The repository Pi wrapper is a POSIX shell script and the npm
+            # extensionless shim is not CreateProcess-startable; Windows must
+            # land on the sibling pi.cmd / pi.exe instead.
+            path_value = windows_executable_candidate(path_value)
+            if not path_value:
+                continue
         if path_value and os.path.isfile(path_value) and os.access(path_value, os.X_OK):
             return os.path.abspath(path_value)
     return ""

--- a/mms_web/bot_memory.py
+++ b/mms_web/bot_memory.py
@@ -7,7 +7,6 @@ the caller are retained as ``kind=task`` notes and are clearly labelled.
 """
 from __future__ import annotations
 
-import fcntl
 import json
 import re
 import shutil
@@ -17,6 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
 
+from .file_lock import LOCK_EX, LOCK_SH, LOCK_UN, flock
 from .runtime import private_json
 
 SCHEMA = 1
@@ -151,11 +151,11 @@ class BotMemoryStore:
         lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         handle = lock_path.open("a+")
         try:
-            fcntl.flock(handle, fcntl.LOCK_EX if write else fcntl.LOCK_SH)
+            flock(handle, LOCK_EX if write else LOCK_SH)
             yield path
         finally:
             try:
-                fcntl.flock(handle, fcntl.LOCK_UN)
+                flock(handle, LOCK_UN)
             finally:
                 handle.close()
 
@@ -296,10 +296,10 @@ class BotMemoryStore:
             lock_path = directory / "owner.lock"
             handle = lock_path.open("a+")
             try:
-                fcntl.flock(handle, fcntl.LOCK_EX)
+                flock(handle, LOCK_EX)
             finally:
                 try:
-                    fcntl.flock(handle, fcntl.LOCK_UN)
+                    flock(handle, LOCK_UN)
                 finally:
                     handle.close()
             shutil.rmtree(directory)

--- a/mms_web/bots.py
+++ b/mms_web/bots.py
@@ -6,7 +6,6 @@ executor, retry-after-uncertain-launch, or arbitrary local-file serving.
 from __future__ import annotations
 
 import base64
-import fcntl
 import hashlib
 import json
 import secrets
@@ -17,6 +16,8 @@ from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
+
+from .file_lock import LOCK_EX, LOCK_NB, flock
 
 from .errors import WebError
 from .runtime import private_json
@@ -175,7 +176,7 @@ class BotRuntime(BotCommunications):
             self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
             handle = (self.root / "owner.lock").open("a+")
             try:
-                fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                flock(handle, LOCK_EX | LOCK_NB)
             except OSError:
                 handle.close()
                 raise WebError("BOT_STORE_BUSY", "另一个 Pilot 正在管理这份 Bot 记录。", 409) from None

--- a/mms_web/drivers/launch_bridge.py
+++ b/mms_web/drivers/launch_bridge.py
@@ -40,6 +40,18 @@ def cached_pi() -> str:
             else:
                 manifest = candidate.parents[1] / "package.json"
             if os.access(candidate, os.X_OK) and manifest.is_file():
+                if os.name == "nt":
+                    if candidate.name != "pi":
+                        # A bare cli.js is not CreateProcess-startable either.
+                        continue
+                    # The npx cache .bin holds the same extensionless POSIX
+                    # shim; only the .cmd/.exe sibling is Popen-startable.
+                    from mms_runtime import windows_executable_candidate
+
+                    resolved = windows_executable_candidate(str(candidate))
+                    if not resolved:
+                        continue
+                    return resolved
                 return str(candidate)
     return ""
 

--- a/packages/mms-install/bin/install.ps1
+++ b/packages/mms-install/bin/install.ps1
@@ -194,11 +194,13 @@ try {
     $venvPython = Join-Path $venv "Scripts\python.exe"
     if (-not (Test-Path -LiteralPath $venvPython)) {
       & $python.path @($python.args) -m venv $venv
-      if ($LASTEXITCODE -ne 0) { throw "创建 venv 失败：$venv。可以加 -NoVenv 跳过，但那样必须自己安装 rich httpx tomli-w。" }
+      if ($LASTEXITCODE -ne 0) { throw "创建 venv 失败：$venv。可以加 -NoVenv 跳过，但那样必须自己安装 rich httpx tomli-w tzdata。" }
     }
     & $venvPython -m pip install --quiet --upgrade pip
-    & $venvPython -m pip install --quiet rich httpx tomli-w
-    if ($LASTEXITCODE -ne 0) { throw "安装 Python 依赖失败（rich httpx tomli-w）。没有 httpx，Pilot 无法连接模型通道。" }
+    # tzdata: Windows CPython ships no IANA database; zoneinfo(Asia/Singapore)
+    # in session timestamps fails without it.
+    & $venvPython -m pip install --quiet rich httpx tomli-w tzdata
+    if ($LASTEXITCODE -ne 0) { throw "安装 Python 依赖失败（rich httpx tomli-w tzdata）。没有 httpx，Pilot 无法连接模型通道。" }
     $launchPython = $venvPython
     $launchArgs = @()
   }
@@ -227,7 +229,9 @@ try {
   Write-TextFile $ps1 (($psLines -join "`n") + "`n")
 
   & $launchPython -c "import httpx, rich" 2>$null
-  if ($LASTEXITCODE -ne 0) { Write-Warning "启动用的 Python 缺少 httpx/rich，Pilot 绑定通道会失败。请运行：`"$launchPython`" -m pip install rich httpx tomli-w" }
+  if ($LASTEXITCODE -ne 0) { Write-Warning "启动用的 Python 缺少 httpx/rich，Pilot 绑定通道会失败。请运行：`"$launchPython`" -m pip install rich httpx tomli-w tzdata" }
+  & $launchPython -c "from zoneinfo import ZoneInfo; ZoneInfo('Asia/Singapore')" 2>$null
+  if ($LASTEXITCODE -ne 0) { Write-Warning "启动用的 Python 缺少 tzdata，会话时间戳会失败。请运行：`"$launchPython`" -m pip install tzdata" }
 
   $resolvedConfig = ""
   try {

--- a/scripts/ci/windows_acceptance.ps1
+++ b/scripts/ci/windows_acceptance.ps1
@@ -243,6 +243,117 @@ print("PI_DISCOVERED", found)
 '@
   Assert-True ($piProbe -match "PI_DISCOVERED") "pilot-style PATH discovery failed: $piProbe"
   Write-Host "pi OK: $($piVersion -join ' ') -> $piProbe"
+
+  # --- Phase 7b: MMS resolver must return pi.cmd/pi.exe and RPC must answer --
+  Write-Phase "7b pi-rpc-get-state"
+  $whereOrder = (& where.exe pi 2>$null | ForEach-Object { "$_" }) -join "`n"
+  Write-Host "where.exe pi order:`n$whereOrder"
+  $rpcProbe = Invoke-PyProbe @'
+import json, queue, subprocess, sys, threading
+from mms_runtime import resolve_cli_binary
+
+resolved = resolve_cli_binary("pi")
+assert resolved, "resolve_cli_binary found no pi"
+assert resolved.lower().endswith((".cmd", ".exe", ".bat", ".com")), \
+    "resolver returned a non-CreateProcess target: " + resolved
+proc = subprocess.Popen([resolved, "--mode", "rpc", "--no-session"],
+                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL, text=True, encoding="utf-8")
+lines = queue.Queue()
+reader = threading.Thread(target=lambda: [lines.put(l) for l in proc.stdout], daemon=True)
+reader.start()
+proc.stdin.write(json.dumps({"id": "smoke1", "type": "get_state"}) + "\n")
+proc.stdin.flush()
+deadline_lines = []
+try:
+    while True:
+        line = lines.get(timeout=30).strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("type") == "response" and event.get("id") == "smoke1":
+            assert event.get("success") is True, "get_state failed: " + line
+            print("RPC_GET_STATE_OK", resolved)
+            break
+except queue.Empty:
+    print("RPC_TIMEOUT no get_state response from", resolved)
+    sys.exit(4)
+finally:
+    try:
+        proc.stdin.close()
+    except OSError:
+        pass
+    proc.kill()
+    proc.wait(timeout=10)
+'@
+  Assert-True ($rpcProbe -match "RPC_GET_STATE_OK") "pi rpc get_state smoke failed: $rpcProbe"
+  Write-Host $rpcProbe
+
+  # --- Phase 7c: one real model reply (opt-in, secret-gated) ------------------
+  # Runs only when MMS_SMOKE_OPENAI_KEY is provided (GitHub secret or a manual
+  # machine export). The key goes straight to Pi's own OPENAI_API_KEY handling;
+  # no MMS config, model route, or protocol is touched.
+  if ($env:MMS_SMOKE_OPENAI_KEY) {
+    Write-Phase "7c pi-model-reply"
+    $env:OPENAI_API_KEY = $env:MMS_SMOKE_OPENAI_KEY
+    $replyProbe = Invoke-PyProbe @'
+import json, os, queue, subprocess, sys, threading
+from mms_runtime import resolve_cli_binary
+
+resolved = resolve_cli_binary("pi")
+assert resolved, "resolve_cli_binary found no pi"
+proc = subprocess.Popen([resolved, "--mode", "rpc", "--no-session",
+                         "--provider", "openai", "--model", "gpt-4o-mini"],
+                        stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                        stderr=subprocess.DEVNULL, text=True, encoding="utf-8")
+lines = queue.Queue()
+threading.Thread(target=lambda: [lines.put(l) for l in proc.stdout], daemon=True).start()
+
+def send(payload):
+    proc.stdin.write(json.dumps(payload) + "\n")
+    proc.stdin.flush()
+
+try:
+    send({"id": "p1", "type": "prompt", "message": "Reply with the single word: ok"})
+    settled = False
+    while True:
+        line = lines.get(timeout=180).strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("type") == "response" and event.get("id") == "p1":
+            assert event.get("success") is True, "prompt rejected: " + line
+        if event.get("type") == "agent_settled":
+            settled = True
+            break
+    assert settled
+    send({"id": "t1", "type": "get_last_assistant_text"})
+    while True:
+        line = lines.get(timeout=30).strip()
+        if not line:
+            continue
+        event = json.loads(line)
+        if event.get("type") == "response" and event.get("id") == "t1":
+            text = ((event.get("data") or {}).get("text") or "").strip()
+            assert text, "empty assistant reply: " + line
+            print("RPC_MODEL_REPLY_OK", resolved, "reply=", text[:80])
+            break
+except queue.Empty:
+    print("RPC_TIMEOUT waiting for model reply")
+    sys.exit(4)
+finally:
+    try:
+        proc.stdin.close()
+    except OSError:
+        pass
+    proc.kill()
+    proc.wait(timeout=10)
+'@
+    Assert-True ($replyProbe -match "RPC_MODEL_REPLY_OK") "pi model reply smoke failed: $replyProbe"
+    Write-Host $replyProbe
+  } else {
+    Write-Host "phase 7c skipped: MMS_SMOKE_OPENAI_KEY not configured (get_state smoke in 7b still ran)"
+  }
 } else {
   Assert-True ($null -eq $piCommand) "pi must be absent in the floor cell so the missing-Pi path stays covered"
   Write-Host "pi intentionally absent; missing-Pi messaging was checked in phase 2"

--- a/tests/test_mms_runtime.py
+++ b/tests/test_mms_runtime.py
@@ -1,5 +1,13 @@
+import os
 import sys
 from types import SimpleNamespace
+
+import pytest
+
+# These three fixtures build extensionless POSIX executables; on Windows the
+# resolver correctly rejects extensionless files (CreateProcess cannot start
+# them), so the POSIX contract is only checkable on POSIX.
+posix_only = pytest.mark.skipif(os.name == "nt", reason="POSIX CLI executables carry no extension")
 
 
 def test_runtime_accepts_current_supported_python():
@@ -56,6 +64,7 @@ def test_runtime_reexecs_even_when_reexec_flag_is_inherited(monkeypatch):
     assert "stderr" not in captured
 
 
+@posix_only
 def test_cli_resolver_finds_claude_in_other_nvm_version(tmp_path, monkeypatch):
     import mms_runtime
 
@@ -75,6 +84,7 @@ def test_cli_resolver_finds_claude_in_other_nvm_version(tmp_path, monkeypatch):
     assert resolved == str(claude)
 
 
+@posix_only
 def test_prepare_cli_command_prepends_resolved_bin_dir(tmp_path):
     import mms_runtime
 
@@ -95,6 +105,7 @@ def test_prepare_cli_command_prepends_resolved_bin_dir(tmp_path):
     assert env["PATH"].split(":")[0] == str(node22.resolve())
 
 
+@posix_only
 def test_cli_resolver_preserves_nvm_bin_symlink(tmp_path):
     import mms_runtime
 

--- a/tests/test_mms_runtime.py
+++ b/tests/test_mms_runtime.py
@@ -135,3 +135,67 @@ def test_windows_cli_resolver_skips_posix_wrapper_for_cmd_shim(tmp_path, monkeyp
     resolved = mms_runtime.resolve_cli_binary("pi", env={"MMS_PI_BIN": str(wrapper), "PATH": str(tmp_path)})
 
     assert resolved == str(cmd)
+
+
+def _windows_shim_pair(tmp_path):
+    """An npm-global layout: extensionless POSIX shim beside the real pi.cmd."""
+    bare = tmp_path / "pi"
+    bare.write_text("#!/bin/sh\nexec node ...\n", encoding="utf-8")
+    bare.chmod(0o755)
+    cmd = tmp_path / "pi.cmd"
+    cmd.write_text("@echo off\r\n", encoding="utf-8")
+    cmd.chmod(0o755)  # the X_OK check still runs on the POSIX test host
+    return bare, cmd
+
+
+def test_windows_resolver_prefers_cmd_sibling_over_extensionless_shim(tmp_path, monkeypatch):
+    """where.exe lists the bare npm shim first; MMS must still return pi.cmd."""
+    import mms_runtime
+
+    bare, cmd = _windows_shim_pair(tmp_path)
+    monkeypatch.setattr(mms_runtime.os, "name", "nt")
+    monkeypatch.setattr(mms_runtime, "_repo_cli_wrapper", lambda name: "")
+    # Simulate a PATHEXT quirk where shutil.which returns the bare shim.
+    monkeypatch.setattr(mms_runtime.shutil, "which", lambda name, path=None: str(bare))
+
+    resolved = mms_runtime.resolve_cli_binary("pi", env={"PATH": str(tmp_path)})
+
+    assert resolved == str(cmd)
+
+
+def test_windows_resolver_rewrites_bare_override_to_cmd_sibling(tmp_path, monkeypatch):
+    import mms_runtime
+
+    bare, cmd = _windows_shim_pair(tmp_path)
+    monkeypatch.setattr(mms_runtime.os, "name", "nt")
+    monkeypatch.setattr(mms_runtime, "_repo_cli_wrapper", lambda name: "")
+
+    resolved = mms_runtime.resolve_cli_binary("pi", env={"MMS_PI_BIN": str(bare), "PATH": str(tmp_path)})
+
+    assert resolved == str(cmd)
+
+
+def test_windows_resolver_rejects_shim_without_executable_sibling(tmp_path, monkeypatch):
+    """A bare shim with no pi.cmd/pi.exe beside it is never a Popen target."""
+    import mms_runtime
+
+    bare, _ = _windows_shim_pair(tmp_path)
+    (tmp_path / "pi.cmd").unlink()
+    (tmp_path / "pi.ps1").write_text("pi.ps1\n", encoding="utf-8")  # .ps1 is not CreateProcess-startable
+    monkeypatch.setattr(mms_runtime.os, "name", "nt")
+    monkeypatch.setattr(mms_runtime, "_repo_cli_wrapper", lambda name: "")
+    monkeypatch.setattr(mms_runtime.shutil, "which", lambda name, path=None: str(bare))
+
+    assert mms_runtime.resolve_cli_binary("pi", env={"PATH": str(tmp_path)}) == ""
+    assert mms_runtime.resolve_cli_binary("pi", env={"MMS_PI_BIN": str(tmp_path / "pi.ps1"), "PATH": str(tmp_path)}) == ""
+
+
+def test_posix_resolver_keeps_accepting_extensionless_executables(tmp_path, monkeypatch):
+    import mms_runtime
+
+    bare, _ = _windows_shim_pair(tmp_path)
+    monkeypatch.setattr(mms_runtime.os, "name", "posix")
+    monkeypatch.setattr(mms_runtime, "_repo_cli_wrapper", lambda name: "")
+    monkeypatch.setattr(mms_runtime.shutil, "which", lambda name, path=None: str(bare))
+
+    assert mms_runtime.resolve_cli_binary("pi", env={"PATH": str(tmp_path)}) == str(bare)

--- a/tests/test_mms_web_windows_imports.py
+++ b/tests/test_mms_web_windows_imports.py
@@ -1,0 +1,81 @@
+"""The Pilot web import graph must not require POSIX-only modules on Windows.
+
+Unconditional ``import fcntl`` in ``mms_web/bots.py`` and ``mms_web/bot_memory.py``
+broke ``mms web start`` on Windows with ModuleNotFoundError (Windows acceptance
+phase 8). Locks must go through ``mms_web/file_lock.py``, which carries the
+msvcrt branch. These tests pin that contract:
+
+* no bare top-level fcntl import anywhere in the web import graph;
+* the full server import chain loads in a fresh interpreter;
+* the Bot store and memory locks exercise the shim on every platform.
+"""
+import ast
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORT_GRAPH = sorted((ROOT / "mms_web").rglob("*.py")) + [
+    ROOT / name
+    for name in ("mms", "mms_runtime.py", "mms_platform.py", "mms_state_io.py", "mms_core.py")
+    if (ROOT / name).is_file()
+]
+
+
+def _bare_fcntl_imports(path: Path) -> list[int]:
+    """Top-level fcntl imports not guarded by try/except or a platform branch."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    offenders = []
+
+    def visit(statements, guarded):
+        for node in statements:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = [a.name for a in node.names] if isinstance(node, ast.Import) else [node.module or ""]
+                if any(name.split(".")[0] == "fcntl" for name in names) and not guarded:
+                    offenders.append(node.lineno)
+            elif isinstance(node, ast.Try):
+                visit(node.body, True)
+            elif isinstance(node, ast.If):
+                # Platform branches (os.name / sys.platform) are explicit guards.
+                visit(node.body, True)
+                visit(node.orelse, True)
+            # Function/class bodies hold runtime imports, not import-time blockers.
+
+    visit(tree.body, False)
+    return offenders
+
+
+def test_no_bare_fcntl_import_in_web_import_graph():
+    failures = {
+        str(path.relative_to(ROOT)): lines
+        for path in IMPORT_GRAPH
+        if (lines := _bare_fcntl_imports(path))
+    }
+    assert not failures, f"unconditional fcntl imports fail on Windows: {failures}"
+
+
+def test_pilot_server_import_chain_loads_in_a_fresh_interpreter():
+    code = (
+        "import mms_web.server, mms_web.bots, mms_web.bot_memory, mms_web.__main__;"
+        "print('IMPORT_CHAIN_OK')"
+    )
+    env = {**os.environ, "PYTHONPATH": str(ROOT)}
+    result = subprocess.run([sys.executable, "-P", "-c", code], cwd=ROOT, env=env,
+                            capture_output=True, text=True, timeout=60)
+    assert "IMPORT_CHAIN_OK" in result.stdout, result.stderr[-2000:]
+
+
+def test_bot_store_and_memory_locks_use_the_cross_platform_shim(tmp_path):
+    """Both stores must lock through mms_web.file_lock, not fcntl directly."""
+    from mms_web import bots, bot_memory
+
+    assert bots.flock is bot_memory.flock
+    assert bots.flock.__module__ == "mms_web.file_lock"
+
+    store = bot_memory.BotMemoryStore(tmp_path)
+    store.remember("bot_probe", "windows lock probe")
+    notes = store.get("bot_probe")["notes"]
+    assert notes[0]["content"] == "windows lock probe" and notes[0]["kind"] == "fact"
+    store.delete("bot_probe")
+    assert not (tmp_path / "bots" / "memory" / "bot_probe").exists()

--- a/tests/test_pi_windows_resolution.py
+++ b/tests/test_pi_windows_resolution.py
@@ -1,0 +1,129 @@
+"""Windows Pi executable resolution: never the extensionless npm shim.
+
+The npm-global layout on Windows puts ``pi`` (POSIX shell), ``pi.cmd`` and
+``pi.ps1`` directly in the prefix with no ``bin/`` directory. Only the
+``.cmd``/``.exe`` sibling is a valid subprocess.Popen target.
+"""
+import os
+import stat
+
+import pytest
+
+
+def _npm_layout(tmp_path):
+    prefix = tmp_path / "npm-prefix"
+    prefix.mkdir()
+    bare = prefix / "pi"
+    bare.write_text("#!/bin/sh\n", encoding="utf-8")
+    bare.chmod(0o755)
+    cmd = prefix / "pi.cmd"
+    cmd.write_text("@echo off\r\n", encoding="utf-8")
+    cmd.chmod(0o755)  # the X_OK check still runs on the POSIX test host
+    return prefix, bare, cmd
+
+
+def test_pi_global_executable_prefers_cmd_sibling_on_windows(tmp_path, monkeypatch):
+    import mms_pi_support
+
+    prefix, bare, cmd = _npm_layout(tmp_path)
+    monkeypatch.setattr(mms_pi_support.os, "name", "nt")
+    # PATHEXT quirk: which() returns the bare shim first.
+    monkeypatch.setattr(mms_pi_support.shutil, "which", lambda name: str(bare))
+
+    assert mms_pi_support._pi_global_executable() == str(cmd)
+
+
+def test_pi_global_executable_uses_windows_prefix_layout_without_bin(tmp_path, monkeypatch):
+    """No PATH hit: Windows npm-global has shims in the prefix, not prefix/bin."""
+    import mms_pi_support
+
+    prefix, bare, cmd = _npm_layout(tmp_path)
+    monkeypatch.setattr(mms_pi_support.os, "name", "nt")
+    monkeypatch.setattr(mms_pi_support.shutil, "which", lambda name: None)
+    monkeypatch.setattr(mms_pi_support, "_npm_global_prefix", lambda: str(prefix))
+
+    assert mms_pi_support._pi_global_executable() == str(cmd)
+
+
+def test_pi_global_executable_never_returns_extensionless_shim_on_windows(tmp_path, monkeypatch):
+    import mms_pi_support
+
+    prefix, bare, cmd = _npm_layout(tmp_path)
+    cmd.unlink()
+    monkeypatch.setattr(mms_pi_support.os, "name", "nt")
+    monkeypatch.setattr(mms_pi_support.shutil, "which", lambda name: str(bare))
+    monkeypatch.setattr(mms_pi_support, "_npm_global_prefix", lambda: str(prefix))
+
+    assert mms_pi_support._pi_global_executable() == ""
+
+
+def test_pi_global_executable_posix_layout_unchanged(tmp_path, monkeypatch):
+    import mms_pi_support
+
+    prefix, bare, _ = _npm_layout(tmp_path)
+    bin_dir = prefix / "bin"
+    bin_dir.mkdir()
+    posix_pi = bin_dir / "pi"
+    posix_pi.write_text("#!/bin/sh\n", encoding="utf-8")
+    posix_pi.chmod(0o755)
+    monkeypatch.setattr(mms_pi_support.os, "name", "posix")
+    monkeypatch.setattr(mms_pi_support.shutil, "which", lambda name: None)
+    monkeypatch.setattr(mms_pi_support, "_npm_global_prefix", lambda: str(prefix))
+
+    assert mms_pi_support._pi_global_executable() == str(posix_pi)
+
+
+def _npx_cache_layout(tmp_path, *, with_cmd=True, with_cli_js=False):
+    cache = tmp_path / "npm-cache"
+    package = cache / "_npx" / "abc123" / "node_modules" / "@earendil-works" / "pi-coding-agent"
+    bin_dir = cache / "_npx" / "abc123" / "node_modules" / ".bin"
+    bin_dir.mkdir(parents=True)
+    package.mkdir(parents=True)
+    (package / "package.json").write_text("{}", encoding="utf-8")
+    bare = bin_dir / "pi"
+    bare.write_text("#!/bin/sh\n", encoding="utf-8")
+    bare.chmod(0o755)
+    if with_cmd:
+        cmd = bin_dir / "pi.cmd"
+        cmd.write_text("@echo off\r\n", encoding="utf-8")
+        cmd.chmod(0o755)
+    if with_cli_js:
+        cli = package / "dist" / "cli.js"
+        cli.parent.mkdir(parents=True, exist_ok=True)
+        cli.write_text("// cli\n", encoding="utf-8")
+        cli.chmod(0o755)
+    return cache, bin_dir
+
+
+def test_cached_pi_returns_cmd_sibling_on_windows(tmp_path, monkeypatch):
+    from mms_web.drivers import launch_bridge
+
+    cache, bin_dir = _npx_cache_layout(tmp_path)
+    monkeypatch.setattr(launch_bridge.os, "name", "nt")
+    monkeypatch.setattr(launch_bridge, "_npx_caches", lambda: [cache])
+
+    resolved = launch_bridge.cached_pi()
+
+    assert resolved == str(bin_dir / "pi.cmd")
+    assert not resolved.endswith("\\pi") and not resolved.endswith("/pi")
+
+
+def test_cached_pi_skips_unstartable_entries_on_windows(tmp_path, monkeypatch):
+    """cli.js and a lone extensionless shim are both dead ends for Popen."""
+    from mms_web.drivers import launch_bridge
+
+    cache, _ = _npx_cache_layout(tmp_path, with_cmd=False, with_cli_js=True)
+    monkeypatch.setattr(launch_bridge.os, "name", "nt")
+    monkeypatch.setattr(launch_bridge, "_npx_caches", lambda: [cache])
+
+    assert launch_bridge.cached_pi() == ""
+
+
+def test_cached_pi_posix_keeps_extensionless_shim(tmp_path, monkeypatch):
+    from mms_web.drivers import launch_bridge
+
+    cache, bin_dir = _npx_cache_layout(tmp_path, with_cmd=False)
+    monkeypatch.setattr(launch_bridge.os, "name", "posix")
+    monkeypatch.setattr(launch_bridge, "_npx_caches", lambda: [cache])
+
+    assert launch_bridge.cached_pi() == str(bin_dir / "pi")


### PR DESCRIPTION
## 变更

将已在 Windows 实机验证的 Pi 启动修复合入 `dev`：

- Windows 下优先解析可执行的 `pi.cmd` / `pi.exe`，跳过 npm 的 extensionless shell shim
- Windows installer 与 acceptance 环境补齐 `tzdata`
- 增加 Windows Pi resolver、runtime、launch smoke 覆盖

`origin/dev` 已包含当前 Bot/Settings 更新，本 PR 不重复引入旧集成分支。

## 验证

- Windows 实机：用户已验证 Pi RPC `get_state`、Pilot 启动和模型对话链路
- 定向 Python 回归：114 passed
- `py_compile`：passed
- `git diff --check`：passed
- merge-tree：无冲突

## 风险与回滚

仅影响 Windows launcher resolution、installer dependency 和 acceptance smoke；回滚可还原本 PR merge commit。
