### PR TITLE
release: v4.21.0 Windows Preview fixes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -51,7 +51,7 @@ Limits: it listens on the loopback address only, there is no remote multi-user a
 
 ## Current Version
 
-Current release: `v4.20.0` on the `dev` track. Stable and canary tracks keep
+Current release: `v4.21.0` on the `dev` track. Stable and canary tracks keep
 their branch-specific versions; see [Release channels](docs/RELEASE_CHANNELS.md)
 for the channel contract.
 
@@ -131,7 +131,7 @@ curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/ins
 Exact pin when needed:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref v4.20.0
+curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref v4.21.0
 curl -fsSL https://raw.githubusercontent.com/CtriXin/multi-model-switch/main/install.sh | bash -s -- --ref main
 ```
 

--- a/apps/mms-web/package-lock.json
+++ b/apps/mms-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mms/web",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mms/web",
-      "version": "4.20.0",
+      "version": "4.21.0",
       "dependencies": {
         "lucide-react": "0.468.0",
         "qrcode-generator": "2.0.4",

--- a/apps/mms-web/package.json
+++ b/apps/mms-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mms/web",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/mms-web/RELEASE-v4.21.0.md
+++ b/docs/mms-web/RELEASE-v4.21.0.md
@@ -1,0 +1,34 @@
+# v4.21.0 · Windows Native Preview 修复版
+
+## 升级须知
+
+本版本只收口 Windows Native Preview 的启动与对话阻塞。Windows 仍是 Preview，不等同于 Stable 支持；macOS/Linux 继续沿用原有升级路径。
+
+## Windows 修复
+
+- Windows 下优先解析可执行的 `pi.cmd` / `pi.exe`，跳过 npm 生成的 extensionless shim。
+- Windows installer 和运行环境补齐 `tzdata`，避免 `ZoneInfo` 初始化失败。
+- Bot runtime 和 Bot memory 改用 MMS 的跨平台 `file_lock` shim，避免 Windows 因 `fcntl` 导入失败而无法启动 Pilot。
+- Windows Acceptance 增加 Pi resolver、Windows import、Pilot lifecycle 和模型回复路径覆盖。
+
+## 验证
+
+GitHub Actions 已通过 Windows Server 2022/2025、PowerShell 5.1/7、Python 3.11–3.13、Node 18–22 矩阵。真实 Windows 机器上的 Pilot 启动、Pi RPC 和模型对话由用户完成验证。
+
+Windows 10/11 桌面、真实 Edge/Chrome 登录态 CDP、Pi native model bootstrap、Job Object 和真实升级恢复仍属于后续 Preview 边界。
+
+## 安装
+
+Windows 不使用公开 npm installer 的 `npx @ctrixin/mms` 路径。请从本 Release 下载 `packages/mms-install/bin/install.ps1`，或在 PowerShell 中执行：
+
+```powershell
+$script = Join-Path $env:TEMP 'mms-install-v4.21.0.ps1'
+Invoke-WebRequest https://raw.githubusercontent.com/CtriXin/multi-model-switch/v4.21.0/packages/mms-install/bin/install.ps1 -OutFile $script
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File $script -Ref v4.21.0
+```
+
+要求：PowerShell 5.1 或 7、Python 3.11+、Node 18.17+。安装器会使用独立版本目录并保留已有 config、session 和 OAuth。
+
+## 回滚
+
+Windows 安装保留版本目录。出现问题时可停止 Pilot 并选择先前版本目录；不要删除包含会话和 runtime 的 state 目录。

--- a/mms_version.py
+++ b/mms_version.py
@@ -1,2 +1,2 @@
 """Version of the packaged MMS source and Web client."""
-VERSION = "4.20.0"
+VERSION = "4.21.0"

--- a/mms_web_static/build.json
+++ b/mms_web_static/build.json
@@ -1,6 +1,6 @@
 {
-  "version": "4.20.0",
-  "sourceSha256": "8ee5900ff66aebf1d35b7b14d144b5ea8f8b3f484805a2dc0121c61ba6ff5b21",
+  "version": "4.21.0",
+  "sourceSha256": "47fc99637a20d621f4ecb542fbdad9cdcaa5c6a49d74eb4801445d6f607104ed",
   "files": {
     "assets/index-DY6M0OD5.js": "e3340c92f7ea50aa5eced41b0374e24623de8b56123a1544eb84dd83326ed7ef",
     "assets/index-nQv9IR0e.css": "94e70c860fe2f067f295f8eff6efdb0b16294052be13d53f5979493b024c07b8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-model-switch",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "private": true,
   "type": "module",
   "workspaces": [


### PR DESCRIPTION
## v4.21.0 Windows Native Preview 修复版

基于已合并的 PR #244，发布一个只收口 Windows blocker 的版本：

- Pi Windows `.cmd` / `.exe` resolver
- installer `tzdata`
- Bot runtime/memory 使用跨平台 `file_lock`
- Windows Acceptance lifecycle 与 import 覆盖
- 版本元数据、static bundle 和 Windows release notes 更新到 `4.21.0`

## 验证

- frontend build passed
- 78 frontend tests passed
- 117 Python tests passed
- static bundle packaged as 4.21.0
- PR #244 Windows matrix 已全部通过
